### PR TITLE
Get free Variables

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -1,14 +1,23 @@
 Change Log
 ==========
 
+0.2.4 XXXXXXXX  -- YYYY
+-----------------------
+
+General:
+
+* Iterative implementation of FNode.get_free_variables().
+  This also deprecates FNode.get_dependencies().
+
+
 0.2.3 2015-03-12 -- Logics Refactoring
 --------------------------------------
 
 General:
 
 * install.py: script to automate the installation of supported
-  solvers. 
-  
+  solvers.
+
 * get_logic() Oracle: Detects the logic used in a formula. This can now be used in the shortcuts (_is_sat()_, _is_unsat()_, _is_valid()_, and
   _get_model()_) by choosing the special logic pysmt.logics.AUTO.
 
@@ -24,7 +33,7 @@ General:
 * The default logic for Factory.get_solver() is now the most generic
   *quantifier free* logic supported by pySMT (currently,
   QF_UFLIRA). The factory not provides a way to change this default.
-  
+
 * Removed option _quantified_ from all shortcuts.
 
 

--- a/pysmt/environment.py
+++ b/pysmt/environment.py
@@ -46,6 +46,7 @@ class Environment(object):
         self._serializer = pysmt.printers.HRSerializer(self)
         self._qfo = pysmt.oracles.QuantifierOracle(self)
         self._theoryo = pysmt.oracles.TheoryOracle(self)
+        self._fvo = pysmt.oracles.FreeVarsOracle(self)
 
         self._factory = None
         # Configurations
@@ -85,6 +86,11 @@ class Environment(object):
     def theoryo(self):
         """ Get the Theory Oracle """
         return self._theoryo
+
+    @property
+    def fvo(self):
+        """ Get the FreeVars Oracle """
+        return self._fvo
 
     def add_dynamic_walker_function(self, nodetype, walker, function):
         """Dynamically bind the given function to the walker for the nodetype.

--- a/pysmt/fnode.py
+++ b/pysmt/fnode.py
@@ -16,11 +16,10 @@
 #   limitations under the License.
 #
 """FNode are the building blocks of formulae."""
-
 import collections
 
 import shortcuts
-from pysmt.operators import ALL_TYPES, QUANTIFIERS, CONSTANTS
+from pysmt.operators import CONSTANTS
 from pysmt.operators import (FORALL, EXISTS, AND, OR, NOT, IMPLIES, IFF,
                              SYMBOL, FUNCTION,
                              REAL_CONSTANT, BOOL_CONSTANT, INT_CONSTANT,
@@ -29,14 +28,10 @@ from pysmt.operators import (FORALL, EXISTS, AND, OR, NOT, IMPLIES, IFF,
                              ITE,
                              TOREAL)
 from pysmt.typing import BOOL, REAL, INT, PYSMT_TYPES
+from pysmt.decorators import deprecated
 
 FNodeContent = collections.namedtuple("FNodeContent",
                                       ["node_type", "args", "payload"])
-
-# Operators for which Args is an FNode (used by compute_dependencies
-DEPENDENCIES_SIMPLE_ARGS = (set(ALL_TYPES) - \
-                            (set([SYMBOL, FUNCTION]) | QUANTIFIERS | CONSTANTS))
-
 
 class FNode(object):
     r"""FNode represent the basic structure for representing a formula.
@@ -55,7 +50,6 @@ class FNode(object):
 
     def __init__(self, content):
         self._content = content
-        self._dependencies = None
         return
 
     # __eq__ and __hash__ are left as default
@@ -70,42 +64,15 @@ class FNode(object):
     def arg(self, idx):
         return self._content.args[idx]
 
-
+    @deprecated("get_free_variables")
     def get_dependencies(self):
-        if self._dependencies is None:
-            self._dependencies = self._compute_dependencies()
-        return self._dependencies
+        return self.get_free_variables()
 
