### PR TITLE
Issure #23: Added interface for Converter and enforced property Solver.converter

### DIFF
--- a/pysmt/solvers/bdd.py
+++ b/pysmt/solvers/bdd.py
@@ -22,7 +22,7 @@ import pycudd
 import pysmt.logics
 
 from pysmt import typing as types
-from pysmt.solvers.solver import Solver
+from pysmt.solvers.solver import Solver, Converter
 from pysmt.solvers.eager import EagerModel
 from pysmt.walkers import DagWalker
 from pysmt.decorators import clear_pending_pop
@@ -166,7 +166,7 @@ class BddSolver(Solver):
             del self.ddmanager
 
 
-class BddConverter(DagWalker):
+class BddConverter(Converter, DagWalker):
 
     def __init__(self, environment, ddmanager):
         DagWalker.__init__(self)

--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -20,7 +20,7 @@ from fractions import Fraction
 import CVC4
 
 import pysmt
-from pysmt.solvers.solver import Solver
+from pysmt.solvers.solver import Solver, Converter
 from pysmt.exceptions import SolverReturnedUnknownResultError
 from pysmt.walkers import DagWalker
 from pysmt.solvers.smtlib import SmtLibBasicSolver, SmtLibIgnoreMixin
@@ -123,7 +123,7 @@ class CVC4Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
             del self.cvc4
 
 
-class CVC4Converter(DagWalker):
+class CVC4Converter(Converter, DagWalker):
 
     def __init__(self, environment, cvc4_exprMgr):
         DagWalker.__init__(self, environment)

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -22,7 +22,7 @@ import mathsat
 
 import pysmt.logics
 from pysmt import typing as types
-from pysmt.solvers.solver import Solver
+from pysmt.solvers.solver import Solver, Converter
 from pysmt.solvers.smtlib import SmtLibBasicSolver, SmtLibIgnoreMixin
 from pysmt.solvers.eager import EagerModel
 from pysmt.walkers import DagWalker
@@ -197,7 +197,7 @@ class MathSAT5Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
             mathsat.msat_destroy_config(self.config)
 
 
-class MSatConverter(DagWalker):
+class MSatConverter(Converter, DagWalker):
 
     def __init__(self, environment, msat_env):
         DagWalker.__init__(self, environment)

--- a/pysmt/solvers/solver.py
+++ b/pysmt/solvers/solver.py
@@ -222,6 +222,7 @@ class Model(object):
 
     def __init__(self, environment):
         self.environment = environment
+        self._converter = None
 
     def get_value(self, formula):
         """ Returns the value of formula in the current model (if one exists).
@@ -263,6 +264,15 @@ class Model(object):
             res[f] = v
         return res
 
+    @property
+    def converter(self):
+        """Get the Converter associated with the Solver."""
+        return self._converter
+
+    @converter.setter
+    def converter(self, value):
+        self._converter = value
+
     def __getitem__(self, idx):
         return self.get_value(idx)
 
@@ -273,3 +283,20 @@ class Model(object):
 
     def __str__(self):
         return "\n".join([ "%s := %s" % (var, value) for (var, value) in self])
+
+
+class Converter(object):
+    """A Converter implements functionalities to convert expressions.
+
+    There are two key methods: convert() and back().
+    The first performs the forward conversion (pySMT -> Solver API),
+    the second performs the backwards conversion (Solver API -> pySMT)
+    """
+
+    def convert(self, formula):
+        """Convert a PySMT formula into a Solver term."""
+        raise NotImplementedError
+
+    def back(self, expr):
+        """Convert an expression of the Solver into a PySMT term."""
+        raise NotImplementedError

--- a/pysmt/solvers/yices.py
+++ b/pysmt/solvers/yices.py
@@ -27,7 +27,7 @@ import pyices.fix_env
 from pyices.yices_lib import String
 
 from pysmt.solvers.eager import EagerModel
-from pysmt.solvers.solver import Solver
+from pysmt.solvers.solver import Solver, Converter
 from pysmt.solvers.smtlib import SmtLibBasicSolver, SmtLibIgnoreMixin
 
 from pysmt.walkers import DagWalker
@@ -188,7 +188,7 @@ class YicesSolver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
 
 
 
-class YicesConverter(DagWalker):
+class YicesConverter(Converter, DagWalker):
 
     def __init__(self, environment):
         DagWalker.__init__(self, environment)

--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -22,7 +22,7 @@ import z3
 from fractions import Fraction
 
 from pysmt import typing as types
-from pysmt.solvers.solver import Solver, Model
+from pysmt.solvers.solver import Solver, Model, Converter
 from pysmt.solvers.smtlib import SmtLibBasicSolver, SmtLibIgnoreMixin
 from pysmt.solvers.qelim import QuantifierEliminator
 
@@ -164,7 +164,7 @@ class Z3Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
 
 
 
-class Z3Converter(DagWalker):
+class Z3Converter(Converter, DagWalker):
 
     def __init__(self, environment):
         DagWalker.__init__(self, environment)


### PR DESCRIPTION
A Converter Interface provides only two methods .convert() and .back()

A Solver needs to provide a converter property.