### PR TITLE
Dynamic Walker Function

### DIFF
--- a/pysmt/environment.py
+++ b/pysmt/environment.py
@@ -48,7 +48,7 @@ class Environment(object):
         self._factory = None
         # Configurations
         self.enable_infix_notation = False
-
+        self.dwf = {} # {nodetype, {walker: function}}
 
     @property
     def formula_manager(self):
@@ -75,6 +75,22 @@ class Environment(object):
     def qfo(self):
         """ Get the Quantifier Oracle """
         return self._qfo
+
+    def add_dynamic_walker_function(self, nodetype, walker, function):
+        """Dynamically bind the given function to the walker for the nodetype.
+
+        This function enables the extension of walkers for new
+        nodetypes. When introducing a new nodetype, we link a new
+        function to a given walker, so that the walker will be able to
+        handle the new nodetype.
+
+        See Walker.walk_error for more information.
+        """
+        if nodetype not in self.dwf:
+            self.dwf[nodetype] = {}
+
+        assert walker not in self.dwf[nodetype], "Redefinition"
+        self.dwf[nodetype][walker] = function
 
 
     @pysmt.decorators.deprecated("Environment.factory")

--- a/pysmt/environment.py
+++ b/pysmt/environment.py
@@ -48,7 +48,10 @@ class Environment(object):
         self._factory = None
         # Configurations
         self.enable_infix_notation = False
-        self.dwf = {} # {nodetype, {walker: function}}
+
+        # Dynamic Walker Configuration Map
+        # See: add_dynamic_walker_function
+        self.dwf = {}
 
     @property
     def formula_manager(self):
@@ -86,6 +89,7 @@ class Environment(object):
 
         See Walker.walk_error for more information.
         """
+        # self.dwf is a map of maps: {nodetype, {walker: function}}
         if nodetype not in self.dwf:
             self.dwf[nodetype] = {}
 

--- a/pysmt/operators.py
+++ b/pysmt/operators.py
@@ -43,3 +43,18 @@ BOOL_OPERATORS = frozenset(QUANTIFIERS | BOOL_CONNECTIVES)
 RELATIONS = frozenset([LE, LT, EQUALS])
 
 CONSTANTS = frozenset([REAL_CONSTANT, BOOL_CONSTANT, INT_CONSTANT])
+
+CUSTOM_NODE_TYPES = []
+
+def new_node_type(new_node_id=None):
+    """Adds a new node type to the list of custom node types and returns the ID."""
+    if new_node_id is None:
+        if len(CUSTOM_NODE_TYPES) == 0:
+            new_node_id = ALL_TYPES[-1] + 1
+        else:
+            new_node_id = CUSTOM_NODE_TYPES[-1] + 1
+
+    assert new_node_id not in ALL_TYPES
+    assert new_node_id not in CUSTOM_NODE_TYPES
+    CUSTOM_NODE_TYPES.append(new_node_id)
+    return new_node_id

--- a/pysmt/test/test_dwf.py
+++ b/pysmt/test/test_dwf.py
@@ -16,7 +16,7 @@
 #   limitations under the License.
 #
 from pysmt.test import TestCase
-from pysmt.operators import ALL_TYPES
+from pysmt.operators import ALL_TYPES, CUSTOM_NODE_TYPES, new_node_type
 from pysmt.type_checker import SimpleTypeChecker
 from pysmt.printers import HRPrinter
 from pysmt.shortcuts import get_env, Symbol
@@ -55,3 +55,14 @@ class TestDwf(TestCase):
         # We did not define an implementation for the Simplifier
         with self.assertRaises(NotImplementedError):
             f1.simplify()
+
+
+    def test_new_node_type(self):
+        self.assertEquals(len(CUSTOM_NODE_TYPES), 0, "Initially there should be no custom types")
+        idx = new_node_type()
+        self.assertIsNotNone(idx)
+        with self.assertRaises(AssertionError):
+            new_node_type(idx)
+
+        n = new_node_type(idx+100)
+        self.assertEquals(n, idx+100)

--- a/pysmt/test/test_dwf.py
+++ b/pysmt/test/test_dwf.py
@@ -1,0 +1,57 @@
+#
+# This file is part of pySMT.
+#
+#   Copyright 2015 Andrea Micheli and Marco Gario
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+from pysmt.test import TestCase
+from pysmt.operators import ALL_TYPES
+from pysmt.type_checker import SimpleTypeChecker
+from pysmt.printers import HRPrinter
+from pysmt.shortcuts import get_env, Symbol
+
+
+class TestDwf(TestCase):
+
+    def test_dwf(self):
+        # Ad-hoc method to handle printing of the new node
+        def hrprinter_walk_XOR(self, formula):
+            self.stream.write(self.tb("("))
+            self.walk(formula.arg(0))
+            self.stream.write(self.tb(" *+* "))
+            self.walk(formula.arg(1))
+            self.stream.write(self.tb(")"))
+            return
+
+        # Shortcuts for function in env
+        add_dwf = get_env().add_dynamic_walker_function
+        create_node = get_env().formula_manager.create_node
+
+        # Define the new node type and register the walkers in the env
+        XOR = ALL_TYPES[-1] + 1
+        add_dwf(XOR, SimpleTypeChecker, SimpleTypeChecker.walk_bool_to_bool)
+        add_dwf(XOR, HRPrinter, hrprinter_walk_XOR)
+
+        # Create a test node (This implicitely calls the Type-checker)
+        x = Symbol("x")
+        f1 = create_node(node_type=XOR, args=(x,x))
+        self.assertIsNotNone(f1)
+
+        # String conversion should use the function defined above.
+        s_f1 = str(f1)
+        self.assertEquals(s_f1, "(x *+* x)")
+
+        # We did not define an implementation for the Simplifier
+        with self.assertRaises(NotImplementedError):
+            f1.simplify()

--- a/pysmt/walkers/generic.py
+++ b/pysmt/walkers/generic.py
@@ -15,7 +15,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from functools import partial
+
 import pysmt.operators as op
+
 
 class Walker(object):
 
@@ -55,6 +58,13 @@ class Walker(object):
         """ Default function for a node that is not handled by the Walker, by
         raising a NotImplementedError.
         """
+        node_type = formula.node_type()
+        if node_type in self.env.dwf:
+            dwf = self.env.dwf[node_type]
+            walker_class = type(self)
+            if type(self) in dwf:
+                self.functions[node_type] = partial(dwf[walker_class], self)
+                return self.functions[node_type](formula, **kwargs)
 
         raise NotImplementedError("Was not expecting a node of type %d" %
                                   formula.node_type())


### PR DESCRIPTION
Whenever a walker finds an unexpected node-type, it will ask the environment which function to use. This can be used to define new node-types. See test_dwf.py for an example usage.
