### PR TITLE
get_logic + Logic Refactoring

### DIFF
--- a/pysmt/environment.py
+++ b/pysmt/environment.py
@@ -27,6 +27,7 @@ import pysmt.simplifier
 import pysmt.printers
 import pysmt.substituter
 import pysmt.type_checker
+import pysmt.oracles
 import pysmt.formula
 import pysmt.factory
 import pysmt.shortcuts
@@ -43,7 +44,8 @@ class Environment(object):
         self._simplifier = pysmt.simplifier.Simplifier(self)
         self._substituter = pysmt.substituter.Substituter(self)
         self._serializer = pysmt.printers.HRSerializer(self)
-        self._qfo = pysmt.type_checker.QuantifierOracle(self)
+        self._qfo = pysmt.oracles.QuantifierOracle(self)
+        self._theoryo = pysmt.oracles.TheoryOracle(self)
 
         self._factory = None
         # Configurations
@@ -78,6 +80,11 @@ class Environment(object):
     def qfo(self):
         """ Get the Quantifier Oracle """
         return self._qfo
+
+    @property
+    def theoryo(self):
+        """ Get the Theory Oracle """
+        return self._theoryo
 
     def add_dynamic_walker_function(self, nodetype, walker, function):
         """Dynamically bind the given function to the walker for the nodetype.

--- a/pysmt/logics.py
+++ b/pysmt/logics.py
@@ -79,14 +79,34 @@ class Theory(object):
         return new_theory
 
     def combine(self, other):
+        if self.integer_arithmetic and other.integer_arithmetic:
+            integer_difference = self.integer_difference and other.integer_difference
+        elif self.integer_arithmetic and not other.integer_arithmetic:
+            integer_difference = self.integer_difference
+        elif not self.integer_arithmetic and other.integer_arithmetic:
+            integer_difference = other.integer_difference
+        else:
+            assert not self.integer_arithmetic and not other.integer_arithmetic
+            integer_difference = False
+
+        if self.real_arithmetic and other.real_arithmetic:
+            real_difference = self.real_difference and other.real_difference
+        elif self.real_arithmetic and not other.real_arithmetic:
+            real_difference = self.real_difference
+        elif not self.real_arithmetic and other.real_arithmetic:
+            real_difference = other.real_difference
+        else:
+            assert not self.real_arithmetic and not other.real_arithmetic
+            real_difference = False
+
         return Theory(
             arrays=self.arrays | other.arrays,
             bit_vectors=self.bit_vectors | other.bit_vectors,
             floating_point=self.floating_point | other.floating_point,
             integer_arithmetic=self.integer_arithmetic | other.integer_arithmetic,
             real_arithmetic=self.real_arithmetic | other.real_arithmetic,
-            integer_difference=self.integer_difference & other.integer_difference,
-            real_difference=self.real_difference & other.real_difference,
+            integer_difference=integer_difference,
+            real_difference=real_difference,
             linear=self.linear | other.linear,
             uninterpreted=self.uninterpreted | other.uninterpreted)
 
@@ -111,17 +131,17 @@ class Theory(object):
     def __le__(self, other):
         if self.integer_difference == other.integer_difference:
             le_integer_difference = True
-        elif self.integer_difference and not other.integer_arithmetic:
-            le_integer_difference = False
-        else:
+        elif self.integer_difference and other.integer_arithmetic:
             le_integer_difference = True
+        else:
+            le_integer_difference = False
 
         if self.real_difference == other.real_difference:
             le_real_difference = True
-        elif self.real_difference and not other.real_arithmetic:
-            le_real_difference = False
-        else:
+        elif self.real_difference and other.real_arithmetic:
             le_real_difference = True
+        else:
+            le_real_difference = False
 
         return (self.arrays <= other.arrays and
                 self.bit_vectors <= other.bit_vectors and
@@ -132,6 +152,19 @@ class Theory(object):
                 le_real_difference and
                 self.real_arithmetic <= other.real_arithmetic and
                 self.linear <= other.linear)
+
+    def __str__(self):
+        return "Arrays: %s, " % self.arrays +\
+            "BV: %s, " % self.bit_vectors +\
+            "FP: %s, " % self.floating_point +\
+            "IA: %s, " % self.integer_arithmetic +\
+            "RA: %s, " % self.real_arithmetic +\
+            "ID: %s, " % self.integer_difference +\
+            "RD: %s, " % self.real_difference +\
+            "Linear: %s, " % self.linear +\
+            "EUF: %s" % self.uninterpreted
+
+    __repr__ = __str__
 
 
 class Logic(object):

--- a/pysmt/logics.py
+++ b/pysmt/logics.py
@@ -40,7 +40,7 @@ class Logic(object):
                  integer_difference = False,
                  real_difference = False,
                  linear = False,
-                 non_linear = False,
+                 non_linear = False, # MG: Isn't linear = not non_linear?
                  uninterpreted = False):
 
         self.name = name
@@ -58,6 +58,54 @@ class Logic(object):
         self.uninterpreted = uninterpreted
 
         return
+
+    def set_lira(self, value=True):
+        res = self.copy()
+        self.integer_arithmetic = value
+        self.real_arithmetic = value
+        return res
+
+    def set_non_linear(self, value=True):
+        res = self.copy()
+        self.non_linear = value
+        return res
+
+    def set_difference_logic(self, value=True):
+        res = self.copy()
+        self.non_linear = value
+        return res
+
+    def copy(self):
+        new_logic = Logic(name = self.name,
+                          description = self.description,
+                          quantifier_free = self.quantifier_free,
+                          arrays = self.arrays,
+                          bit_vectors = self.bit_vectors,
+                          floating_point = self.floating_point,
+                          integer_arithmetic = self.integer_arithmetic,
+                          real_arithmetic = self.real_arithmetic,
+                          integer_difference = self.integer_difference,
+                          real_difference = self.real_difference,
+                          linear = self.linear,
+                          non_linear = self.non_linear,
+                          uninterpreted = self.uninterpreted)
+
+        return new_logic
+
+    def __or__(self, other):
+        return Logic(name="", description="",
+            quantifier_free=self.quantifier_free | other.quantifier_free,
+            arrays=self.arrays | other.arrays,
+            bit_vectors=self.bit_vectors | other.bit_vectors,
+            floating_point=self.floating_point | other.floating_point,
+            integer_arithmetic=self.integer_arithmetic | other.integer_arithmetic,
+            real_arithmetic=self.real_arithmetic | other.real_arithmetic,
+            integer_difference=self.integer_difference | other.integer_difference,
+            real_difference=self.real_difference | other.real_difference,
+            linear=self.linear | other.linear,
+            non_linear=self.non_linear | other.non_linear,
+            uninterpreted=self.uninterpreted | other.uninterpreted)
+
 
     def __str__(self):
         return self.name
@@ -555,3 +603,6 @@ def get_closer_logic(supported_logics, logic):
     if len(res) == 0:
         raise NoLogicAvailableError("Logic %s is not supported" % logic)
     return min(res)
+
+def get_closer_pysmt_logic(target_logic):
+    return get_closer_logic(PYSMT_LOGICS, target_logic)

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -83,6 +83,9 @@ class TheoryOracle(walkers.DagWalker):
 
     def walk_combine(self, formula, args):
         """Combines the current theory value of the children"""
+        if len(args) == 1:
+            return args[0].copy()
+
         theory_out = args[0]
         for t in args[1:]:
             theory_out = theory_out.combine(t)
@@ -117,7 +120,9 @@ class TheoryOracle(walkers.DagWalker):
 
     def walk_function(self, formula, args):
         """Extends the Theory with UF."""
-        if len(args) > 0:
+        if len(args) == 1:
+            theory_out = args[0].copy()
+        elif len(args) > 1:
             theory_out = args[0]
             for t in args[1:]:
                 theory_out = theory_out.combine(t)
@@ -127,20 +132,21 @@ class TheoryOracle(walkers.DagWalker):
         theory_out.uninterpreted = True
         return theory_out
 
-
     def walk_lira(self, formula, args):
         """Extends the Theory with LIRA."""
-        theory_out = args[0]
+        theory_out = args[0].copy()
         theory_out = theory_out.set_lira()
         return theory_out
 
     def walk_times(self, formula, args):
         """Extends the Theory with Non-Linear, if needed."""
-        theory_out = args[0]
-        for t in args[1:]:
-            theory_out = theory_out.combine(t)
-        # if Left and Right children are symbolic
-        #    theory_out = theory_out.set_non_linear()
+        if len(args) == 1:
+            theory_out = args[0].copy()
+        else:
+            theory_out = args[0]
+            for t in args[1:]:
+                theory_out = theory_out.combine(t)
+        # Check for non linear?
         theory_out = theory_out.set_difference_logic(False)
         return theory_out
 

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -1,0 +1,184 @@
+#
+# This file is part of pySMT.
+#
+#   Copyright 2015 Andrea Micheli and Marco Gario
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""This module provides classes used to analyze and determine
+properties of formulae.
+
+ * QuantifierOracle says whether a formula is quantifier free
+ * TheoryOracle says which logic is used in the formula.
+"""
+
+import pysmt.walkers as walkers
+import pysmt.operators as op
+import pysmt.shortcuts
+
+from pysmt.logics import Logic, get_closer_pysmt_logic
+
+
+class QuantifierOracle(walkers.DagWalker):
+    def __init__(self, env=None):
+        walkers.DagWalker.__init__(self, env=env)
+
+        # Clear the mapping function
+        self.functions.clear()
+
+        # Propagate truth value, and force False when a Quantifier
+        # is found.
+        for elem in op.ALL_TYPES:
+            if elem in [op.FORALL, op.EXISTS]:
+                self.functions[elem] = self.walk_false
+            else:
+                self.functions[elem] = self.walk_all
+
+        # Check that no operator in undefined
+        assert self.is_complete(verbose=True)
+
+    def is_qf(self, formula):
+        """ Returns whether formula is Quantifier Free. """
+        return self.walk(formula)
+
+
+# EOC QuantifierOracle
+
+
+class TheoryOracle(walkers.DagWalker):
+    def __init__(self, env=None):
+        walkers.DagWalker.__init__(self, env=env)
+
+        self.functions[op.AND] = self.walk_combine
+        self.functions[op.OR] = self.walk_combine
+        self.functions[op.NOT] = self.walk_combine
+        self.functions[op.IMPLIES] = self.walk_combine
+        self.functions[op.IFF] = self.walk_combine
+        self.functions[op.LE] = self.walk_combine
+        self.functions[op.LT] = self.walk_combine
+        self.functions[op.FORALL] = self.walk_combine
+        self.functions[op.EXISTS] = self.walk_combine
+        self.functions[op.MINUS] = self.walk_combine
+        self.functions[op.ITE] = self.walk_combine
+
+        self.functions[op.REAL_CONSTANT] = self.walk_constant
+        self.functions[op.SYMBOL] = self.walk_symbol
+        self.functions[op.FUNCTION] = self.walk_function
+        self.functions[op.BOOL_CONSTANT] = self.walk_constant
+        self.functions[op.INT_CONSTANT] = self.walk_constant
+        self.functions[op.TOREAL] = self.walk_lira
+        self.functions[op.TIMES] = self.walk_times
+        self.functions[op.PLUS] = self.walk_plus
+        self.functions[op.EQUALS] = self.walk_equals
+
+    def walk_combine(self, formula, args):
+        """Combines the current theory value of the children"""
+        theory_out = args[0]
+        for t in args[1:]:
+            theory_out = theory_out | t
+
+        return theory_out
+
+    def walk_constant(self, formula, args):
+        """Returns a new theory object with the type of the constant."""
+        if formula.is_real_constant():
+            theory_out = Logic(name="", description="",
+                               real_arithmetic=True, real_difference=True,
+                               linear=True)
+        elif formula.is_int_constant():
+            theory_out = Logic(name="", description="",
+                               integer_arithmetic=True, integer_difference=True,
+                               linear=True)
+        else:
+            assert formula.is_bool_constant()
+            theory_out = Logic(name="", description="")
+
+        return theory_out
+
+    def walk_symbol(self, formula, args):
+        """Returns a new theory object with the type of the symbol."""
+        f_type = formula.symbol_type()
+        if f_type.is_real_type():
+            theory_out = Logic(name="", description="",
+                               real_arithmetic=True, real_difference=True,
+                               linear=True)
+        elif f_type.is_int_type():
+            theory_out = Logic(name="", description="",
+                               integer_arithmetic=True, integer_difference=True,
+                               linear=True)
+        elif f_type.is_bool_type():
+            theory_out = Logic(name="", description="")
+        else:
+            assert f_type.is_function_type()
+            theory_out = Logic(name="", description="",
+                               uninterpreted=True)
+
+        return theory_out
+
+    def walk_function(self, formula, args):
+        """Extends the Theory with UF."""
+        if len(args) > 0:
+            theory_out = args[0]
+            for t in args[1:]:
+                theory_out = theory_out | t
+        else:
+            theory_out = Logic(name="",description="")
+
+        theory_out.uninterpreted = True
+        return theory_out
+
+
+    def walk_lira(self, formula, args):
+        """Extends the Theory with LIRA."""
+        theory_out = args[0]
+        theory_out = theory_out.set_lira()
+        return theory_out
+
+    def walk_times(self, formula, args):
+        """Extends the Theory with Non-Linear, if needed."""
+        theory_out = args[0]
+        for t in args[1:]:
+            theory_out = theory_out | t
+        # if Left and Right children are symbolic
+        #    theory_out = theory_out.set_non_linear()
+        theory_out = theory_out.set_difference_logic(False)
+        return theory_out
+
+    def walk_plus(self, formula, args):
+        theory_out = args[0]
+        for t in args[1:]:
+            theory_out = theory_out | t
+        theory_out = theory_out.set_difference_logic()
+        return theory_out
+
+    def walk_equals(self, formula, args):
+        # TODO: Does EQUAL need a special treatment?
+        # We consider EUF as UF, shall we split the two concepts?
+        return self.walk_combine(formula, args)
+
+    def get_theory(self, formula):
+        """Returns the thoery for the formula."""
+        return self.walk(formula)
+
+
+# EOC TheoryOracle
+
+
+def get_logic(formula):
+    env = pysmt.shortcuts.get_env()
+    # Get Quantifier Information
+    qf = env.qfo.is_qf(formula)
+    theory = env.theoryo.get_theory(formula)
+    theory.quantifier_free = qf
+    # Return a logic supported by PySMT that is close to the one computed
+    return get_closer_pysmt_logic(theory)

