### PR TITLE
Changed FNode's hash to be deterministic among succesive executions

### DIFF
--- a/pysmt/fnode.py
+++ b/pysmt/fnode.py
@@ -55,14 +55,26 @@ class FNode(object):
     (e.g., for the formula A /\ B, args=(A,B)) and its payload,
     content of the node that is not an FNode (e.g., for an integer
     constant, the payload might be the python value 1).
+
+    The node_id is an integer uniquely identifying the node within the
+    FormulaManager it belongs.
     """
 
-    def __init__(self, content):
+    def __init__(self, content, node_id):
         self._content = content
+        self._node_id = node_id
         return
 
-    # __eq__ and __hash__ are left as default
-    # This is because we always have shared FNode's
+    # __eq__ is left as default while __hash__ uses the node id. This
+    # is because we always have shared FNodes, hence in a single
+    # environment two nodes have always different ids, but in
+    # different environments they can have the same id. This is not an
+    # issue since, by default, equality coincides with identity.
+    def __hash__(self):
+        return self._node_id
+
+    def node_id(self):
+        return self._node_id
 
     def node_type(self):
         return self._content.node_type

--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -50,6 +50,7 @@ class FormulaManager(object):
         self._fresh_guess = 0
         # get_type() from TypeChecker will be initialized lazily
         self.get_type = None
+        self._next_free_id = 1
 
         self.int_constants = {}
         self.real_constants = {}
@@ -74,7 +75,8 @@ class FormulaManager(object):
         if content in self.formulae:
             return self.formulae[content]
         else:
-            n = FNode(content)
+            n = FNode(content, self._next_free_id)
+            self._next_free_id += 1
             self.formulae[content] = n
             self._do_type_check(n)
             return n

--- a/pysmt/walkers/identitydag.py
+++ b/pysmt/walkers/identitydag.py
@@ -96,7 +96,11 @@ class IdentityDagWalker(DagWalker):
         return self.mgr.Minus(*args)
 
     def walk_function(self, formula, args):
-        return self.mgr.Function(formula.function_name(), args)
+        # We re-create the symbol name
+        old_name = formula.function_name()
+        new_name = self.mgr.Symbol(old_name.symbol_name(),
+                                   old_name.symbol_type())
+        return self.mgr.Function(new_name, args)
 
     def walk_toreal(self, formula, args):
         return self.mgr.ToReal(*args)


### PR DESCRIPTION
Changed FNode's hash to be deterministic among succesive executions and on different machines. This is done by adding an id to each FNode
that is unique within the Formula Manager it belongs to.

This addresses issue #113.