### PR TITLE
Smart Printing

### DIFF
--- a/pysmt/printers.py
+++ b/pysmt/printers.py
@@ -22,251 +22,230 @@ from six.moves import cStringIO
 
 
 class HRPrinter(TreeWalker):
+    """Performs serialization of a formula in a human-readable way.
+
+    E.g., Implies(And(Symbol(x), Symbol(y)), Symbol(z))  ~>   '(x * y) -> z'
+    """
 
     def __init__(self, stream):
         TreeWalker.__init__(self)
         self.stream = stream
-        return
-
+        self.write = self.stream.write
 
     def printer(self, f, threshold=None):
+        """Performs the serialization of 'f'.
+
+        Thresholding can be used to define how deep in the formula to
+        go. After reaching the thresholded value, "..." will be
+        printed instead. This is mainly used for debugging.
+        """
         if threshold is not None:
             self.threshold_cnt = threshold
         self.walk(f)
-        return
 
     def walk_threshold(self, formula):
-        self.stream.write("...")
-        return
+        self.write("...")
 
     def walk_and(self, formula):
-        self.stream.write("(")
+        self.write("(")
         args = formula.args()
         count = 0
         for s in args:
             self.walk(s)
             count += 1
             if count != len(args):
-                self.stream.write(" & ")
-        self.stream.write(")")
-        return
-
+                self.write(" & ")
+        self.write(")")
 
     def walk_or(self, formula):
-        self.stream.write("(")
+        self.write("(")
         args = formula.args()
         count = 0
         for s in args:
             self.walk(s)
             count += 1
             if count != len(args):
-                self.stream.write(" | ")
-        self.stream.write(")")
-        return
-
+                self.write(" | ")
+        self.write(")")
 
     def walk_not(self, formula):
-        self.stream.write("(! ")
+        self.write("(! ")
         self.walk(formula.arg(0))
-        self.stream.write(")")
-        return
-
+        self.write(")")
 
     def walk_symbol(self, formula):
-        self.stream.write(formula.symbol_name())
-        return
-
+        self.write(formula.symbol_name())
 
     def walk_plus(self, formula):
-        self.stream.write("(")
+        self.write("(")
         args = formula.args()
         count = 0
         for s in args:
             self.walk(s)
             count += 1
             if count != len(args):
-                self.stream.write(" + ")
-        self.stream.write(")")
-        return
-
+                self.write(" + ")
+        self.write(")")
 
     def walk_times(self, formula):
-        self.stream.write("(")
+        self.write("(")
         self.walk(formula.arg(0))
-        self.stream.write(" * ")
+        self.write(" * ")
         self.walk(formula.arg(1))
-        self.stream.write(")")
-        return
+        self.write(")")
 
     def walk_iff(self, formula):
-        self.stream.write("(")
+        self.write("(")
         self.walk(formula.arg(0))
-        self.stream.write(" <-> ")
+        self.write(" <-> ")
         self.walk(formula.arg(1))
-        self.stream.write(")")
-        return
+        self.write(")")
 
     def walk_implies(self, formula):
-        self.stream.write("(")
+        self.write("(")
         self.walk(formula.arg(0))
-        self.stream.write(" -> ")
+        self.write(" -> ")
         self.walk(formula.arg(1))
-        self.stream.write(")")
-        return
+        self.write(")")
 
     def walk_minus(self, formula):
-        self.stream.write("(")
+        self.write("(")
         self.walk(formula.arg(0))
-        self.stream.write(" - ")
+        self.write(" - ")
         self.walk(formula.arg(1))
-        self.stream.write(")")
-        return
-
+        self.write(")")
 
     def walk_equals(self, formula):
-        self.stream.write("(")
+        self.write("(")
         self.walk(formula.arg(0))
-        self.stream.write(" = ")
+        self.write(" = ")
         self.walk(formula.arg(1))
-        self.stream.write(")")
-        return
-
+        self.write(")")
 
     def walk_le(self, formula):
-        self.stream.write("(")
+        self.write("(")
         self.walk(formula.arg(0))
-        self.stream.write(" <= ")
+        self.write(" <= ")
         self.walk(formula.arg(1))
-        self.stream.write(")")
-        return
-
+        self.write(")")
 
     def walk_lt(self, formula):
-        self.stream.write("(")
+        self.write("(")
         self.walk(formula.arg(0))
-        self.stream.write(" < ")
+        self.write(" < ")
         self.walk(formula.arg(1))
-        self.stream.write(")")
-        return
-
+        self.write(")")
 
     def walk_function(self, formula):
         self.walk(formula.function_name())
-        self.stream.write("(")
+        self.write("(")
         count = 0
         for p in formula.args():
             self.walk(p)
             count += 1
             if count != len(formula.args()):
-                self.stream.write(", ")
-        self.stream.write(")")
-        return
-
+                self.write(", ")
+        self.write(")")
 
     def walk_real_constant(self, formula):
         assert type(formula.constant_value()) == Fraction, \
             "The type was " + str(type(formula.constant_value()))