-    def _compute_dependencies(self):
-        if self.node_type() in DEPENDENCIES_SIMPLE_ARGS:
-            res = set()
-            for s in self.get_sons():
-                res.update(s.get_dependencies())
-            return res
-
-        elif self.node_type() in QUANTIFIERS:
-            return self.arg(0).get_dependencies().difference(self._content.payload)
-
-        elif self.node_type() == SYMBOL:
-            return frozenset([self])
-
-        elif self.node_type() in CONSTANTS:
-            return frozenset()
-
-        elif self.node_type() == FUNCTION:
-            res = set([self._content.payload])
-            for p in self.args():
-                res.update(p.get_dependencies())
-            return res
-
-        else:
-            assert False
-        return
-
+    def get_free_variables(self):
+        return shortcuts.get_free_variables(self)
 
     def get_sons(self):
         return self.args()
-
 
     def simplify(self):
         return shortcuts.simplify(self)

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -219,7 +219,7 @@ class FreeVarsOracle(pysmt.walkers.DagWalker):
         return frozenset(res)
 
     def walk_quantifier(self, formula, args):
-        return args[0].difference(formula._content.payload)
+        return args[0].difference(formula.quantifier_vars())
 
     def walk_symbol(self, formula, args):
         return frozenset([formula])
@@ -228,8 +228,7 @@ class FreeVarsOracle(pysmt.walkers.DagWalker):
         return frozenset()
 
     def walk_function(self, formula, args):
-        # MG: Do we need to create a list?
-        res = set([formula._content.payload])
+        res = set([formula.function_name()])
         for arg in args:
             res.update(arg)
         return frozenset(res)

--- a/pysmt/shortcuts.py
+++ b/pysmt/shortcuts.py
@@ -81,6 +81,10 @@ def serialize(formula, threshold=None):
     return get_env().serializer.serialize(formula,
                                           threshold=threshold)
 
+def get_free_variables(formula):
+    """Returns the simplified version of the formula."""
+    return get_env().fvo.get_free_variables(formula)
+
 ##### Nodes Creation #####
 
 def ForAll(variables, formula):

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -248,7 +248,7 @@ class Simplifier(walkers.DagWalker):
         assert len(args) == 1
         sf = args[0]
 
-        varset = set(formula.quantifier_vars()).intersection(sf.get_dependencies())
+        varset = set(formula.quantifier_vars()).intersection(sf.get_free_variables())
 
         if len(varset) == 0:
             return sf
@@ -260,7 +260,7 @@ class Simplifier(walkers.DagWalker):
         assert len(args) == 1
         sf = args[0]
 
-        varset = set(formula.quantifier_vars()).intersection(sf.get_dependencies())
+        varset = set(formula.quantifier_vars()).intersection(sf.get_free_variables())
 
         if len(varset) == 0:
             return sf

--- a/pysmt/smtlib/printers.py
+++ b/pysmt/smtlib/printers.py
@@ -173,7 +173,7 @@ class SmtDagPrinter(DagWalker):
     def printer(self, f):
         self.openings = 0
         self.name_seed = 0
-        self.names = set(x.symbol_name() for x in f.get_dependencies())
+        self.names = set(x.symbol_name() for x in f.get_free_variables())
 
         key = self.walk(f)
         self.write(key)

--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -200,7 +200,7 @@ def smtlibscript_from_formula(formula):
     script.add(name=smtcmd.SET_LOGIC,
                args=[UFLIRA])
 
-    deps = formula.get_dependencies()
+    deps = formula.get_free_variables()
     # Declare all variables
     for symbol in deps:
         assert symbol.is_symbol()

--- a/pysmt/smtlib/solver.py
+++ b/pysmt/smtlib/solver.py
@@ -72,7 +72,7 @@ class SmtLibSolver(Solver):
         return
 
     def add_assertion(self, formula, named=None):
