### PR TITLE
Adding custom methods to pysmt.TestCase

### DIFF
--- a/pysmt/test/__init__.py
+++ b/pysmt/test/__init__.py
@@ -19,7 +19,7 @@ import unittest
 
 from functools import wraps
 
-from pysmt.shortcuts import reset_env, get_env
+from pysmt.shortcuts import reset_env, get_env, is_sat, is_valid, is_unsat
 from pysmt.decorators import deprecated
 
 class TestCase(unittest.TestCase):
@@ -37,6 +37,27 @@ class TestCase(unittest.TestCase):
 
     if "assertRaisesRegex" not in dir(unittest.TestCase):
         assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
+
+    def assertValid(self, formula, msg=None, solver_name=None, logic=None):
+        """Assert that formula is VALID."""
+        self.assertTrue(self.env.factory.is_valid(formula=formula,
+                                                  solver_name=solver_name,
+                                                  logic=logic),
+                        msg=msg)
+
+    def assertSat(self, formula, msg=None, solver_name=None, logic=None):
+        """Assert that formula is SAT."""
+        self.assertTrue(self.env.factory.is_sat(formula=formula,
+                                                solver_name=solver_name,
+                                                logic=logic),
+                        msg=msg)
+
+    def assertUnsat(self, formula, msg=None, solver_name=None, logic=None):
+        """Assert that formula is UNSAT."""
+        self.assertTrue(self.env.factory.is_unsat(formula=formula,
+                                                  solver_name=solver_name,
+                                                  logic=logic),
+                        msg=msg)
 
 
 @deprecated("skipIfNoSolverForLogic (be specific about expectations!)")

--- a/pysmt/test/test_cnf.py
+++ b/pysmt/test/test_cnf.py
@@ -36,8 +36,7 @@ class TestCnf(TestCase):
                 continue
             cnf = conv.convert_as_formula(example.expr)
 
-            res = is_valid(Implies(cnf, example.expr), logic=logic)
-            self.assertTrue(res)
+            self.assertValid(Implies(cnf, example.expr), logic=logic)
 
             res = is_sat(cnf, logic=logic)
             self.assertEqual(res, example.is_sat)
@@ -87,8 +86,7 @@ class TestCnf(TestCase):
                 conv.convert_as_formula(expr)
             return
         cnf = conv.convert_as_formula(expr)
-        res = is_valid(Implies(cnf, expr), logic=logic)
-        self.assertTrue(res)
+        self.assertValid(Implies(cnf, expr), logic=logic)
 
         res = is_sat(cnf, logic=logic)
         self.assertEqual(res, res_is_sat)

--- a/pysmt/test/test_euf.py
+++ b/pysmt/test/test_euf.py
@@ -34,8 +34,8 @@ class TestEUF(TestCase):
 
         check = Equals(Function(f, [Real(1)]), Function(g, (Real(2), Int(4))))
 
-        self.assertTrue(is_sat(check, logic=UFLIRA),
-                        "Formula was expected to be sat")
+        self.assertSat(check, logic=UFLIRA,
+                       msg="Formula was expected to be sat")
 
     @skipIfNoSolverForLogic(UFLRA)
     def test_quantified_euf(self):
@@ -53,8 +53,8 @@ class TestEUF(TestCase):
 
         check = Implies(axiom, And(test1, test2))
 
-        self.assertTrue(is_valid(check, logic=UFLRA),
-                        "Formula was expected to be valid")
+        self.assertValid(check, logic=UFLRA,
+                        msg="Formula was expected to be valid")
 
 
     def test_simplify(self):

--- a/pysmt/test/test_int.py
+++ b/pysmt/test/test_int.py
@@ -31,8 +31,8 @@ class TestLIA(TestCase):
                 GT(varA, Minus(varB, Int(1))))
         g = Equals(varA, varB)
 
