### PR TITLE
ENVIRONMENT: Relocated the global environment

### DIFF
--- a/pysmt/environment.py
+++ b/pysmt/environment.py
@@ -19,8 +19,6 @@
 The Environment is a key structure in pySMT. It contains multiple
 singleton objects that are used throughout the system, such as the
 FormulaManager, Simplifier, HRSerializer, SimpleTypeChecker.
-
-A global environment is defined in shortcuts.py
 """
 
 import pysmt.simplifier
@@ -30,8 +28,8 @@ import pysmt.type_checker
 import pysmt.oracles
 import pysmt.formula
 import pysmt.factory
-import pysmt.shortcuts
 import pysmt.decorators
+
 
 class Environment(object):
     FormulaManagerClass = pysmt.formula.FormulaManager
@@ -129,11 +127,37 @@ class Environment(object):
 
     def __enter__(self):
         """Entering a Context """
-        pysmt.shortcuts.push_env(self)
+        push_env(self)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Remove environment from global stack."""
-        pysmt.shortcuts.pop_env()
+        pop_env()
 
 # EOC Environment
+
+#### GLOBAL ENVIRONMENTS STACKS ####
+ENVIRONMENTS_STACK = []
+
+def get_env():
+    """Returns the Environment at the head of the stack."""
+    return ENVIRONMENTS_STACK[-1]
+
+def push_env(env=None):
+    """Push a env in the stack. If env is None, a new Environment is created."""
+    if env is None:
+        env = Environment()
+    ENVIRONMENTS_STACK.append(env)
+
+def pop_env():
+    """Pop an env from the stack."""
+    return ENVIRONMENTS_STACK.pop()
+
+def reset_env():
+    """Destroys and recreate the head environment."""
+    pop_env()
+    push_env()
+    return get_env()
+
+# Create the default environment
+push_env()

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -23,16 +23,16 @@ properties of formulae.
  * FreeVarsOracle says which variables are free in the formula
 """
 
-import pysmt.walkers as walkers
+import pysmt.walkers
 import pysmt.operators as op
-import pysmt.shortcuts
+import pysmt.environment
 
 from pysmt import typing as types
 
 from pysmt.logics import Logic, Theory, get_closer_pysmt_logic
 
 
-class SizeOracle(walkers.DagWalker):
+class SizeOracle(pysmt.walkers.DagWalker):
     """Evaluates the size of a formula"""
 
     # Counting type can be:
@@ -48,7 +48,7 @@ class SizeOracle(walkers.DagWalker):
      MEASURE_SYMBOLS) = range(5)
 
     def __init__(self, env=None):
-        walkers.DagWalker.__init__(self, env=env)
+        pysmt.walkers.DagWalker.__init__(self, env=env)
 
         self.measure_to_fun = \
                         {SizeOracle.MEASURE_TREE_NODES: self.walk_count_tree,
@@ -112,9 +112,9 @@ class SizeOracle(walkers.DagWalker):
 
 
 
-class QuantifierOracle(walkers.DagWalker):
+class QuantifierOracle(pysmt.walkers.DagWalker):
     def __init__(self, env=None):
-        walkers.DagWalker.__init__(self, env=env)
+        pysmt.walkers.DagWalker.__init__(self, env=env)
 
         # Clear the mapping function
         self.functions.clear()
@@ -138,9 +138,9 @@ class QuantifierOracle(walkers.DagWalker):
 # EOC QuantifierOracle
 
 
-class TheoryOracle(walkers.DagWalker):
+class TheoryOracle(pysmt.walkers.DagWalker):
     def __init__(self, env=None):
-        walkers.DagWalker.__init__(self, env=env)
+        pysmt.walkers.DagWalker.__init__(self, env=env)
 
         self.functions[op.AND] = self.walk_combine
         self.functions[op.OR] = self.walk_combine
@@ -402,7 +402,7 @@ class AtomsOracle(pysmt.walkers.DagWalker):
 
 def get_logic(formula, env=None):
     if env is None:
-        env = pysmt.shortcuts.get_env()
+        env = pysmt.environment.get_env()
     # Get Quantifier Information
     qf = env.qfo.is_qf(formula)
     theory = env.theoryo.get_theory(formula)

--- a/pysmt/rewritings.py
+++ b/pysmt/rewritings.py
@@ -22,6 +22,7 @@ This module defines some rewritings for pySMT formulae.
 from pysmt.walkers.dag import DagWalker
 import pysmt.typing as types
 import pysmt.operators as op
+import pysmt.environment
 
 class CNFizer(DagWalker):
 
@@ -227,8 +228,7 @@ class NNFizer(object):
     def __init__(self, environment=None):
         if environment is None:
             # Avoids possible circular imports
-            import pysmt.shortcuts
-            environment = pysmt.shortcuts.get_env()
+            environment = pysmt.environment.get_env()
 
         self.env = environment
         self.memoization = {}

--- a/pysmt/shortcuts.py
+++ b/pysmt/shortcuts.py
@@ -26,46 +26,25 @@ particularly true for tests. For tests it is recommended to perform an
 environment reset in the setUp phase, to be guaranteed that a fresh
 environment is used.
 """