-        deps = formula.get_dependencies()
+        deps = formula.get_free_variables()
         for d in deps:
             if d not in self.declared_vars:
                 self._declare_variable(d)

--- a/pysmt/substituter.py
+++ b/pysmt/substituter.py
@@ -79,7 +79,7 @@ class Substituter(walkers.DagWalker):
                 # we do not consider this substitution in the body of
                 # the quantifier.
                 if all(m not in formula.quantifier_vars()
-                       for m in k.get_dependencies()):
+                       for m in k.get_free_variables()):
                     new_subs[k] = v
 
             # 2. We apply the substitution on the quantifier body with

--- a/pysmt/test/test_formula.py
+++ b/pysmt/test/test_formula.py
@@ -92,7 +92,7 @@ class TestFormulaManager(TestCase):
         n = self.mgr.And(self.x, self.y)
         self.assertIsNotNone(n)
         self.assertTrue(n.is_and())
-        self.assertEquals(n.get_dependencies(), set([self.x, self.y]))
+        self.assertEquals(n.get_free_variables(), set([self.x, self.y]))
 
         m = self.mgr.And([self.x, self.y])
         self.assertEquals(m, n, "And(1,2) != And([1,2]")
@@ -112,7 +112,7 @@ class TestFormulaManager(TestCase):
         n = self.mgr.Or(self.x, self.y)
         self.assertIsNotNone(n)
         self.assertTrue(n.is_or())
-        self.assertEquals(n.get_dependencies(), set([self.x, self.y]))
+        self.assertEquals(n.get_free_variables(), set([self.x, self.y]))
 
         m = self.mgr.Or([self.x, self.y])
         self.assertEquals(m, n, "Or(1,2) != Or([1,2]")
@@ -134,7 +134,7 @@ class TestFormulaManager(TestCase):
         self.assertIsNotNone(n)
 
         self.assertTrue(n.is_not())
-        self.assertEquals(n.get_dependencies(), set([self.x]))
+        self.assertEquals(n.get_free_variables(), set([self.x]))
 
         sons = n.get_sons()
         self.assertIn(self.x, sons)
@@ -145,7 +145,7 @@ class TestFormulaManager(TestCase):
         self.assertIsNotNone(n)
 
         self.assertTrue(n.is_implies())
-        self.assertEquals(n.get_dependencies(), set([self.x, self.y]))
+        self.assertEquals(n.get_free_variables(), set([self.x, self.y]))
 
         sons = n.get_sons()
         self.assertEqual(self.x, sons[0])
@@ -157,7 +157,7 @@ class TestFormulaManager(TestCase):
         self.assertIsNotNone(n)
 
         self.assertTrue(n.is_iff())
-        self.assertEquals(n.get_dependencies(), set([self.x, self.y]))
+        self.assertEquals(n.get_free_variables(), set([self.x, self.y]))
 
         sons = n.get_sons()
         self.assertIn(self.x, sons)
@@ -217,7 +217,7 @@ class TestFormulaManager(TestCase):
         self.assertIsNotNone(n)
 
         self.assertTrue(n.is_minus())
-        self.assertEquals(n.get_dependencies(), set([self.p, self.q]))
+        self.assertEquals(n.get_free_variables(), set([self.p, self.q]))
 
         with self.assertRaises(TypeError):
             n = self.mgr.Minus(self.r, self.q)
@@ -241,7 +241,7 @@ class TestFormulaManager(TestCase):
         n = self.mgr.Times(self.r, self.s)
         self.assertIsNotNone(n)
         self.assertTrue(n.is_times())
-        self.assertEquals(n.get_dependencies(), set([self.r, self.s]))
+        self.assertEquals(n.get_free_variables(), set([self.r, self.s]))
 
         n = self.mgr.Times(self.iconst, self.q)
         self.assertIsNotNone(n)
@@ -282,7 +282,7 @@ class TestFormulaManager(TestCase):
         self.assertIsNotNone(n)
 
         self.assertTrue(n.is_equals())
