### PR TITLE
Generic Wrapper: Fixed Testing of examples

### DIFF
--- a/pysmt/factory.py
+++ b/pysmt/factory.py
@@ -199,7 +199,7 @@ class Factory(object):
         if name in self._all_solvers:
             raise SolverRedefinitionError("Solver %s already defined" % name)
         self._generic_solvers[name] = (args, logics)
-        solver = partial(SmtLibSolver, args)
+        solver = partial(SmtLibSolver, args, LOGICS=logics)
         solver.LOGICS = logics
         solver.UNSAT_CORE_SUPPORT = unsat_core_support
         self._all_solvers[name] = solver

--- a/pysmt/smtlib/solver.py
+++ b/pysmt/smtlib/solver.py
@@ -18,12 +18,14 @@ class SmtLibSolver(Solver):
     the executable. Interaction with the solver occurs via pipe.
     """
 
-    def __init__(self, args, environment, logic, user_options=None):
+    def __init__(self, args, environment, logic, user_options=None,
+                 LOGICS=None):
         Solver.__init__(self,
                         environment,
                         logic=logic,
                         user_options=user_options)
 
+        if LOGICS is not None: self.LOGICS = LOGICS
         self.args = args
         self.declared_vars = set()
         self.solver = Popen(args, stdout=PIPE, stderr=PIPE, stdin=PIPE)

--- a/pysmt/test/smtlib/test_generic_wrapper.py
+++ b/pysmt/test/smtlib/test_generic_wrapper.py
@@ -1,12 +1,29 @@
+#
+# This file is part of pySMT.
+#
+#   Copyright 2014 Andrea Micheli and Marco Gario
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
 import os
 import unittest
 
-from pysmt.shortcuts import *
 from pysmt.test import TestCase
-from pysmt.shortcuts import Symbol, And, Not, get_env, Solver
+from pysmt.shortcuts import get_env, Solver, is_valid, is_sat
+from pysmt.shortcuts import LE, LT, Real, GT, Int, Symbol, And, Not
 from pysmt.typing import BOOL, REAL, INT
-from pysmt.logics import QF_UFLIRA, QF_BOOL
-from pysmt.exceptions import SolverRedefinitionError
+from pysmt.logics import QF_UFLIRA, QF_BOOL, QF_UFBV, get_closer_logic
+from pysmt.exceptions import SolverRedefinitionError, NoLogicAvailableError
 
 from pysmt.test.examples import get_example_formulae
 
@@ -37,8 +54,10 @@ class TestGenericWrapper(TestCase):
                     path = os.path.join(BASE_DIR, "bin/" + f)
                     env.factory.add_generic_solver(name,
                                                    [path],
-                                                   [QF_UFLIRA])
+                                                   [QF_UFLIRA,
+                                                    QF_UFBV])
                     self.all_solvers.append(f)
+
 
     @unittest.skipIf(NO_WRAPPERS_AVAILABLE, "No wrapper available")
     def test_generic_wrapper_basic(self):
@@ -90,10 +109,14 @@ class TestGenericWrapper(TestCase):
     def test_examples(self):
         for n in self.all_solvers:
             with Solver(name=n) as solver:
+                print("Solver %s : %s" % (n, solver.LOGICS))
                 for (f, validity, satisfiability, logic) in \
                     get_example_formulae():
-                    if logic not in solver.LOGICS: continue
-
+                    try:
+                        get_closer_logic(solver.LOGICS, logic)
+                    except NoLogicAvailableError:
+                        continue
+                    print(f)
                     v = is_valid(f, solver_name=n, logic=logic)
                     s = is_sat(f, solver_name=n, logic=logic)
 


### PR DESCRIPTION
Extended constructor of SmtLibSolver, to include information on the
supported logics. This was causing most of the test on generic wrapper
to be skept.

This commit makes sure that BV are tested on the Generic Wrapper.