### PR TITLE
CI: Enable artifact creation on shippable

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -7,6 +7,8 @@ python:
   - 2.7
   - 3.4
 
+# Allow the download of the generated files
+archive: true
 
 before_install:
  #  set up a virtualenv and activate the python version that you want to use


### PR DESCRIPTION
This creates a pkg for each run of the contents of the ./shippable directory, that can be later downloaded.  For now it includes only the code-coverage and xunit data.

NOTE: In the future, this should be used:

- to build the binaries of the solvers to upload to the binary mirror (if not available)
- to build the python package (with a dedicated job)