-        self.assertEquals(n.get_dependencies(), set([self.p, self.q]))
+        self.assertEquals(n.get_free_variables(), set([self.p, self.q]))
 
         with self.assertRaises(TypeError):
             n = self.mgr.Equals(self.p, self.r)
@@ -337,7 +337,7 @@ class TestFormulaManager(TestCase):
         self.assertIsNotNone(n)
 
         self.assertTrue(n.is_le())
-        self.assertEquals(n.get_dependencies(), set([self.r, self.s]))
+        self.assertEquals(n.get_free_variables(), set([self.r, self.s]))
 
         sons = n.get_sons()
         self.assertIn(self.r, sons)
@@ -364,7 +364,7 @@ class TestFormulaManager(TestCase):
         self.assertIsNotNone(n)
 
         self.assertTrue(n.is_lt())
-        self.assertEquals(n.get_dependencies(), set([self.r, self.s]))
+        self.assertEquals(n.get_free_variables(), set([self.r, self.s]))
 
         sons = n.get_sons()
         self.assertIn(self.r, sons)
@@ -387,7 +387,7 @@ class TestFormulaManager(TestCase):
         self.assertIsNotNone(n)
 
         self.assertTrue(n.is_ite())
-        self.assertEquals(n.get_dependencies(), set([self.x, self.p, self.q]))
+        self.assertEquals(n.get_free_variables(), set([self.x, self.p, self.q]))
 
         with self.assertRaises(TypeError):
             self.mgr.Ite(self.x, self.p, self.r)
@@ -403,7 +403,7 @@ class TestFormulaManager(TestCase):
         self.assertEqual(len(sons), 2)
 
         self.assertTrue(n.is_function_application())
-        self.assertEquals(n.get_dependencies(), set([self.f, self.r, self.s]))
+        self.assertEquals(n.get_free_variables(), set([self.f, self.r, self.s]))
 
 
     def test_constant(self):
@@ -464,7 +464,7 @@ class TestFormulaManager(TestCase):
         self.assertEqual(n1, n2, "Constructed Plus expression do not match")
 
         self.assertTrue(n1.is_plus())
-        self.assertEquals(set([self.r, self.s]), n1.get_dependencies())
+        self.assertEquals(set([self.r, self.s]), n1.get_free_variables())
 
         one = self.mgr.Plus([self.p])
         self.assertEquals(one, self.p)
@@ -613,7 +613,7 @@ class TestFormulaManager(TestCase):
         self.assertEquals(f1, f2)
 
         self.assertTrue(f1.is_toreal())
-        self.assertEquals(set([self.p]), f1.get_dependencies())
+        self.assertEquals(set([self.p]), f1.get_free_variables())
 
         f3 = self.mgr.Equals(self.iconst, self.p)
         with self.assertRaises(TypeError):

--- a/pysmt/test/test_oracles.py
+++ b/pysmt/test/test_oracles.py
@@ -17,10 +17,12 @@
 #
 from unittest import skip
 
-from pysmt.shortcuts import get_env
+from pysmt.shortcuts import get_env, get_free_variables
+from pysmt.shortcuts import Symbol, Implies, And, Not
 from pysmt.test.examples import EXAMPLE_FORMULAS
 from pysmt.test import TestCase
 from pysmt.oracles import get_logic
+
 
 class TestOracles(TestCase):
     @skip
@@ -37,12 +39,9 @@ class TestOracles(TestCase):
             self.assertEquals(res, target_logic, "%s - %s != %s" % \
                               (example.expr, target_logic, res))
 
-    def test_regression(self):
-        from pysmt.shortcuts import Symbol, Plus, Equals, Real, GT, LT, Implies, And, ForAll, Minus
-        from pysmt.typing import REAL
-        r,s = Symbol("r", REAL), Symbol("s", REAL)
-        x,y = Symbol("x"), Symbol("y")
+    def test_get_free_vars(self):
+        x, y = Symbol("x"), Symbol("y")
+        f = Implies(x, And(y, Not(x)))
 