-        self.assertTrue(is_valid(Iff(f, g), logic=QF_LIA),
-                        "Formulae were expected to be equivalent")
+        self.assertValid(Iff(f, g), "Formulae were expected to be equivalent",
+                         logic=QF_LIA)
 
     @skipIfNoSolverForLogic(QF_LIA)
     def test_lira(self):
@@ -44,9 +44,9 @@ class TestLIA(TestCase):
                     GT(varA, Minus(varB, Real(1))))
             g = Equals(varB, Int(0))
 
-            self.assertTrue(is_unsat(And(f, g, Equals(varA, Real(1.2))),
-                                     logic=QF_UFLIRA),
-                            "Formula was expected to be unsat")
+            self.assertUnsat(And(f, g, Equals(varA, Real(1.2))),
+                             "Formula was expected to be unsat",
+                             logic=QF_UFLIRA)
 
 
 

--- a/pysmt/test/test_lira.py
+++ b/pysmt/test/test_lira.py
@@ -58,7 +58,7 @@ class TestLIRA(TestCase):
                         GE(Function(h, (a, b)), Real(0)))
 
         for sname in get_env().factory.all_solvers(logic=UFLIRA):
-            self.assertTrue(is_valid(check, solver_name=sname))
+            self.assertValid(check, solver_name=sname)
 
 
 if __name__ == '__main__':

--- a/pysmt/test/test_msat_back.py
+++ b/pysmt/test/test_msat_back.py
@@ -17,7 +17,7 @@
 #
 import unittest
 from pysmt.shortcuts import FreshSymbol, GT, And, Plus, Real, Int, LE, Iff
-from pysmt.shortcuts import is_valid, get_env
+from pysmt.shortcuts import get_env
 from pysmt.typing import REAL, INT
 from pysmt.test import TestCase, skipIfSolverNotAvailable
 from pysmt.test.examples import get_example_formulae
@@ -45,7 +45,7 @@ class TestBasic(TestCase):
 
         # Checking equality is not enough: MathSAT can change the
         # shape of the formula into a logically equivalent form.
-        self.assertTrue(is_valid(Iff(f, res), logic=QF_UFLIRA))
+        self.assertValid(Iff(f, res), logic=QF_UFLIRA)
 
 
     @skipIfSolverNotAvailable("msat")
@@ -77,8 +77,7 @@ class TestBasic(TestCase):
             if logic.quantifier_free:
                 term = new_converter.convert(formula)
                 res = new_converter.back(term)
-                self.assertTrue(is_valid(Iff(formula, res), logic=QF_UFLIRA))
-
+                self.assertValid(Iff(formula, res), logic=QF_UFLIRA)
 
 
 if __name__ == '__main__':

--- a/pysmt/test/test_qe.py
+++ b/pysmt/test/test_qe.py
@@ -45,10 +45,10 @@ class TestQE(TestCase):
         r1 = qe.eliminate_quantifiers(qf)
 
         try:
-            res = is_valid(Iff(r1, qf), logic=LRA)
+            self.assertValid(Iff(r1, qf), logic=LRA,
+                             msg="The two formulas should be equivalent.")
         except SolverReturnedUnknownResultError:
             pass