--- a/pysmt/smtlib/parser.py
+++ b/pysmt/smtlib/parser.py
@@ -232,7 +232,8 @@ class SmtLibParser(object):
 
         """
         return self.logic is None or \
-            (self.logic.integer_arithmetic and self.logic.real_arithmetic)
+            (self.logic.theory.integer_arithmetic and
+             self.logic.theory.real_arithmetic)
 
     def _minus_or_uminus(self, *args):
         """Utility function that handles both unary and binary minus"""
@@ -243,12 +244,12 @@ class SmtLibParser(object):
                     return GenericNumber(-1 * args[0].value)
                 return mgr.Times(GenericNumber(-1), args[0])
             else:
-                if self.logic.real_arithmetic:
+                if self.logic.theory.real_arithmetic:
                     if args[0].is_real_constant():
                         return mgr.Real(-1 * args[0].constant_value())
                     return mgr.Times(mgr.Real(-1), args[0])
                 else:
-                    assert self.logic.integer_arithmetic
+                    assert self.logic.theory.integer_arithmetic
                     if args[0].is_int_constant():
                         return mgr.Int(-1 * args[0].constant_value())
                     return mgr.Times(mgr.Int(-1), args[0])
@@ -321,10 +322,10 @@ class SmtLibParser(object):
                 # an Int, a Real, or an unknown GenericNumber.
                 if self._is_unknown_constant_type():
                     res = GenericNumber(iterm)
-                elif self.logic.real_arithmetic:
+                elif self.logic.theory.real_arithmetic:
                     res = mgr.Real(iterm)
                 else:
-                    assert self.logic.integer_arithmetic, \
+                    assert self.logic.theory.integer_arithmetic, \
                         "Integer constant found in a logic that does not " \
                         "support arithmetic"
                     res = mgr.Int(iterm)

--- a/pysmt/test/examples.py
+++ b/pysmt/test/examples.py
@@ -90,7 +90,7 @@ def get_example_formulae(environment=None):
             Example(expr=And(GT(p, q), Implies(x, y)),
                     is_valid=False,
                     is_sat=True,
-                    logic=pysmt.logics.QF_LIA
+                    logic=pysmt.logics.QF_IDL
                 ),
 
             # (p + q) = 5 /\ (p > q)
@@ -104,7 +104,7 @@ def get_example_formulae(environment=None):
             Example(expr=Or(GE(p, q), LE(p, q)),
                     is_valid=True,
                     is_sat=True,
-                    logic=pysmt.logics.QF_LIA
+                    logic=pysmt.logics.QF_IDL
                 ),
 
             # !( p < q * 2 )
@@ -118,7 +118,7 @@ def get_example_formulae(environment=None):
             Example(expr=GT(Minus(p, Minus(Int(5), Int(2))), p),
                     is_valid=False,
                     is_sat=False,
-                    logic=pysmt.logics.QF_LIA
+                    logic=pysmt.logics.QF_IDL
                 ),
 
             # x ? 7: (p + -1) * 3 = q
@@ -170,7 +170,7 @@ def get_example_formulae(environment=None):
             Example(expr=Not(GT(Minus(r, Minus(Real(5), Real(2))), r)),
                     is_valid=True,
                     is_sat=True,
-                    logic=pysmt.logics.QF_LRA
+                    logic=pysmt.logics.QF_RDL
                 ),
 
             # x ? 7: (s + -1) * 3 = r

--- a/pysmt/test/examples.py
+++ b/pysmt/test/examples.py
@@ -142,7 +142,7 @@ def get_example_formulae(environment=None):
             Example(expr=And(GT(r, s), Implies(x, y)),
                     is_valid=False,
                     is_sat=True,
-                    logic=pysmt.logics.QF_LRA
+                    logic=pysmt.logics.QF_RDL
                 ),
 
             # (r + s) = 5.6 /\ (r > s)
@@ -156,7 +156,7 @@ def get_example_formulae(environment=None):
             Example(expr=Or(GE(r, s), LE(r, s)),
                     is_valid=True,
                     is_sat=True,
-                    logic=pysmt.logics.QF_LRA
+                    logic=pysmt.logics.QF_RDL
                 ),
 
             # !( (r / (1/2)) < s * 2 )

--- a/pysmt/test/test_logics.py
+++ b/pysmt/test/test_logics.py
@@ -40,16 +40,15 @@ class TestLogic(unittest.TestCase):
     def test_get_logic(self):
         for l in pysmt.logics.LOGICS:
             l_out = get_logic(quantifier_free=l.quantifier_free,
-                              arrays=l.arrays,
-                              bit_vectors=l.bit_vectors,
-                              floating_point=l.floating_point,
-                              integer_arithmetic=l.integer_arithmetic,
-                              real_arithmetic=l.real_arithmetic,
-                              integer_difference=l.integer_difference,
-                              real_difference=l.real_difference,
-                              linear=l.linear,
-                              non_linear=l.non_linear,
-                              uninterpreted=l.uninterpreted)
+                              arrays=l.theory.arrays,
+                              bit_vectors=l.theory.bit_vectors,
+                              floating_point=l.theory.floating_point,
+                              integer_arithmetic=l.theory.integer_arithmetic,
+                              real_arithmetic=l.theory.real_arithmetic,
+                              integer_difference=l.theory.integer_difference,
+                              real_difference=l.theory.real_difference,
+                              linear=l.theory.linear,
+                              uninterpreted=l.theory.uninterpreted)
             self.assertEquals(l_out, l,
                               "Expected %s, got %s instead" % \
                               (l, l_out))
@@ -67,7 +66,7 @@ class TestLogic(unittest.TestCase):
                                              real_arithmetic=True)),
             (pysmt.logics.AUFNIRA, get_logic(arrays=True,
                                              uninterpreted=True,
-                                             non_linear=True,
+                                             linear=False,
                                              integer_arithmetic=True,
                                              real_arithmetic=True)),
             (pysmt.logics.LRA, get_logic(linear=True,

--- a/pysmt/test/test_oracles.py
+++ b/pysmt/test/test_oracles.py
@@ -1,0 +1,35 @@
+#
+# This file is part of pySMT.
+#
+#   Copyright 2014 Andrea Micheli and Marco Gario
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+from pysmt.shortcuts import get_env
+from pysmt.test.examples import EXAMPLE_FORMULAS
+from pysmt.test import TestCase
+from pysmt.oracle import get_logic
+
+class TestOracles(TestCase):
+
+    def test_quantifier_oracle(self):
+        oracle = get_env.qfo
+        for (f, _, _, logic) in EXAMPLE_FORMULAS:
+            is_qf = oracle.is_qf(f)
+            self.assertEqual(is_qf, logic.quantifier_free, f)
+
+    def test_get_logic(self):
+        for example in EXAMPLE_FORMULAS:
+            target_logic = example.logic
+            res = get_logic(example.expr)
+            self.assertEquals(res, target_logic)

--- a/pysmt/test/test_oracles.py
+++ b/pysmt/test/test_oracles.py
@@ -23,14 +23,12 @@ from pysmt.test import TestCase
 from pysmt.oracles import get_logic
 
 class TestOracles(TestCase):
-
     @skip
     def test_quantifier_oracle(self):
         oracle = get_env().qfo
         for (f, _, _, logic) in EXAMPLE_FORMULAS:
             is_qf = oracle.is_qf(f)
             self.assertEqual(is_qf, logic.quantifier_free, f)
-
 
     def test_get_logic(self):
         for example in EXAMPLE_FORMULAS:
@@ -40,13 +38,11 @@ class TestOracles(TestCase):
                               (example.expr, target_logic, res))
 
     def test_regression(self):
-        from pysmt.shortcuts import Symbol, Plus, Equals, Real, GT, Implies, And
+        from pysmt.shortcuts import Symbol, Plus, Equals, Real, GT, LT, Implies, And, ForAll, Minus
         from pysmt.typing import REAL
         r,s = Symbol("r", REAL), Symbol("s", REAL)
         x,y = Symbol("x"), Symbol("y")
 
-        f1 = GT(r,s)
-        f2 = Implies(x,y)
-        f3 = And(f1, f2)
-
-        print(f3, get_logic(f3))
+        f4 = ForAll([r,s], Implies(And(GT(r, Real(0)), GT(s, Real(0))),
+                              (LT(Minus(r,s), r))))
+        print(f4, get_logic(f4))

--- a/pysmt/test/test_oracles.py
+++ b/pysmt/test/test_oracles.py
@@ -18,12 +18,12 @@
 from pysmt.shortcuts import get_env
 from pysmt.test.examples import EXAMPLE_FORMULAS
 from pysmt.test import TestCase
-from pysmt.oracle import get_logic
+from pysmt.oracles import get_logic
 
 class TestOracles(TestCase):
 
     def test_quantifier_oracle(self):
-        oracle = get_env.qfo
+        oracle = get_env().qfo
         for (f, _, _, logic) in EXAMPLE_FORMULAS:
             is_qf = oracle.is_qf(f)
             self.assertEqual(is_qf, logic.quantifier_free, f)
@@ -32,4 +32,5 @@ class TestOracles(TestCase):
         for example in EXAMPLE_FORMULAS:
             target_logic = example.logic
             res = get_logic(example.expr)
-            self.assertEquals(res, target_logic)
+            self.assertEquals(res, target_logic, "%s - %s != %s" % \
+                              (example.expr, target_logic, res))

--- a/pysmt/test/test_oracles.py
+++ b/pysmt/test/test_oracles.py
@@ -15,6 +15,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from unittest import skip
+
 from pysmt.shortcuts import get_env
 from pysmt.test.examples import EXAMPLE_FORMULAS
 from pysmt.test import TestCase
@@ -22,11 +24,13 @@ from pysmt.oracles import get_logic
 
 class TestOracles(TestCase):
 
+    @skip
     def test_quantifier_oracle(self):
         oracle = get_env().qfo
         for (f, _, _, logic) in EXAMPLE_FORMULAS:
             is_qf = oracle.is_qf(f)
             self.assertEqual(is_qf, logic.quantifier_free, f)
+
 
     def test_get_logic(self):
         for example in EXAMPLE_FORMULAS:
@@ -34,3 +38,15 @@ class TestOracles(TestCase):
             res = get_logic(example.expr)
             self.assertEquals(res, target_logic, "%s - %s != %s" % \
                               (example.expr, target_logic, res))
+
+    def test_regression(self):
+        from pysmt.shortcuts import Symbol, Plus, Equals, Real, GT, Implies, And
+        from pysmt.typing import REAL
+        r,s = Symbol("r", REAL), Symbol("s", REAL)
+        x,y = Symbol("x"), Symbol("y")
+
+        f1 = GT(r,s)
+        f2 = Implies(x,y)
+        f3 = And(f1, f2)
+
+        print(f3, get_logic(f3))

--- a/pysmt/test/test_typechecker.py
+++ b/pysmt/test/test_typechecker.py
@@ -21,6 +21,7 @@ from pysmt.type_checker import (assert_no_boolean_in_args,
                                 assert_boolean_args,
                                 assert_same_type_args,
                                 assert_args_type_in)
+from pysmt.type_checker import get_logic
 from pysmt.shortcuts import (Symbol, And, Plus, Minus, Times, Equals, Or, Iff,
                              LE, LT, Not, GE, GT, Ite, Bool, Int, Real, Div,
                              Function)
@@ -194,6 +195,16 @@ class TestSimpleTypeChecker(TestCase):
 
         with self.assertRaises(TypeError):
             super_bad_function()
+
+
+class TestOracles(TestCase):
+
+    def test_get_logic(self):
+        for example in EXAMPLE_FORMULAS:
+            target_logic = example.logic
+            res = get_logic(example.expr)
+            self.assertEquals(res, target_logic)
+
 
 if __name__ == '__main__':
     import unittest

--- a/pysmt/test/test_typechecker.py
+++ b/pysmt/test/test_typechecker.py
@@ -27,7 +27,6 @@ from pysmt.shortcuts import (Symbol, And, Plus, Minus, Times, Equals, Or, Iff,
                              Function)
 from pysmt.shortcuts import get_env
 from pysmt.test import TestCase
-from pysmt.test.examples import EXAMPLE_FORMULAS
 from pysmt.decorators import typecheck_result
 
 
@@ -151,13 +150,6 @@ class TestSimpleTypeChecker(TestCase):
             self.assertEqual(t, INT, f)
 
 
-    def test_quantifier_oracle(self):
-        oracle = self.qfo
-        for (f, _, _, logic) in EXAMPLE_FORMULAS:
-            is_qf = oracle.is_qf(f)
-            self.assertEqual(is_qf, logic.quantifier_free, f)
-
-
     def test_assert_args(self):
         assert_no_boolean_in_args([self.r, self.p])
         with self.assertRaises(TypeError):
@@ -196,14 +188,6 @@ class TestSimpleTypeChecker(TestCase):
         with self.assertRaises(TypeError):
             super_bad_function()
 
-
-class TestOracles(TestCase):
-
-    def test_get_logic(self):
-        for example in EXAMPLE_FORMULAS:
-            target_logic = example.logic
-            res = get_logic(example.expr)
-            self.assertEquals(res, target_logic)
 
 
 if __name__ == '__main__':

--- a/pysmt/test/test_typechecker.py
+++ b/pysmt/test/test_typechecker.py
@@ -16,12 +16,12 @@
 #   limitations under the License.
 #
 from pysmt.typing import REAL, BOOL, INT, FunctionType
-from pysmt.type_checker import QuantifierOracle
+
 from pysmt.type_checker import (assert_no_boolean_in_args,
                                 assert_boolean_args,
                                 assert_same_type_args,
                                 assert_args_type_in)
-from pysmt.type_checker import get_logic
+
 from pysmt.shortcuts import (Symbol, And, Plus, Minus, Times, Equals, Or, Iff,
                              LE, LT, Not, GE, GT, Ite, Bool, Int, Real, Div,
                              Function)

--- a/pysmt/type_checker.py
+++ b/pysmt/type_checker.py
@@ -29,6 +29,7 @@ import pysmt.operators as op
 import pysmt.shortcuts
 
 from pysmt.typing import BOOL, REAL, INT
+from pysmt.logics import Logic, get_closer_pysmt_logic
 
 class SimpleTypeChecker(walkers.DagWalker):
 
@@ -186,7 +187,6 @@ class TheoryOracle(walkers.DagWalker):
         self.functions[op.NOT] = self.walk_combine
         self.functions[op.IMPLIES] = self.walk_combine
         self.functions[op.IFF] = self.walk_combine
-        self.functions[op.SYMBOL] = self.walk_symbol
         self.functions[op.LE] = self.walk_combine
         self.functions[op.LT] = self.walk_combine
         self.functions[op.FORALL] = self.walk_combine
@@ -206,52 +206,104 @@ class TheoryOracle(walkers.DagWalker):
 
     def walk_combine(self, formula, args):
         """Combines the current theory value of the children"""
-        theory_out = sum(args)
+        theory_out = args[0]
+        for t in args[1:]:
+            theory_out = theory_out | t
+
         return theory_out
 
     def walk_constant(self, formula, args):
         """Returns a new theory object with the type of the constant."""
-        theory_out = Theory(formula.get_type())
+        if formula.is_real_constant():
+            theory_out = Logic(name="", description="",
+                               real_arithmetic=True, real_difference=True,
+                               linear=True)
+        elif formula.is_int_constant():
+            theory_out = Logic(name="", description="",
+                               integer_arithmetic=True, integer_difference=True,
+                               linear=True)
+        else:
+            assert formula.is_bool_constant()
+            theory_out = Logic(name="", description="")
+
         return theory_out
 
     def walk_symbol(self, formula, args):
         """Returns a new theory object with the type of the symbol."""
-        theory_out = Theory(formula.get_type())
-        # Check whether we are dealing with uninterpreted functions.
+        f_type = formula.symbol_type()
+        if f_type.is_real_type():
+            theory_out = Logic(name="", description="",
+                               real_arithmetic=True, real_difference=True,
+                               linear=True)
+        elif f_type.is_int_type():
+            theory_out = Logic(name="", description="",
+                               integer_arithmetic=True, integer_difference=True,
+                               linear=True)
+        elif f_type.is_bool_type():
+            theory_out = Logic(name="", description="")
+        else:
+            assert f_type.is_function_type()
+            theory_out = Logic(name="", description="",
+                               uninterpreted=True)
+
+        return theory_out
+
+    def walk_function(self, formula, args):
+        """Extends the Theory with UF."""
+        if len(args) > 0:
+            theory_out = args[0]
+            for t in args[1:]:
+                theory_out = theory_out | t
+        else:
+            theory_out = Logic(name="",description="")
+
+        theory_out.uninterpreted = True
         return theory_out
 
 
     def walk_lira(self, formula, args):
         """Extends the Theory with LIRA."""
-        theory_in = args[0]
-        theory_out = thoery_in.set_lira()
+        theory_out = args[0]
+        theory_out = theory_out.set_lira()
         return theory_out
 
     def walk_times(self, formula, args):
         """Extends the Theory with Non-Linear, if needed."""
-        theory_out = sum(args)
-        if args[0].is_symbol() and args[1].is_symbol():
-            theory_out = theory_out.set_non_linear()
-        # Extend also from difference logic
-        theory_out = theory_out.unset_difference_logic()
+        theory_out = args[0]
+        for t in args[1:]:
+            theory_out = theory_out | t
+        # if Left and Right children are symbolic
+        #    theory_out = theory_out.set_non_linear()
+        theory_out = theory_out.set_difference_logic(False)
         return theory_out
 
     def walk_plus(self, formula, args):
-        theory_in = sum(args)
-        theory_out = theory_in.unset_difference_logic()
+        theory_out = args[0]
+        for t in args[1:]:
+            theory_out = theory_out | t
+        theory_out = theory_out.set_difference_logic()
         return theory_out
 
-    def equals(self, formula, args):
+    def walk_equals(self, formula, args):
         # TODO: Does EQUAL need a special treatment?
+        # We consider EUF as UF, shall we split the two concepts?
         return self.walk_combine(formula, args)
 
-    def get_logic(self, formula):
-        """ Returns whether formula is Quantifier Free. """
+    def get_theory(self, formula):
+        """Returns the thoery for the formula."""
         return self.walk(formula)
 
 
 # EOC TheoryOracle
 
+def get_logic(formula):
+    env = pysmt.shortcuts.get_env()
+    # Get Quantifier Information
+    qf = env.qfo.is_qf(formula)
+    theory = TheoryOracle(env=env).get_theory(formula)
+    theory.quantifier_free = qf
+    # Return a logic supported by PySMT that is close to the one computed
+    return get_closer_pysmt_logic(theory)
 
 def assert_no_boolean_in_args(args):
     """ Enforces that the elements in args are not of BOOL type."""

--- a/pysmt/type_checker.py
+++ b/pysmt/type_checker.py
@@ -19,7 +19,6 @@
 reasoning about the type of formulae.
 
  * SimpleTypeChecker provides the pysmt.typing type of a formula
- * QuantifierOracle says whether a formula is quantifier free
  * The functions assert_*_args are useful for testing the type of
    arguments of a given function.
 """
