### PR TITLE
Enabling Smt-Lib wrappers testing in CI

### DIFF
--- a/pysmt/smtlib/parser.py
+++ b/pysmt/smtlib/parser.py
@@ -200,6 +200,7 @@ class SmtLibParser(object):
         self._current_env = None
         self.cache = None
         self.logic = None
+        self._reset()
 
         # Special tokens appearing in expressions
         self.parentheses = set(["(", ")"])

--- a/shippable.sh
+++ b/shippable.sh
@@ -6,6 +6,15 @@ then
     ./install.py --confirm-agreement --msat
 fi
 
+if [ "$1" == "msat_wrap" ]
+then
+    apt-get update
+    apt-get install -y make build-essential swig libgmp-dev
+    apt-get install -y python-all-dev
+    ./install.py --confirm-agreement --msat
+fi
+
+
 if [ "$1" == "z3" ]
 then
     apt-get update

--- a/shippable.yml
+++ b/shippable.yml
@@ -77,7 +77,7 @@ before_script:
 script:
   - ./install.py --check
   - if [ "$PYSMT_SOLVER" == "msat_wrap" ]; then cd $TRAVIS_BUILD_DIR/pysmt/test/smtlib/bin; cp $TRAVIS_BUILD_DIR/.smt_solvers/mathsat-5.2.12-linux-x86_64/bin/mathsat .; mv mathsat.solver.sh.template mathsat.solver.sh; fi
-  - nosetests pysmt -v --processes=4 --process-timeout=360 --with-xunit --xunit-file=shippable/testresults/nosetests.xml
+  - nosetests pysmt --processes=4 --process-timeout=360 --with-xunit --xunit-file=shippable/testresults/nosetests.xml
 
 # Push of container is disabled
 # commit_container: gario/shippable_pysmt

--- a/shippable.yml
+++ b/shippable.yml
@@ -38,6 +38,7 @@ env:
     - PYSMT_SOLVER="yices"
     - PYSMT_SOLVER="cudd"
     - PYSMT_SOLVER="picosat"
+    - PYSMT_SOLVER="msat_wrap"
 
 matrix:
   include:
@@ -75,7 +76,8 @@ before_script:
 
 script:
   - ./install.py --check
-  - nosetests pysmt --processes=4 --process-timeout=360 --with-xunit --xunit-file=shippable/testresults/nosetests.xml
+  - if [ "$PYSMT_SOLVER" == "msat_wrap" ]; then cd $TRAVIS_BUILD_DIR/pysmt/test/smtlib/bin; cp $TRAVIS_BUILD_DIR/.smt_solvers/mathsat-5.2.12-linux-x86_64/bin/mathsat .; mv mathsat.solver.sh.template mathsat.solver.sh; fi
+  - nosetests pysmt -v --processes=4 --process-timeout=360 --with-xunit --xunit-file=shippable/testresults/nosetests.xml
 
 # Push of container is disabled
 # commit_container: gario/shippable_pysmt


### PR DESCRIPTION
This also fixes a bug in SmtLibParser Initialization that appeared only when testing with wrappers.