### PR TITLE
SMT-LIB: Added __getitem__ method in Annotations class

### DIFF
--- a/pysmt/smtlib/annotations.py
+++ b/pysmt/smtlib/annotations.py
@@ -114,3 +114,6 @@ class Annotations(object):
                     res.append(str(v) + ", ")
                 res.append("} ")
         return "".join(res + ["}"])
+
+    def __getitem__(self, formula):
+        return self.annotations(formula)

--- a/pysmt/test/smtlib/test_annotations.py
+++ b/pysmt/test/smtlib/test_annotations.py
@@ -137,6 +137,7 @@ class TestBasic(TestCase):
         self.assertFalse(ann.has_annotation(a1, "next", "non-existent"))
 
         self.assertIn("A_1__AT1", ann.annotations(a1)["next"])
+        self.assertIn("A_1__AT1", ann[a1]["next"])
 
         curr_a1 = ann.all_annotated_formulae("next", "A_1__AT1")
         self.assertEqual(curr_a1, set([a1]))


### PR DESCRIPTION
For a annotation object 'a' it is now possible to write a[f] to obtain all annotations of f.

```
a.annotations(f) == a[f]
```