### PR TITLE
BUGFIX for the exit() method

### DIFF
--- a/pysmt/smtlib/parser.py
+++ b/pysmt/smtlib/parser.py
@@ -754,6 +754,7 @@ if __name__ == "__main__":
 
     def main():
         """Simple testing script"""
+        from pysmt.shortcuts import Solver
         args = sys.argv
         if len(args) != 2 and len(args) != 3:
             print "Usage %s <file.smt2> [-tu]" % args[0]
@@ -778,6 +779,8 @@ if __name__ == "__main__":
 
         res = parser.get_script_fname(fname)
         assert res != None
+
+        res.evaluate(Solver(name='yices'))
 
         print "Done"
 

--- a/pysmt/smtlib/parser.py
+++ b/pysmt/smtlib/parser.py
@@ -754,7 +754,6 @@ if __name__ == "__main__":
 
     def main():
         """Simple testing script"""
-        from pysmt.shortcuts import Solver
         args = sys.argv
         if len(args) != 2 and len(args) != 3:
             print "Usage %s <file.smt2> [-tu]" % args[0]
@@ -779,8 +778,6 @@ if __name__ == "__main__":
 
         res = parser.get_script_fname(fname)
         assert res != None
-
-        res.evaluate(Solver(name='yices'))
 
         print "Done"
 

--- a/pysmt/solvers/bdd.py
+++ b/pysmt/solvers/bdd.py
@@ -143,8 +143,10 @@ class BddSolver(Solver):
             l = self.backtrack.pop()
             self.assertions_stack = self.assertions_stack[:l]
 
-    def __del__(self):
-        del self.ddmanager
+    def exit(self):
+        if not self._destroyed:
+            self._destroyed = True
+            del self.ddmanager
 
 
 class BddConverter(DagWalker):

--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -118,9 +118,9 @@ class CVC4Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
         return res
 
     def exit(self):
-        del self.cvc4
-        self.cvc4 = None
-        return
+        if not self._destroyed:
+            self._destroyed = True
+            del self.cvc4
 
 
 class CVC4Converter(DagWalker):

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -191,13 +191,10 @@ class MathSAT5Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
 
 
     def exit(self):
-        if self.msat_env:
+        if not self._destroyed:
+            self._destroyed = True
             mathsat.msat_destroy_env(self.msat_env)
             mathsat.msat_destroy_config(self.config)
-            self.msat_env = None
-            self.config = None
-        return
-
 
 
 class MSatConverter(DagWalker):

--- a/pysmt/solvers/solver.py
+++ b/pysmt/solvers/solver.py
@@ -30,6 +30,7 @@ class Solver(object):
         self.pending_pop = False
         assert logic is not None
         assert options is None, "Options are not supported, yet."
+        self._destroyed = False
         return
 
     def is_sat(self, formula):

--- a/pysmt/solvers/yices.py
+++ b/pysmt/solvers/yices.py
@@ -171,11 +171,10 @@ class YicesSolver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
             raise NotImplementedError()
 
 
-    def destroy(self):
-        return self.exit()
-
     def exit(self):
-        libyices.yices_free_context(self.yices)
+        if not self._destroyed:
+            libyices.yices_free_context(self.yices)
+            self._destroyed = True
 
 
     def _get_yices_value(self, term, term_type, getter_func):

--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -158,9 +158,10 @@ class Z3Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
         return r
 
     def exit(self):
-        del self.z3
-        self.z3 = None
-        return
+        if not self._destroyed:
+            self._destroyed = True
+            del self.z3
+
 
 
 class Z3Converter(DagWalker):

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -135,6 +135,15 @@ class TestRegressions(TestCase):
         # a "different" type.
         f1 = Symbol("f1", ft2)
 
+    def test_multiple_exit(self):
+        for sname in get_env().factory.all_solvers():
+            # Multiple exits should be ignored
+            s = Solver(name=sname)
+            s.exit()
+            s.exit()
+            self.assertTrue(True)
+
+
 if __name__ == "__main__":
     import unittest
     unittest.main()


### PR DESCRIPTION
Fixed and uniformed exit() method of solvers: a common _destroyed flag
has been introduced to avoid multiple calls to the cleanup code of
each solver that caused segmentation faults with yices