-        self.stream.write(str(formula.constant_value()))
+        self.write(str(formula.constant_value()))
         if formula.constant_value().denominator == 1:
-            self.stream.write(".0")
-        return
+            self.write(".0")
 
     def walk_int_constant(self, formula):
         assert (type(formula.constant_value()) == int or
                 type(formula.constant_value()) == long) , \
             "The type was " + str(type(formula.constant_value()))
-        self.stream.write(str(formula.constant_value()))
-        return
-
+        self.write(str(formula.constant_value()))
 
     def walk_bool_constant(self, formula):
         if formula.constant_value():
-            self.stream.write("True")
+            self.write("True")
         else:
-            self.stream.write("False")
-        return
+            self.write("False")
 
     def walk_bv_constant(self, formula):
         # This is the simplest SMT-LIB way of printing the value of a BV
         # self.stream.write("(_ bv%d %d)" % (formula.bv_width(),
         #                                    formula.constant_value()))
-        self.stream.write("%d_%d" % (formula.constant_value(),
+        self.write("%d_%d" % (formula.constant_value(),
                                      formula.bv_width()))
-        return
 
     def walk_bv_xor(self, formula):
-        self.stream.write("(")
+        self.write("(")
         self.walk(formula.arg(0))
-        self.stream.write(" xor ")
+        self.write(" xor ")
         self.walk(formula.arg(1))
-        self.stream.write(")")
+        self.write(")")
 
     def walk_bv_concat(self, formula):
-        self.stream.write("(")
+        self.write("(")
         self.walk(formula.arg(0))
-        self.stream.write("::")
+        self.write("::")
         self.walk(formula.arg(1))
-        self.stream.write(")")
+        self.write(")")
 
     def walk_bv_extract(self, formula):
         self.walk(formula.arg(0))
-        self.stream.write("[%d:%d]" % (formula.bv_extract_start(),
+        self.write("[%d:%d]" % (formula.bv_extract_start(),
                                        formula.bv_extract_end()))
 
     def walk_bv_neg(self, formula):
-        self.stream.write("(- ")
+        self.write("(- ")
         self.walk(formula.arg(0))
-        self.stream.write(")")
+        self.write(")")
 
     def walk_bv_udiv(self, formula):
-        self.stream.write("(")
+        self.write("(")
         self.walk(formula.arg(0))
-        self.stream.write(" / ")
+        self.write(" / ")
         self.walk(formula.arg(1))
-        self.stream.write(")")
+        self.write(")")
 
     def walk_bv_urem(self, formula):
-        self.stream.write("(")
+        self.write("(")
         self.walk(formula.arg(0))
-        self.stream.write(" % ")
+        self.write(" % ")
         self.walk(formula.arg(1))
-        self.stream.write(")")
+        self.write(")")
 
     def walk_bv_lshl(self, formula):
-        self.stream.write("(")
+        self.write("(")
         self.walk(formula.arg(0))
-        self.stream.write(" << ")
+        self.write(" << ")
         self.walk(formula.arg(1))
-        self.stream.write(")")
+        self.write(")")
 
     def walk_bv_lshr(self, formula):
-        self.stream.write("(")
+        self.write("(")
         self.walk(formula.arg(0))
-        self.stream.write(" >> ")
+        self.write(" >> ")
         self.walk(formula.arg(1))
-        self.stream.write(")")
+        self.write(")")
 
     def walk_bv_ror(self, formula):
-        self.stream.write("(")
+        self.write("(")
         self.walk(formula.arg(0))
-        self.stream.write(" ROR ")
-        self.stream.write("%d)" % formula.bv_rotation_step())
+        self.write(" ROR ")
+        self.write("%d)" % formula.bv_rotation_step())
 
     def walk_bv_rol(self, formula):
-        self.stream.write("(")
+        self.write("(")
         self.walk(formula.arg(0))
-        self.stream.write(" ROL ")
-        self.stream.write("%d)" % formula.bv_rotation_step())
+        self.write(" ROL ")
+        self.write("%d)" % formula.bv_rotation_step())
 
     def walk_bv_zext(self, formula):
-        self.stream.write("Zext(")
+        self.write("Zext(")
         self.walk(formula.arg(0))
-        self.stream.write(", %d)" % formula.bv_extend_step())
+        self.write(", %d)" % formula.bv_extend_step())
 
     def walk_bv_sext(self, formula):
-        self.stream.write("Sext(")
+        self.write("Sext(")
         self.walk(formula.arg(0))
-        self.stream.write(", %d)" % formula.bv_extend_step())
+        self.write(", %d)" % formula.bv_extend_step())
 
     # Recycling functions form LIRA
     walk_bv_not = walk_not
@@ -277,76 +256,67 @@ class HRPrinter(TreeWalker):
     walk_bv_add = walk_plus
     walk_bv_mul = walk_times
 
-
-
     def walk_ite(self, formula):
-        self.stream.write("(")
+        self.write("(")
         self.walk(formula.arg(0))
-        self.stream.write(" ? ")
+        self.write(" ? ")
         self.walk(formula.arg(1))
-        self.stream.write(" : ")
+        self.write(" : ")
         self.walk(formula.arg(2))
-        self.stream.write(")")
-        return
-
+        self.write(")")
 
     def walk_forall(self, formula):
         if len(formula.quantifier_vars()) > 0:
-            self.stream.write("(forall ")
+            self.write("(forall ")
 
             count = 0
             for s in formula.quantifier_vars():
                 self.walk(s)
                 count += 1
                 if count != len(formula.quantifier_vars()):
-                    self.stream.write(", ")
+                    self.write(", ")
 
-            self.stream.write(" . ")
-
+            self.write(" . ")
             self.walk(formula.arg(0))
-
-            self.stream.write(")")
+            self.write(")")
         else:
             self.walk(formula.arg(0))
-        return
-
 
     def walk_exists(self, formula):
         if len(formula.quantifier_vars()) > 0:
-            self.stream.write("(exists ")
+            self.write("(exists ")
 
             count = 0
             for s in formula.quantifier_vars():
                 self.walk(s)
                 count += 1
                 if count != len(formula.quantifier_vars()):
-                    self.stream.write(", ")
-
-            self.stream.write(" . ")
-
+                    self.write(", ")
+            self.write(" . ")
             self.walk(formula.arg(0))
-
-            self.stream.write(")")
+            self.write(")")
         else:
             self.walk(formula.arg(0))
-        return
-
 
     def walk_toreal(self, formula):
-        self.stream.write("ToReal(")
+        self.write("ToReal(")
         self.walk(formula.arg(0))
-        self.stream.write(")")
-        return
+        self.write(")")
+
 
 class HRSerializer(object):
+    """Return the serialized version of the formula as a string."""
 
     def __init__(self, environment=None):
         self.environment = environment
 
     def serialize(self, formula, printer=None, threshold=None):
-        buf = cStringIO()
+        """Returns a string with the human-readable version of the formula.
 
-        p = None
+        'printer' is the printer to call to perform the serialization.
+        'threshold' is the thresholding value for the printing function.
+        """
+        buf = cStringIO()
         if printer is None:
             p = HRPrinter(buf)
         else:
@@ -356,3 +326,71 @@ class HRSerializer(object):
         res = buf.getvalue()
         buf.close()
         return res
+
+
+class SmartPrinter(HRPrinter):
+    """Better serialization allowing special printing of subformula.
+
+    The formula is serialized according to the format defined in the
+    HRPrinter. However, everytime a formula that is present in
+    'subs' is found, this is replaced.
+
+    E.g., subs  = {And(a,b): "ab"}
+
+    Everytime that the subformula And(a,b) is found, "ab" will be
+    printed instead of "a & b". This makes it possible to rename big
+    subformulae, and provide better human-readable representation.
+    """
+
+    def __init__(self, stream, subs=None):
+        HRPrinter.__init__(self, stream)
+        if subs is None:
+            self.subs = {}
+        else:
+            self.subs = subs
+
+    def printer(self, f, threshold=None):
+        oldvalues = (self.threshold_cnt, self.subs)
+
+        if threshold is not None:
+            self.threshold_cnt = threshold
+        self.walk(f)
+        self.threshold_cnt, self.subs = oldvalues
+
+    def walk(self, formula):
+        if self.smart_walk(formula):
+            return
+
+        if self.threshold_cnt == 0:
+            self.walk_threshold(formula)
+            return
+        if self.threshold_cnt >= 0: self.threshold_cnt -= 1
+
+        try:
+            f = self.functions[formula.node_type()]
+        except KeyError:
+            f = self.walk_error
+
+        f(formula) # Apply the function to the formula
+
+        if self.threshold_cnt >= 0: self.threshold_cnt += 1
+        return
+
+    def smart_walk(self, formula):
+        if formula not in self.subs:
+            return False
+        else:
+            # Smarties contains a string.
+            # In the future, we could allow for arbitrary function calls
+            self.write(self.subs[formula])
+            return True
+
+
+def smart_serialize(formula, subs=None, threshold=None):
+    """Creates and calls a SmartPrinter to perform smart serialization."""
+    buf = cStringIO()
+    p = SmartPrinter(buf, subs=subs)
+    p.printer(formula, threshold=threshold)
+    res = buf.getvalue()
+    buf.close()
+    return res


### PR DESCRIPTION
Smart Printing is meant to provide a way of printing complex expressions using aliases.

Two typical use cases are non-primitive operators and DEFINEs (SMV-style).
For the first case, I provide an example in test_printing.py : `ExactlyOne(x1, ..., xn)` is translated into a disjunction and a set of mutual exclusion constraints. Using smart printing, we can print it as `ExactlyOne(x1, ..., xn)`. 

For now the integration with the rest of the system is weak. You need to manually create the 'smarties' (i.e., the map formula -> string) and call smart_serialize. I think we could:

- Integrate this in FNode.serialize() : If no smarties are provided, SmartPrinter falls-back to the HRPrinter
- Generate the smarties when building expressions, and have a global dictionary of smarties.


