### PR TITLE
Enabling tests for solvers wrapper

### DIFF
--- a/pysmt/smtlib/parser.py
+++ b/pysmt/smtlib/parser.py
@@ -200,6 +200,7 @@ class SmtLibParser(object):
         self._current_env = None
         self.cache = None
         self.logic = None
+        self._reset()
 
         # Special tokens appearing in expressions
         self.parentheses = set(["(", ")"])

--- a/pysmt/test/smtlib/test_generic_wrapper.py
+++ b/pysmt/test/smtlib/test_generic_wrapper.py
@@ -129,3 +129,6 @@ class TestGenericWrapper(TestCase):
                 s.add_assertion(f)
                 res = s.solve()
                 self.assertFalse(res)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shippable.sh
+++ b/shippable.sh
@@ -6,6 +6,15 @@ then
     ./install.py --confirm-agreement --msat
 fi
 
+if [ "$1" == "msat_wrap" ]
+then
+    apt-get update
+    apt-get install -y make build-essential swig libgmp-dev
+    apt-get install -y python-all-dev
+    ./install.py --confirm-agreement --msat
+fi
+
+
 if [ "$1" == "z3" ]
 then
     apt-get update

--- a/shippable.yml
+++ b/shippable.yml
@@ -39,6 +39,7 @@ env:
     - PYSMT_SOLVER="yices"
     - PYSMT_SOLVER="cudd"
     - PYSMT_SOLVER="picosat"
+    - PYSMT_SOLVER="msat_wrap"
 
 matrix:
   include:
@@ -76,7 +77,8 @@ before_script:
 
 script:
   - ./install.py --check
-  - nosetests pysmt --processes=4 --process-timeout=360 --with-xunit --xunit-file=shippable/testresults/nosetests.xml
+  - if [ "$PYSMT_SOLVER" == "msat_wrap" ]; then cd $TRAVIS_BUILD_DIR/pysmt/test/smtlib/bin; cp $TRAVIS_BUILD_DIR/.smt_solvers/mathsat-5.2.12-linux-x86_64/bin/mathsat .; mv mathsat.solver.sh.template mathsat.solver.sh; cd $TRAVIS_BUILD_DIR/; fi
+  - nosetests pysmt -v --processes=4 --process-timeout=360 --with-xunit --xunit-file=shippable/testresults/nosetests.xml
 
 # Push of container is disabled
 # commit_container: gario/shippable_pysmt


### PR DESCRIPTION
We were not executing the tests on the solvers wrapper. We now do so on msat.

The configuration is called msat_wrap, and copies mathsat within the test/smtlib/bin directory.
This PR fixes also some issues that appeared after enabling the tests.