### PR TITLE
Yices int/real number precision

### DIFF
--- a/pysmt/solvers/yices.py
+++ b/pysmt/solvers/yices.py
@@ -17,7 +17,6 @@
 #
 import atexit
 import ctypes
-import warnings
 
 from fractions import Fraction
 from six.moves import xrange

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -206,6 +206,10 @@ class TestBasic(TestCase):
     def test_model_msat(self):
         self.do_model("msat")
 
+    @skipIfSolverNotAvailable("yices")
+    def test_model_yices(self):
+        self.do_model("yices")
+
     @skipIfSolverNotAvailable("z3")
     def test_examples_z3(self):
         for (f, validity, satisfiability, _) in get_example_formulae():


### PR DESCRIPTION
This PR adds a more principled support for model extraction in the yices wrapper.

In particular:

* We extract rationals as pairs of integers (numerator / denominator) instead of using doubles.
* For each term that is evaluated, we check if its value is representable within the integer limits, otherwise an error is generated