### PR TITLE
Using get_logic oracle in shortcuts and defining default for Factory

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -12,6 +12,12 @@ General:
   automatically used in _is_sat()_, _is_unsat()_, _is_valid()_, and
   _get_model()_.
 
+Backwards Incompatible Changes:
+
+* The default logic for Factory.get_solver() is now the most generic
+  *quantifier free* logic supported by pySMT (currently,
+  QF_UFLIRA). Previously it was UFLIRA, but this was due to a bug in
+  the logic of get_solver().
 
 
 0.2.2 2015-02-07 -- BDDs

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -8,6 +8,10 @@ General:
 
 * install.py: script to automate the installation of supported
   solvers.
+* get_logic() Oracle: Detects the logic used in a formula. This is now
+  automatically used in _is_sat()_, _is_unsat()_, _is_valid()_, and
+  _get_model()_.
+
 
 
 0.2.2 2015-02-07 -- BDDs

--- a/pysmt/factory.py
+++ b/pysmt/factory.py
@@ -282,14 +282,14 @@ class Factory(object):
             return retval
 
     def is_valid(self, formula, quantified=False, solver_name=None, logic=None):
-        if logic is AUTO_LOGIC:
+        if logic == AUTO_LOGIC:
             logic = get_logic(formula, self.environment)
         with self.Solver(quantified=quantified, name=solver_name, logic=logic) \
              as solver:
             return solver.is_valid(formula)
 
     def is_unsat(self, formula, quantified=False, solver_name=None, logic=None):
-        if logic is None:
+        if logic == AUTO_LOGIC:
             logic = get_logic(formula, self.environment)
         with self.Solver(quantified=quantified, name=solver_name, logic=logic) \
              as solver:

--- a/pysmt/factory.py
+++ b/pysmt/factory.py
@@ -27,7 +27,9 @@ import warnings
 from functools import partial
 
 from pysmt.exceptions import NoSolverAvailableError, SolverRedefinitionError
-from pysmt.logics import PYSMT_LOGICS, most_generic_logic, get_closer_logic
+from pysmt.logics import PYSMT_LOGICS, PYSMT_QF_LOGICS
+from pysmt.logics import most_generic_logic, get_closer_logic
+from pysmt.oracles import get_logic
 
 DEFAULT_SOLVER_PREFERENCE_LIST = ['msat', 'z3', 'cvc4', 'yices', 'bdd']
 DEFAULT_QELIM_PREFERENCE_LIST = ['z3']
@@ -87,7 +89,8 @@ class Factory(object):
                 raise NoSolverAvailableError("Solver %s is not available" % name)
 
         if logic is None:
-            logic = most_generic_logic(PYSMT_LOGICS)
+            assert not quantified
+            logic = most_generic_logic(PYSMT_QF_LOGICS)
 
         solvers = self.all_solvers(logic=logic)
 
@@ -258,11 +261,15 @@ class Factory(object):
         return self.get_quantifier_eliminator(name=name)
 
     def is_sat(self, formula, quantified=None, solver_name=None, logic=None):
+        if logic is None:
+            logic = get_logic(formula, self.environment)
         with self.Solver(quantified=quantified, name=solver_name, logic=logic) \
              as solver:
             return solver.is_sat(formula)
 
     def get_model(self, formula, quantified=None, solver_name=None, logic=None):
+        if logic is None:
+            logic = get_logic(formula, self.environment)
         with self.Solver(quantified=quantified, name=solver_name, logic=logic) \
              as solver:
             solver.add_assertion(formula)
@@ -273,11 +280,15 @@ class Factory(object):
             return retval
 
     def is_valid(self, formula, quantified=False, solver_name=None, logic=None):
+        if logic is None:
+            logic = get_logic(formula, self.environment)
         with self.Solver(quantified=quantified, name=solver_name, logic=logic) \
              as solver:
             return solver.is_valid(formula)
 
     def is_unsat(self, formula, quantified=False, solver_name=None, logic=None):