-        f4 = ForAll([r,s], Implies(And(GT(r, Real(0)), GT(s, Real(0))),
-                              (LT(Minus(r,s), r))))
-        print(f4, get_logic(f4))
+        s = get_free_variables(f)
+        self.assertEqual(set([x,y]), s)

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -114,7 +114,7 @@ class TestRegressions(TestCase):
     def test_dependencies_not_includes_toreal(self):
         p = Symbol("p", INT)
         r = ToReal(p)
-        deps = r.get_dependencies()
+        deps = r.get_free_variables()
 
         self.assertIn(p, deps)
         self.assertNotIn(r, deps)

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -21,7 +21,6 @@ from pysmt.shortcuts import Symbol, FreshSymbol, And, Not, GT, Function, Plus
 from pysmt.shortcuts import Bool, TRUE, Real, LE, FALSE, Or, Equals
 from pysmt.shortcuts import Solver
 from pysmt.shortcuts import is_sat, is_valid, get_env, get_model
-from pysmt.shortcuts import get_env
 from pysmt.typing import BOOL, REAL, FunctionType
 from pysmt.test import TestCase, skipIfSolverNotAvailable, skipIfNoSolverForLogic
 from pysmt.test.examples import get_example_formulae
@@ -178,7 +177,7 @@ class TestBasic(TestCase):
 
                     # Ask single values to the solver
                     subs = {}
-                    for d in f.get_dependencies():
+                    for d in f.get_free_variables():
                         m = s.get_value(d)
                         subs[d] = m
 
@@ -188,7 +187,7 @@ class TestBasic(TestCase):
                     # Ask the eager model
                     subs = {}
                     model = s.get_model()
-                    for d in f.get_dependencies():
+                    for d in f.get_free_variables():
                         m = model.get_value(d)
                         subs[d] = m
 

--- a/pysmt/test/test_walkers.py
+++ b/pysmt/test/test_walkers.py
@@ -26,6 +26,8 @@ from pysmt.walkers import TreeWalker, DagWalker, IdentityDagWalker
 from pysmt.test import TestCase
 from pysmt.formula import FormulaManager
 
+
+
 class TestWalkers(TestCase):
 
     def test_subst(self):
@@ -179,6 +181,13 @@ class TestWalkers(TestCase):
         phi_sub = substitute(phi, {r: Real(0), i: Int(0)}).simplify()
         self.assertEquals(phi_sub, Function(f, [Int(1), Real(-2)]))
 
+    def test_iterative_get_dependencies(self):
+        f = Symbol("x")
+        for _ in xrange(1000):
+            f = And(f, f)
+
+        cone = f.get_dependencies()
+        self.assertEqual(cone, set([Symbol("x")]))
 
 
 if __name__ == '__main__':

--- a/pysmt/test/test_walkers.py
+++ b/pysmt/test/test_walkers.py
@@ -181,12 +181,12 @@ class TestWalkers(TestCase):
         phi_sub = substitute(phi, {r: Real(0), i: Int(0)}).simplify()
         self.assertEquals(phi_sub, Function(f, [Int(1), Real(-2)]))
 
-    def test_iterative_get_dependencies(self):
+    def test_iterative_get_free_variables(self):
         f = Symbol("x")
         for _ in xrange(1000):
             f = And(f, f)
 
-        cone = f.get_dependencies()
+        cone = f.get_free_variables()
         self.assertEqual(cone, set([Symbol("x")]))
 
 


### PR DESCRIPTION
Refactoring of FNode.get_dependencies() to use iterative walkers.

- Introduces the FreeVarsOracle, and the get_free_variables function/shortcut.
- Added Deprecation warning to get_dependencies
- Updated code-base to use get_free_variables