### PR TITLE
Continuous Integration for each solver

### DIFF
--- a/install.py
+++ b/install.py
@@ -426,7 +426,7 @@ def main():
     print("Add the following to your .bashrc file or to your environment:")
     print("export PYTHONPATH=\"$PYTHONPATH:"+ ":".join(PATHS) + "\"")
 
-    with open(os.path.join(BASE_DIR, "set_paths.sh"), "w") as fout:
+    with open(os.path.join(BASE_DIR, "set_paths.sh"), "a") as fout:
         fout.write("export PYTHONPATH=\"$PYTHONPATH:"+ ":".join(PATHS) + "\"")
 
 

--- a/install.py
+++ b/install.py
@@ -324,10 +324,14 @@ def install_pycudd(options):
     PATHS.append("%s/pycudd" % dir_path)
 
 def check_install():
-    """Checks whether a solver is visible by pySMT."""
+    """Checks which solvers are visible to pySMT."""
 
     from pysmt.shortcuts import Solver
     from pysmt.exceptions import NoSolverAvailableError
+
+    required_solver = os.environ.get("PYSMT_SOLVER")
+    if required_solver is None:
+        required_solver = "None"
 
     for solver in ['msat', 'z3', 'cvc4', 'yices', 'bdd']:
         is_installed = False
@@ -337,6 +341,10 @@ def check_install():
         except NoSolverAvailableError:
             is_installed = False
         print("%s: \t %s" % (solver, is_installed))
+
+        if solver == required_solver and not is_installed:
+            assert "Was expecting to find %s installed" % required_solver
+
 
 
 

--- a/shippable.sh
+++ b/shippable.sh
@@ -35,6 +35,7 @@ if [ "$1" == "cudd" ]
 then
     apt-get update
     apt-get install -y make build-essential swig libgmp-dev
+    apt-get install -y python-all-dev
     ./install.py --confirm-agreement --cudd  --make-j 2
 fi
 

--- a/shippable.sh
+++ b/shippable.sh
@@ -1,0 +1,41 @@
+if [ "$1" == "msat" ]
+then
+    apt-get update
+    apt-get install -y make build-essential swig libgmp-dev
+    apt-get install -y python-all-dev
+    ./install.py --confirm-agreement --msat
+fi
+
+if [ "$1" == "z3" ]
+then
+    apt-get update
+    apt-get install -y make build-essential swig libgmp-dev
+    apt-get install -y python-all-dev
+    ./install.py --confirm-agreement --z3 --make-j 2
+fi
+
+if [ "$1" == "cvc4" ]
+then
+    apt-get update
+    apt-get install -y make build-essential swig libgmp-dev \
+                       python-all-dev \
+                       autoconf libtool antlr3 wget \
+                       curl libboost-dev
+    ./install.py --confirm-agreement --cvc4 --make-j 2
+fi
+
+
+if [ "$1" == "yices" ]
+then
+    ./install.py --confirm-agreement --yices
+fi
+
+
+if [ "$1" == "cudd" ]
+then
+    apt-get update
+    apt-get install -y make build-essential swig libgmp-dev
+    ./install.py --confirm-agreement --cudd  --make-j 2
+fi
+
+echo "Exiting..."

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,16 +1,32 @@
+cache: true
 language: python
 build_image: shippableimages/ubuntu1204_python
 python:
-  - 2.6
+  # - 2.6
   - 2.7
-  - 3.2
-  - 3.3
-  - 3.4
-  - pypy
+  # - 3.2
+  # - 3.3
+  # - 3.4
+  # - pypy
+
 
 install:
   - pip install nose
   - pip install coverage
+  - source shippable.sh $PYSMT_SOLVER
+
+env:
+ # Multiple envs will cause multiple build across multiple python versions.
+ # We test the following:
+ # 1. PySMT w/o solvers
+ # 2. PySMT with one solver at the time
+ - PYSMT_SOLVER="None"
+ - PYSMT_SOLVER="msat"  PYTHONPATH="$PYTHONPATH:$TRAVIS_BUILD_DIR/.smt_solvers/mathsat-5.2.12-linux-x86_64/python:$TRAVIS_BUILD_DIR/.smt_solvers/mathsat-5.2.12-linux-x86_64/python/build/lib.linux-x86_64-2.7"
+ - PYSMT_SOLVER="z3"    PYTHONPATH="$PYTHONPATH:$TRAVIS_BUILD_DIR/.smt_solvers/z3_bin/lib/python2.7/dist-packages"
+ - PYSMT_SOLVER="cvc4"  PYTHONPATH="$PYTHONPATH:$TRAVIS_BUILD_DIR/.smt_solvers/CVC4-68f22235a62f5276b206e9a6692a85001beb8d42/builds/src/bindings/python"
+ - PYSMT_SOLVER="yices" PYTHONPATH="$PYTHONPATH:$TRAVIS_BUILD_DIR/.smt_solvers/pyices-aa0b91c39aa00c19c2160e83aad822dc468ce328/build/lib.linux-x86_64-2.7"
+ - PYSMT_SOLVER="cudd"  PYTHONPATH="$PYTHONPATH:$TRAVIS_BUILD_DIR/.smt_solvers/pycudd2.0.2/pycudd"
+
 
 # Make folders for the reports
 before_script:
@@ -18,4 +34,5 @@ before_script:
   - mkdir -p shippable/codecoverage
 
 script:
+  - ./install.py --check
   - nosetests pysmt --with-xunit --xunit-file=shippable/testresults/nosetests.xml --with-coverage --cover-package=pysmt --cover-xml --cover-xml-file=shippable/codecoverage/coverage.xml --cover-branch


### PR DESCRIPTION
We now test pysmt over each solver independently (and without solvers). 
For now, we limit the tests to python 2.7 - We can think to extend this in the future.

*Note*: Bdd tests fail randomly.