+        if logic is None:
+            logic = get_logic(formula, self.environment)
         with self.Solver(quantified=quantified, name=solver_name, logic=logic) \
              as solver:
             return solver.is_unsat(formula)

--- a/pysmt/logics.py
+++ b/pysmt/logics.py
@@ -206,7 +206,14 @@ class Logic(object):
 
         return
 
-
+    def get_quantified_version(self):
+        """Returns the quantified version of logic."""
+        if self.quantifier_free:
+            return self
+        target_logic = Logic(name="", description="",
+                             quantifier_free=False,
+                             theory=self.theory)
+        return get_closer_pysmt_logic(target_logic)
 
     def __str__(self):
         return self.name

--- a/pysmt/logics.py
+++ b/pysmt/logics.py
@@ -527,6 +527,8 @@ symbols.""",
               linear=False,
               uninterpreted=True)
 
+AUTO = Logic(name="Auto",
+             description="Special logic used to indicate that the logic to be used depends on the formula.")
 
 SMTLIB2_LOGICS = [ AUFLIA,
                    AUFLIRA,

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -172,8 +172,9 @@ class TheoryOracle(walkers.DagWalker):
 # EOC TheoryOracle
 
 
-def get_logic(formula):
-    env = pysmt.shortcuts.get_env()
+def get_logic(formula, env=None):
+    if env is None:
+        env = pysmt.shortcuts.get_env()
     # Get Quantifier Information
     qf = env.qfo.is_qf(formula)
     theory = env.theoryo.get_theory(formula)

--- a/pysmt/shortcuts.py
+++ b/pysmt/shortcuts.py
@@ -226,14 +226,11 @@ def QuantifierEliminator(name=None):
     """Returns a quantifier eliminator"""
     return get_env().factory.QuantifierEliminator(name=name)
 
-def is_sat(formula, quantified=False, solver_name=None, logic=None):
+def is_sat(formula, solver_name=None, logic=None):
     """ Returns whether a formula is satisfiable.
 
     :param formula: The formula to check satisfiability
     :type  formula: FNode