-
-import pysmt.typing as types
-import pysmt.environment
-import pysmt.configuration as config
-
 # Enable default deprecation warnings!
 import warnings
 warnings.simplefilter('default')
 
-#### GLOBAL ENVIRONMENTS STACKS ####
-ENVIRONMENTS_STACK = []
+import pysmt.typing as types
+import pysmt.configuration as config
+import pysmt.environment
 
 def get_env():
-    """Returns the Environment at the head of the stack."""
-    return ENVIRONMENTS_STACK[-1]
-
-def push_env(env=None):
-    """Push a env in the stack. If env is None, a new Environment is created."""
-    if env is None:
-        env = pysmt.environment.Environment()
-    ENVIRONMENTS_STACK.append(env)
-
-def pop_env():
-    """Pop an env from the stack."""
-    return ENVIRONMENTS_STACK.pop()
+    """Returns the global environment."""
+    return pysmt.environment.get_env()
 
 def reset_env():
-    """Destroys and recreate the head environment."""
-    pop_env()
-    push_env()
-    return get_env()
-
-# Create the default environment
-push_env()
-
+    """Resets the global environment, and returns the new one."""
+    return pysmt.environment.reset_env()
 
 ##### Shortcuts for FormulaManager #####
 def get_type(formula):
     """Returns the type of the formula."""
-#    return _choose_environment(env).stc.get_type(formula)
     return get_env().stc.get_type(formula)
 
 def simplify(formula):
@@ -336,7 +315,6 @@ def BVZExt(formula, increase):
     """
     return get_env().formula_manager.BVZExt(formula, increase)
 
-
 def BVSExt(formula, increase):
     """Returns the signed extension of the BV
 
@@ -364,11 +342,9 @@ def QuantifierEliminator(name=None, logic=None):
     """Returns a quantifier eliminator"""
     return get_env().factory.QuantifierEliminator(name=name, logic=logic)
 
-
 def Interpolator(name=None, logic=None):
     """Returns an interpolator"""
     return get_env().factory.Interpolator(name=name, logic=logic)
-
 
 def is_sat(formula, solver_name=None, logic=None):
     """ Returns whether a formula is satisfiable.
@@ -400,7 +376,6 @@ def get_model(formula, solver_name=None, logic=None):
     return env.factory.get_model(formula,
                                  solver_name=solver_name,
                                  logic=logic)
-
 
 def get_implicant(formula, solver_name=None, logic=None):
     """Returns a formula f_i such that Implies(f_i, formula) is valid or None