-        self.assertTrue(res, "The two formulas whould be equivalent.")
 
 
     @unittest.skipIf('z3' not in get_env().factory.all_qelims(),
@@ -147,7 +147,7 @@ class TestQE(TestCase):
         f = ForAll([p], Implies(LT(Int(0), p), LT(q, p)))
         qf = qe.eliminate_quantifiers(f).simplify()
 
-        self.assertTrue(is_valid(Iff(qf, LE(q, Int(0)))))
+        self.assertValid(Iff(qf, LE(q, Int(0))))
 
     def _alternation_bool_example(self, qe):
         # Alternation of quantifiers

--- a/pysmt/test/test_rand.py
+++ b/pysmt/test/test_rand.py
@@ -19,7 +19,7 @@ from nose.plugins.attrib import attr
 from six.moves import xrange
 
 from pysmt.randomizer import build_random_formula, build_random_qf_formula
-from pysmt.shortcuts import is_valid, Iff
+from pysmt.shortcuts import Iff
 from pysmt.shortcuts import get_env
 from pysmt.type_checker import SimpleTypeChecker
 from pysmt.test import TestCase, skipIfSolverNotAvailable
@@ -50,10 +50,9 @@ class TestRand(TestCase):
             sf = f.simplify()
             get_env().simplifier.validate_simplifications = False
 
-            res = is_valid(Iff(f, sf), solver_name='z3')
-            self.assertTrue(res,
-                            "Simplification did not provide equivalent "+
-                            "result:\n f= %s\n sf = %s" % (f, sf))
+            self.assertValid(Iff(f, sf), solver_name='z3',
+                             msg="Simplification did not provide equivalent "+
+                                "result:\n f= %s\n sf = %s" % (f, sf))
 
     @attr("slow")
     @skipIfSolverNotAvailable('z3')
@@ -63,12 +62,10 @@ class TestRand(TestCase):
             f = build_random_qf_formula(10, 20, 4, 0.1, seed=i)
             sf = f.simplify()
             test = Iff(f, sf)
-            res = is_valid(test, solver_name='z3')
-
-            self.assertTrue(res,
-                            "Simplification of formula %d " % i +
-                            "did not provide equivalent "+
-                            "result:\n f= %s\n sf = %s" % (f, sf))
+            self.assertValid(test, solver_name='z3',
+                             msg="Simplification of formula %d " % i +
+                                 "did not provide equivalent "+
+                                 "result:\n f= %s\n sf = %s" % (f, sf))
 
     @attr("slow")
     @skipIfSolverNotAvailable('msat')
@@ -78,12 +75,10 @@ class TestRand(TestCase):
             f = build_random_qf_formula(10, 20, 4, 0.1, seed=i)
             sf = f.simplify()
             test = Iff(f, sf)
-            res = is_valid(test, solver_name='msat')
-
-            self.assertTrue(res,
-                            "Simplification of formula %d " % i +
-                            "did not provide equivalent "+
-                            "result:\n f= %s\n sf = %s" % (f, sf))
+            self.assertValid(test, solver_name='msat',
+                             msg="Simplification of formula %d " % i +
+                                 "did not provide equivalent "+
+                                 "result:\n f= %s\n sf = %s" % (f, sf))
 
 
     def test_hrserializer(self):

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -19,7 +19,7 @@ from fractions import Fraction
 
 from pysmt.shortcuts import (Real, Plus, Symbol, Equals, And, Bool, Or,
                              Div, LT, LE, Int, ToReal, Iff)
-from pysmt.shortcuts import Solver, is_valid, get_env, is_sat
+from pysmt.shortcuts import Solver, get_env
 from pysmt.typing import REAL, BOOL, INT, FunctionType
 from pysmt.test import TestCase, skipIfSolverNotAvailable, skipIfNoSolverForLogic
 from pysmt.logics import QF_UFLIRA, QF_BOOL
@@ -43,9 +43,9 @@ class TestRegressions(TestCase):
         p2 = Plus(a, b, c, Real((1,6)))
 
 
-        self.assertTrue(is_valid(Equals(p1, p2)))
-        self.assertTrue(is_valid(Equals(p1, p2), solver_name='z3'))
-        self.assertTrue(is_valid(Equals(p1, p2), solver_name='msat'))
+        self.assertValid(Equals(p1, p2))
+        self.assertValid(Equals(p1, p2), solver_name='z3')
+        self.assertValid(Equals(p1, p2), solver_name='msat')
 
 
     def test_substitute_memoization(self):
@@ -69,12 +69,12 @@ class TestRegressions(TestCase):
     @skipIfSolverNotAvailable("msat")
     @skipIfSolverNotAvailable("z3")
     def test_conversion_of_fractions_in_z3(self):
-        self.assertTrue(is_valid(Equals(Real(Fraction(1,9)),
-                                        Div(Real(1), Real(9))),
-                                 solver_name="msat"))
-        self.assertTrue(is_valid(Equals(Real(Fraction(1,9)),
-                                        Div(Real(1), Real(9))),
-                                 solver_name="z3"))
+        self.assertValid(Equals(Real(Fraction(1,9)),
+                                Div(Real(1), Real(9))),
+                         solver_name="msat")
+        self.assertValid(Equals(Real(Fraction(1,9)),
+                                Div(Real(1), Real(9))),
+                         solver_name="z3")
 
     def test_simplifying_int_plus_changes_type_of_expression(self):
         varA = Symbol("At", INT)
@@ -102,14 +102,14 @@ class TestRegressions(TestCase):
 
 
         for name in get_env().factory.all_solvers(logic=QF_BOOL):
-            self.assertTrue(is_sat(f_and_one, solver_name=name))
-            self.assertTrue(is_sat(f_or_one, solver_name=name))
-            self.assertTrue(is_sat(f_and_many, solver_name=name))
-            self.assertTrue(is_sat(f_or_many, solver_name=name))
+            self.assertSat(f_and_one, solver_name=name)
+            self.assertSat(f_or_one, solver_name=name)
+            self.assertSat(f_and_many, solver_name=name)
+            self.assertSat(f_or_many, solver_name=name)
 
         for name in get_env().factory.all_solvers(logic=QF_UFLIRA):
-            self.assertTrue(is_sat(f_plus_one, solver_name=name))
-            self.assertTrue(is_sat(f_plus_many, solver_name=name))
+            self.assertSat(f_plus_one, solver_name=name)
+            self.assertSat(f_plus_many, solver_name=name)
 
     def test_dependencies_not_includes_toreal(self):
         p = Symbol("p", INT)

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -22,7 +22,7 @@ import pysmt.operators as op
 from pysmt.shortcuts import Symbol, FreshSymbol, And, Not, GT, Function, Plus
 from pysmt.shortcuts import Bool, TRUE, Real, LE, FALSE, Or, Equals
 from pysmt.shortcuts import Solver
-from pysmt.shortcuts import is_sat, is_valid, get_env, get_model
+from pysmt.shortcuts import get_env, get_model, is_valid, is_sat
 from pysmt.typing import BOOL, REAL, FunctionType
 from pysmt.test import TestCase, skipIfSolverNotAvailable, skipIfNoSolverForLogic
 from pysmt.test.examples import get_example_formulae
@@ -57,12 +57,12 @@ class TestBasic(TestCase):
         f = And(varA, Not(varB))
         g = f.substitute({varB:varA})
 
-        res = is_sat(g, logic=QF_BOOL)
-        self.assertFalse(res, "Formula was expected to be UNSAT")
+        self.assertUnsat(g, logic=QF_BOOL,
+                         msg="Formula was expected to be UNSAT")
 
         for solver in get_env().factory.all_solvers():
-            res = is_sat(g, solver_name=solver)
-            self.assertFalse(res, "Formula was expected to be UNSAT")
+            self.assertUnsat(g, solver_name=solver,
+                             msg="Formula was expected to be UNSAT")
 
     # This test works only if is_sat requests QF_BOOL as logic, since
     # that is the only logic handled by BDDs
@@ -72,8 +72,7 @@ class TestBasic(TestCase):
         varB = Symbol("B", BOOL)
 
         f = And(varA, Not(varB))
-        res = is_sat(f, logic=AUTO)
-        self.assertTrue(res)
+        self.assertSat(f, logic=AUTO)
 
     @skipIfSolverNotAvailable("bdd")
     def test_default_logic_in_is_sat(self):
@@ -85,8 +84,7 @@ class TestBasic(TestCase):
         varB = Symbol("B", BOOL)
 
         f = And(varA, Not(varB))
-        res = is_sat(f)
-        self.assertTrue(res)
+        self.assertSat(f)
 
 
     @skipIfNoSolverForLogic(QF_BOOL)


### PR DESCRIPTION
Added methods assertSat, assertUnsat and assertValid to pysmt.TestCase. Applied to most situations in which we were writing self.assertTrue(is_*)