### PR TITLE
Bugfix: Implemented EagerModel.__contains__

### DIFF
--- a/pysmt/solvers/eager.py
+++ b/pysmt/solvers/eager.py
@@ -67,3 +67,7 @@ class EagerModel(Model):
         include more variables.
         """
         return iter(self.assignment.items())
+
+    def __contains__(self, x):
+        """Returns whether the model contains a value for 'x'."""
+        return x in self.assignment

--- a/pysmt/test/test_eager_model.py
+++ b/pysmt/test/test_eager_model.py
@@ -74,6 +74,13 @@ class TestEagerModel(TestCase):
         self.assertTrue(model.get_value(p).is_constant(INT))
         self.assertTrue(model.get_value(r).is_constant(REAL))
 
+    def test_contains(self):
+        x, y, z = [FreshSymbol() for _ in xrange(3)]
+        d = {x: TRUE(), y: FALSE()}
+        model = EagerModel(assignment=d,
+                           environment=get_env())
+        self.assertTrue(x in model)
+        self.assertFalse(z in model)
 
 if __name__ == '__main__':
     import unittest


### PR DESCRIPTION
Statements such as
```
  if x in model:
     ...
```
were yielding an incorrect result (default to False).  This could cause bugs in situations in which we are not sure on whether we are using a dictionary or an EagerModel, since the two behaviors were different.