@@ -463,7 +438,6 @@ def qelim(formula, solver_name=None, logic=None):
                              solver_name=solver_name,
                              logic=logic)
 
-
 def binary_interpolant(formula_a, formula_b, solver_name=None, logic=None):
     """Computes an interpolant of (formula_a, formula_b). Returns None
     if the conjunction is satisfiable"""
@@ -478,7 +452,6 @@ def binary_interpolant(formula_a, formula_b, solver_name=None, logic=None):
     return env.factory.binary_interpolant(formulas[0], formulas[1],
                                           solver_name=solver_name,
                                           logic=logic)
-
 
 def sequence_interpolant(formulas, solver_name=None, logic=None):
     """Computes a sequence interpolant of the formulas. Returns None
@@ -495,8 +468,6 @@ def sequence_interpolant(formulas, solver_name=None, logic=None):
                                             solver_name=solver_name,
                                             logic=logic)
 
-
-
 def read_configuration(config_filename, environment=None):
     """
     Reads the pysmt configuration of the given file path and applies
@@ -506,7 +477,6 @@ def read_configuration(config_filename, environment=None):
     if environment is None:
         environment = get_env()
     config.configure_environment(config_filename, environment)
-
 
 def write_configuration(config_filename, environment=None):
     """

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -15,15 +15,15 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import pysmt.walkers as walkers
+import pysmt.walkers
 import pysmt.operators as op
 import pysmt.typing as types
 
 
-class Simplifier(walkers.DagWalker):
+class Simplifier(pysmt.walkers.DagWalker):
 
     def __init__(self, env=None):
-        walkers.DagWalker.__init__(self, env=env)
+        pysmt.walkers.DagWalker.__init__(self, env=env)
         self.manager = self.env.formula_manager
 
         self.functions[op.SYMBOL] = self.walk_identity

--- a/pysmt/smtlib/parser.py
+++ b/pysmt/smtlib/parser.py
@@ -22,7 +22,7 @@ from six import iteritems
 from six.moves import xrange
 
 import pysmt.smtlib.commands as smtcmd
-from pysmt.shortcuts import get_env
+from pysmt.environment import get_env
 from pysmt.typing import BOOL, REAL, INT, FunctionType, BVType
 from pysmt.logics import get_logic_by_name, UndefinedLogicError
 from pysmt.exceptions import UnknownSmtLibCommandError

--- a/pysmt/smtlib/printers.py
+++ b/pysmt/smtlib/printers.py
@@ -17,7 +17,7 @@
 #
 from functools import partial
 
-from pysmt.shortcuts import get_env
+from pysmt.environment import get_env
 from pysmt.walkers import TreeWalker, DagWalker
 import pysmt.operators as op
 

--- a/pysmt/solvers/eager.py
+++ b/pysmt/solvers/eager.py
@@ -16,8 +16,8 @@
 #   limitations under the License.
 #
 from pysmt.solvers.solver import Model
-from pysmt.shortcuts import get_env
-from pysmt.typing import REAL, BOOL, INT
+from pysmt.environment import get_env
+
 
 class EagerModel(Model):
     """A model that does not require the existence of a solver instance.

--- a/pysmt/substituter.py
+++ b/pysmt/substituter.py
@@ -17,13 +17,13 @@
 #
 from six import iteritems
 
-import pysmt.walkers as walkers
+import pysmt.walkers
 import pysmt.operators as op
 
-class Substituter(walkers.DagWalker):
+class Substituter(pysmt.walkers.DagWalker):
 
     def __init__(self, env):
-        walkers.DagWalker.__init__(self, env=env, invalidate_memoization=True)
+        pysmt.walkers.DagWalker.__init__(self, env=env, invalidate_memoization=True)
         self.manager = self.env.formula_manager
 
         self.functions[op.SYMBOL] = self.walk_identity
@@ -98,9 +98,9 @@ class Substituter(walkers.DagWalker):
             key = self._get_key(formula, **kwargs)
             self.memoization[key] = res
         else:
