### PR TITLE
Creates "binaries" during installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-include LICENSE.txt, README.rst
-recursive-include docs *.txt
-include example.py
+include LICENSE README.rst
+recursive-include docs *.rst

--- a/README.rst
+++ b/README.rst
@@ -23,28 +23,34 @@ Among others, you can:
            :alt: Documentation Status
 
 
-Requirements
-============
+Getting Started
+===============
+You can install the latest stable release of pySMT from PyPI:
+  
+  $ pip install pysmt
+this will additionally install the *pysmt-install* command, that can be used to install the solvers: e.g., 
 
-* Python (http://www.python.org) >= 2.6
-* MathSAT (http://mathsat.fbk.eu/) >= 5 (Optional)
-* Z3 (http://z3.codeplex.com/releases) >= 4 (Optional)
-* CVC4 (http://cvc4.cs.nyu.edu/web/) (Optional)
-* Yices 2 (http://yices.csl.sri.com/) (Optional)
-* pyCUDD (http://bears.ece.ucsb.edu/pycudd.html) (Optional)
+  $ pysmt-install --msat
+this will download and install Mathsat 5. You will need to set your PYTHONPATH as suggested by the installer to make the python bindings visible. To verify that a solver has been installed run 
+
+  $ pysmt-install --check
+*Note* pysmt-install is provided to simplify the installation of solvers. However, each solver has its own license and restriction on use that you need to take into account.
+
+
+
+Supported Theories and Solvers
+==============================
+pySMT provides methods to define a formula in Linear Real Arithmetic (LRA), Real Difference Logic (RDL), their combination (LIRA) and
+Equalities and Uninterpreted Functions (EUF). The following solvers are supported:
+
+* MathSAT (http://mathsat.fbk.eu/) >= 5
+* Z3 (http://z3.codeplex.com/releases) >= 4
+* CVC4 (http://cvc4.cs.nyu.edu/web/) 
+* Yices 2 (http://yices.csl.sri.com/)
+* pyCUDD (http://bears.ece.ucsb.edu/pycudd.html)
 
 The library assumes that the python binding for the SMT Solver are installed
-and accessible from your PYTHONPATH.
-For Yices 2 we rely on pyices (https://github.com/cheshire/pyices).
-
-
-Supported Theories
-==================
-
-pySMT provides methods to define a formula in Linear Real Arithmetic
-(LRA), Real Difference Logic (RDL), their combination (LIRA) and
-Equalities and Uninterpreted Functions (EUF).
-
+and accessible from your PYTHONPATH. For Yices 2 we rely on pyices (https://github.com/cheshire/pyices).
 
 Usage
 =====

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,25 @@
-from distutils.core import setup
+#from distutils.core import setup
+from setuptools import setup, find_packages
 
 setup(
     name='PySMT',
-    version='0.2.2',
+    version='0.2.3.dev',
     author='PySMT Team',
-    author_email='',
-    packages=['pysmt', 'pysmt.smtlib', 'pysmt.solvers',
-              'pysmt.utils', 'pysmt.walkers',
-              'pysmt.test', 'pysmt.test.smtlib'],
+    author_email='info@pysmt.org',
+    packages = find_packages(),
+    include_package_data = True,
+    # packages=['pysmt', 'pysmt.smtlib', 'pysmt.solvers',
+    #           'pysmt.utils', 'pysmt.walkers',
+    #           'pysmt.test', 'pysmt.test.smtlib'],
     url='http://www.pysmt.org',
-    license='LICENSE',
+    license='APACHE',
     description='A library for SMT Formulae manipulation and solving',
     long_description=open('README.rst').read(),
-    install_requires=[ ],
+    entry_points={
+        'console_scripts': [
+            'pysmt = shell:main',
+            'pysmt-shell = shell:main_interactive',
+            'pysmt-install = install:main',
+        ],
+    },
 )

--- a/shell.py
+++ b/shell.py
@@ -130,7 +130,14 @@ class PysmtShell(object):
                 input_stream = open(self.args.file, "r")
             self.smtlib_solver(input_stream)
 
+def main_interactive():
+    shell = PysmtShell(sys.argv[1:])
+    shell.interactive()
 
-if __name__ == "__main__":
+def main():
     shell = PysmtShell(sys.argv[1:])
     shell.main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
We create 3 "binaries" after installation:
* pysmt : full shell that defaults to smtlib behavior
* pysmt-shell: shell that defaults to interactive
* pystm-install: alias for install.py

This addresses #10 