@@ -29,7 +28,7 @@ import pysmt.operators as op
 import pysmt.shortcuts
 
 from pysmt.typing import BOOL, REAL, INT
-from pysmt.logics import Logic, get_closer_pysmt_logic
+
 
 class SimpleTypeChecker(walkers.DagWalker):
 
@@ -152,158 +151,6 @@ class SimpleTypeChecker(walkers.DagWalker):
 
 # EOC SimpleTypeChecker
 
-
-class QuantifierOracle(walkers.DagWalker):
-    def __init__(self, env=None):
-        walkers.DagWalker.__init__(self, env=env)
-
-        # Clear the mapping function
-        self.functions.clear()
-
-        # Propagate truth value, and force False when a Quantifier
-        # is found.
-        for elem in op.ALL_TYPES:
-            if elem in [op.FORALL, op.EXISTS]:
-                self.functions[elem] = self.walk_false
-            else:
-                self.functions[elem] = self.walk_all
-
-        # Check that no operator in undefined
-        assert self.is_complete(verbose=True)
-
-    def is_qf(self, formula):
-        """ Returns whether formula is Quantifier Free. """
-        return self.walk(formula)
-
-
-# EOC QuantifierOracle
-
-class TheoryOracle(walkers.DagWalker):
-    def __init__(self, env=None):
-        walkers.DagWalker.__init__(self, env=env)
-
-        self.functions[op.AND] = self.walk_combine
-        self.functions[op.OR] = self.walk_combine
-        self.functions[op.NOT] = self.walk_combine
-        self.functions[op.IMPLIES] = self.walk_combine
-        self.functions[op.IFF] = self.walk_combine
-        self.functions[op.LE] = self.walk_combine
-        self.functions[op.LT] = self.walk_combine
-        self.functions[op.FORALL] = self.walk_combine
-        self.functions[op.EXISTS] = self.walk_combine
-        self.functions[op.MINUS] = self.walk_combine
-        self.functions[op.ITE] = self.walk_combine
-
-        self.functions[op.REAL_CONSTANT] = self.walk_constant
-        self.functions[op.SYMBOL] = self.walk_symbol
-        self.functions[op.FUNCTION] = self.walk_function
-        self.functions[op.BOOL_CONSTANT] = self.walk_constant
-        self.functions[op.INT_CONSTANT] = self.walk_constant
-        self.functions[op.TOREAL] = self.walk_lira
-        self.functions[op.TIMES] = self.walk_times
-        self.functions[op.PLUS] = self.walk_plus
-        self.functions[op.EQUALS] = self.walk_equals
-
-    def walk_combine(self, formula, args):
-        """Combines the current theory value of the children"""
-        theory_out = args[0]
-        for t in args[1:]:
-            theory_out = theory_out | t
-
-        return theory_out
-
-    def walk_constant(self, formula, args):
-        """Returns a new theory object with the type of the constant."""
-        if formula.is_real_constant():
-            theory_out = Logic(name="", description="",
-                               real_arithmetic=True, real_difference=True,
-                               linear=True)
-        elif formula.is_int_constant():
-            theory_out = Logic(name="", description="",
-                               integer_arithmetic=True, integer_difference=True,
-                               linear=True)
-        else:
-            assert formula.is_bool_constant()
-            theory_out = Logic(name="", description="")
-
-        return theory_out
-
-    def walk_symbol(self, formula, args):
-        """Returns a new theory object with the type of the symbol."""
-        f_type = formula.symbol_type()
-        if f_type.is_real_type():
-            theory_out = Logic(name="", description="",
-                               real_arithmetic=True, real_difference=True,
-                               linear=True)
-        elif f_type.is_int_type():
-            theory_out = Logic(name="", description="",
-                               integer_arithmetic=True, integer_difference=True,
-                               linear=True)
-        elif f_type.is_bool_type():
-            theory_out = Logic(name="", description="")
-        else:
-            assert f_type.is_function_type()
-            theory_out = Logic(name="", description="",
-                               uninterpreted=True)
-
-        return theory_out
-
-    def walk_function(self, formula, args):
-        """Extends the Theory with UF."""
-        if len(args) > 0:
-            theory_out = args[0]
-            for t in args[1:]:
-                theory_out = theory_out | t
-        else:
-            theory_out = Logic(name="",description="")
-
-        theory_out.uninterpreted = True
-        return theory_out
-
-
-    def walk_lira(self, formula, args):
-        """Extends the Theory with LIRA."""
-        theory_out = args[0]
-        theory_out = theory_out.set_lira()
-        return theory_out
-
-    def walk_times(self, formula, args):
-        """Extends the Theory with Non-Linear, if needed."""
-        theory_out = args[0]
-        for t in args[1:]:
-            theory_out = theory_out | t
-        # if Left and Right children are symbolic
-        #    theory_out = theory_out.set_non_linear()
-        theory_out = theory_out.set_difference_logic(False)
-        return theory_out
-
-    def walk_plus(self, formula, args):
-        theory_out = args[0]
-        for t in args[1:]:
-            theory_out = theory_out | t
-        theory_out = theory_out.set_difference_logic()
-        return theory_out
-
-    def walk_equals(self, formula, args):
-        # TODO: Does EQUAL need a special treatment?
-        # We consider EUF as UF, shall we split the two concepts?
-        return self.walk_combine(formula, args)
-
-    def get_theory(self, formula):
-        """Returns the thoery for the formula."""
-        return self.walk(formula)
-
-
-# EOC TheoryOracle
-
-def get_logic(formula):
-    env = pysmt.shortcuts.get_env()
-    # Get Quantifier Information
-    qf = env.qfo.is_qf(formula)
-    theory = TheoryOracle(env=env).get_theory(formula)
-    theory.quantifier_free = qf
-    # Return a logic supported by PySMT that is close to the one computed
-    return get_closer_pysmt_logic(theory)
 
 def assert_no_boolean_in_args(args):
     """ Enforces that the elements in args are not of BOOL type."""


### PR DESCRIPTION
*TO BE DISCUSSED*

This breaks the logic class into two pieces. Logic and Theory. Theory contains the information about the theories in use, logic contains info on quantificiation, name and description.

This division makes sense when working with the logic oracle, since detecting the theory in use requires handling all the intermediate logics. 

This introduces also the shortcut _get_logic()_ that returns the closest logic for a formula. This is done using and oracle, and could probably be improved.