-    :param quantified: A boolean indicating whether the formula is
-                       quantified (this will influence the choice of
-                       the solver.
     :param solver_name: Specify the name of the solver to be used.
     :param logic: Specify the logic that is going to be used.
     :returns: Whether the formula is SAT or UNSAT.
@@ -245,11 +242,10 @@ def is_sat(formula, quantified=False, solver_name=None, logic=None):
         formula = env.formula_manager.normalize(formula)
 
     return env.factory.is_sat(formula,
-                              quantified=quantified,
                               solver_name=solver_name,
                               logic=logic)
 
-def get_model(formula, quantified=False, solver_name=None, logic=None):
+def get_model(formula, solver_name=None, logic=None):
     """ Similar to :py:func:`is_sat` but returns a model if the formula is
     satisfiable, otherwise None."""
     env = get_env()
@@ -258,11 +254,10 @@ def get_model(formula, quantified=False, solver_name=None, logic=None):
         formula = env.formula_manager.normalize(formula)
 
     return env.factory.get_model(formula,
-                                 quantified=quantified,
                                  solver_name=solver_name,
                                  logic=logic)
 
-def is_valid(formula, quantified=False, solver_name=None, logic=None):
+def is_valid(formula, solver_name=None, logic=None):
     """Similar to :py:func:`is_sat` but checks validity."""
     env = get_env()
     if formula not in env.formula_manager:
@@ -270,11 +265,10 @@ def is_valid(formula, quantified=False, solver_name=None, logic=None):
         formula = env.formula_manager.normalize(formula)
 
     return env.factory.is_valid(formula,
-                                quantified=quantified,
                                 solver_name=solver_name,
                                 logic=logic)
 
-def is_unsat(formula, quantified=False, solver_name=None, logic=None):
+def is_unsat(formula, solver_name=None, logic=None):
     """Similar to :py:func:`is_sat` but checks unsatisfiability."""
     env = get_env()
     if formula not in env.formula_manager:
@@ -282,7 +276,6 @@ def is_unsat(formula, quantified=False, solver_name=None, logic=None):
         formula = env.formula_manager.normalize(formula)
 
     return env.factory.is_unsat(formula,
-                                quantified=quantified,
                                 solver_name=solver_name,
                                 logic=logic)
 

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -21,11 +21,12 @@ from pysmt.shortcuts import Symbol, FreshSymbol, And, Not, GT, Function, Plus
 from pysmt.shortcuts import Bool, TRUE, Real, LE, FALSE, Or, Equals
 from pysmt.shortcuts import Solver
 from pysmt.shortcuts import is_sat, is_valid, get_env, get_model
+from pysmt.shortcuts import get_env
 from pysmt.typing import BOOL, REAL, FunctionType
 from pysmt.test import TestCase, skipIfSolverNotAvailable, skipIfNoSolverForLogic
 from pysmt.test.examples import get_example_formulae
 from pysmt.exceptions import SolverReturnedUnknownResultError, InternalSolverError
-from pysmt.logics import QF_UFLIRA, QF_BOOL, QF_LRA
+from pysmt.logics import QF_UFLIRA, QF_BOOL, QF_LRA, AUTO
 
 class TestBasic(TestCase):
 
@@ -62,13 +63,27 @@ class TestBasic(TestCase):
             res = is_sat(g, solver_name=solver)
             self.assertFalse(res, "Formula was expected to be UNSAT")
 
+    # This test works only if is_sat requests QF_BOOL as logic, since
+    # that is the only logic handled by BDDs
     @skipIfSolverNotAvailable("bdd")
     def test_get_logic_in_is_sat(self):
         varA = Symbol("A", BOOL)
         varB = Symbol("B", BOOL)
 
         f = And(varA, Not(varB))
-        # This test works only if is_sat requests QF_BOOL as logic.
+        res = is_sat(f, logic=AUTO)
+        self.assertTrue(res)
+
+    @skipIfSolverNotAvailable("bdd")
+    def test_default_logic_in_is_sat(self):
+        factory = get_env().factory
+        factory.default_logic = QF_BOOL
+
+        self.assertEquals(factory.default_logic, QF_BOOL)
+        varA = Symbol("A", BOOL)
+        varB = Symbol("B", BOOL)
+
+        f = And(varA, Not(varB))
         res = is_sat(f)
         self.assertTrue(res)
 

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -62,6 +62,17 @@ class TestBasic(TestCase):
             res = is_sat(g, solver_name=solver)
             self.assertFalse(res, "Formula was expected to be UNSAT")
 
+    @skipIfSolverNotAvailable("bdd")
+    def test_get_logic_in_is_sat(self):
+        varA = Symbol("A", BOOL)
+        varB = Symbol("B", BOOL)
+
+        f = And(varA, Not(varB))
+        # This test works only if is_sat requests QF_BOOL as logic.
+        res = is_sat(f)
+        self.assertTrue(res)
+
+
     @skipIfNoSolverForLogic(QF_BOOL)
     def test_get_model_unsat(self):
         varA = Symbol("A", BOOL)


### PR DESCRIPTION
This PR introduces the following changes:

- The special logic pysmt.logics.AUTO is introduced. This logic can be used in the shortcuts (is_sat, etc) when we are not sure of the formula that we are solving. This will select the smallest logic needed.
-  Factory.default_logic (by default QF_UFLIRA) used whenever a logic has not been specified
- Deprecation of _quantified_ argument from all shortcuts. This argument remains in the Factory.Solver, with the semantics that it requires the quantified version of the default logic.

__THIS MIGHT BREAK EXISTING TOOLS RELYING ON THE (DEPRECATED) quantified OPTION__