-            walkers.DagWalker._push_with_children_to_stack(self,
-                                                           formula,
-                                                           **kwargs)
+            pysmt.walkers.DagWalker._push_with_children_to_stack(self,
+                                                                 formula,
+                                                                 **kwargs)
 
 
     def _substitute(self, formula, subs):

--- a/pysmt/test/__init__.py
+++ b/pysmt/test/__init__.py
@@ -19,8 +19,9 @@ import unittest
 
 from functools import wraps
 
-from pysmt.shortcuts import reset_env, get_env, is_sat, is_valid, is_unsat
+from pysmt.environment import get_env, reset_env
 from pysmt.decorators import deprecated
+
 
 class TestCase(unittest.TestCase):
     """Wrapper on the unittest TestCase class.

--- a/pysmt/test/examples.py
+++ b/pysmt/test/examples.py
@@ -19,7 +19,7 @@ from collections import namedtuple
 from fractions import Fraction
 
 import pysmt.logics
-from pysmt.shortcuts import get_env
+from pysmt.environment import get_env
 from pysmt.shortcuts import (Symbol, Function,
                              Int, Real, FALSE, TRUE,
                              And, Iff, Or, Not, Implies, Ite,

--- a/pysmt/test/test_eager_model.py
+++ b/pysmt/test/test_eager_model.py
@@ -18,7 +18,7 @@
 from six.moves import xrange
 
 from pysmt.test import TestCase
-from pysmt.shortcuts import And, Or, FALSE, TRUE, FreshSymbol, get_env
+from pysmt.shortcuts import And, Or, FALSE, TRUE, FreshSymbol
 from pysmt.solvers.eager import EagerModel
 from pysmt.typing import REAL, INT
 
@@ -31,8 +31,7 @@ class TestEagerModel(TestCase):
 
         d = {x: TRUE(), y: FALSE()}
 
-        model = EagerModel(assignment=d,
-                           environment=get_env())
+        model = EagerModel(assignment=d)
 
         self.assertEqual(model.get_value(x), TRUE())
         self.assertEqual(model.get_value(y), FALSE())
@@ -87,8 +86,7 @@ class TestEagerModel(TestCase):
     def test_contains(self):
         x, y, z = [FreshSymbol() for _ in xrange(3)]
         d = {x: TRUE(), y: FALSE()}
-        model = EagerModel(assignment=d,
-                           environment=get_env())
+        model = EagerModel(assignment=d)
         self.assertTrue(x in model)
         self.assertFalse(z in model)
 

--- a/pysmt/test/test_env.py
+++ b/pysmt/test/test_env.py
@@ -17,11 +17,11 @@
 #
 import unittest
 
-from pysmt.shortcuts import get_env, push_env, pop_env, Symbol
+from pysmt.shortcuts import Symbol
 import pysmt.factory
 from pysmt.test import TestCase
 from pysmt.typing import REAL
-from pysmt.environment import Environment
+from pysmt.environment import Environment, pop_env, push_env, get_env
 from pysmt.exceptions import NoSolverAvailableError
 from pysmt import logics
 

--- a/pysmt/walkers/generic.py
+++ b/pysmt/walkers/generic.py
@@ -24,9 +24,9 @@ import pysmt.exceptions
 class Walker(object):
 
     def __init__(self, env=None):
+        import pysmt.environment
         if env is None:
-            import pysmt.shortcuts
-            env = pysmt.shortcuts.get_env()
+            env = pysmt.environment.get_env()
         self.env = env
 
         self.functions = {}


### PR DESCRIPTION
The global environment is now inside environment.py module.

The shortcuts get_env and reset_env are still available in shortcuts.py, instead push_env and pop_env are only left in environment.py . The proper way to get the environment from within pysmt is to use pysmt.environment.get_env. Outside of pysmt, we can simply use the shortcut.