### PR TITLE
Better handling of Solver API discovery.

### DIFF
--- a/pysmt/exceptions.py
+++ b/pysmt/exceptions.py
@@ -97,3 +97,8 @@ class UnsupportedOperatorError(Exception):
 
     def __str__(self):
         return self.message
+
+
+class SolverAPINotFound(Exception):
+    """The Python API of the selected solver cannot be found."""
+    pass

--- a/pysmt/factory.py
+++ b/pysmt/factory.py
@@ -27,7 +27,8 @@ from functools import partial
 from six import iteritems
 
 from pysmt.exceptions import (NoSolverAvailableError, SolverRedefinitionError,
-                              NoLogicAvailableError)
+                              NoLogicAvailableError,
+                              SolverAPINotFound)
 from pysmt.logics import QF_UFLIRA, LRA, QF_UFLRA
 from pysmt.logics import AUTO as AUTO_LOGIC
 from pysmt.logics import most_generic_logic, get_closer_logic
@@ -218,43 +219,43 @@ class Factory(object):
         try:
             from pysmt.solvers.z3 import Z3Solver
             self._all_solvers['z3'] = Z3Solver
-        except ImportError:
+        except SolverAPINotFound:
             pass
 
         try:
             from pysmt.solvers.msat import MathSAT5Solver
             self._all_solvers['msat'] = MathSAT5Solver
-        except ImportError:
+        except SolverAPINotFound:
             pass
 
         try:
             from pysmt.solvers.cvc4 import CVC4Solver
             self._all_solvers['cvc4'] = CVC4Solver
-        except ImportError:
+        except SolverAPINotFound:
             pass
 
         try:
             from pysmt.solvers.yices import YicesSolver
             self._all_solvers['yices'] = YicesSolver
-        except ImportError:
+        except SolverAPINotFound:
             pass
 
         try:
             from pysmt.solvers.bdd import BddSolver
             self._all_solvers['bdd'] = BddSolver
-        except ImportError:
+        except SolverAPINotFound:
             pass
 
         try:
             from pysmt.solvers.pico import PicosatSolver
             self._all_solvers['picosat'] = PicosatSolver
-        except ImportError:
+        except SolverAPINotFound:
             pass
 
         try:
             from pysmt.solvers.btor import BoolectorSolver
             self._all_solvers['btor'] = BoolectorSolver
-        except ImportError:
+        except SolverAPINotFound:
             pass
 
         for k,s in iteritems(self._all_solvers):
@@ -271,7 +272,7 @@ class Factory(object):
         try:
             from pysmt.solvers.z3 import Z3QuantifierEliminator
             self._all_qelims['z3'] = Z3QuantifierEliminator
-        except ImportError:
+        except SolverAPINotFound:
             pass
 
         try:
@@ -279,13 +280,13 @@ class Factory(object):
                                             MSatLWQuantifierEliminator)
             self._all_qelims['msat_fm'] = MSatFMQuantifierEliminator
             self._all_qelims['msat_lw'] = MSatLWQuantifierEliminator
-        except ImportError:
+        except SolverAPINotFound:
             pass
 
         try:
             from pysmt.solvers.bdd import BddQuantifierEliminator
             self._all_qelims['bdd'] = BddQuantifierEliminator
-        except ImportError:
+        except SolverAPINotFound:
             pass
 
 
@@ -295,13 +296,13 @@ class Factory(object):
         try:
             from pysmt.solvers.z3 import Z3Interpolator
             self._all_interpolators['z3'] = Z3Interpolator
-        except ImportError:
+        except SolverAPINotFound:
             pass
 
         try:
             from pysmt.solvers.msat import MSatInterpolator
             self._all_interpolators['msat'] = MSatInterpolator
-        except ImportError:
+        except SolverAPINotFound:
             pass
 
 

--- a/pysmt/solvers/bdd.py
+++ b/pysmt/solvers/bdd.py
@@ -17,7 +17,13 @@
 #
 from six.moves import xrange
 
-import repycudd
+from pysmt.exceptions import SolverAPINotFound
+
+try:
+    import repycudd
+except ImportError:
+    raise SolverAPINotFound
+
 
 import pysmt.logics
 

--- a/pysmt/solvers/btor.py
+++ b/pysmt/solvers/btor.py
@@ -17,7 +17,13 @@
 #
 from math import log, ceil
 
-import boolector
+from pysmt.exceptions import SolverAPINotFound
+
+try:
+    import boolector
+except ImportError:
+    raise SolverAPINotFound
+
 
 from pysmt.solvers.solver import (IncrementalTrackingSolver, UnsatCoreSolver,
                                   Model, Converter)

--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -19,7 +19,12 @@ import warnings
 from fractions import Fraction
 from six.moves import xrange
 
-import CVC4
+from pysmt.exceptions import SolverAPINotFound
+
+try:
+    import CVC4
+except ImportError:
+    raise SolverAPINotFound
 
 from pysmt.logics import PYSMT_QF_LOGICS
 from pysmt.solvers.solver import Solver, Converter

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -19,7 +19,12 @@ import re
 from fractions import Fraction
 from six.moves import xrange
 
-import mathsat
+from pysmt.exceptions import SolverAPINotFound
+
+try:
+    import mathsat
+except ImportError:
+    raise SolverAPINotFound
 
 from pysmt.logics import LRA, QF_UFLIA, QF_UFLRA, QF_BV, PYSMT_QF_LOGICS
 from pysmt.oracles import get_logic

--- a/pysmt/solvers/pico.py
+++ b/pysmt/solvers/pico.py
@@ -15,7 +15,13 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import picosat
+from pysmt.exceptions import SolverAPINotFound
+
+try:
+    import picosat
+except ImportError:
+    raise SolverAPINotFound
+
 
 import pysmt.logics
 

--- a/pysmt/solvers/yices.py
+++ b/pysmt/solvers/yices.py
@@ -21,10 +21,16 @@ import ctypes
 from fractions import Fraction
 from six.moves import xrange
 
-import pyices.context
-import pyices.yices_lib as libyices
-import pyices.fix_env
-from pyices.yices_lib import String
+from pysmt.exceptions import SolverAPINotFound
+
+try:
+    import pyices.context
+    import pyices.yices_lib as libyices
+    import pyices.fix_env
+    from pyices.yices_lib import String
+except ImportError:
+    raise SolverAPINotFound
+
 
 from pysmt.solvers.eager import EagerModel
 from pysmt.solvers.solver import Solver, Converter

--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -17,7 +17,12 @@
 #
 from __future__ import absolute_import
 
-import z3
+from pysmt.exceptions import SolverAPINotFound
+
+try:
+    import z3
+except ImportError:
+    raise SolverAPINotFound
 
 from fractions import Fraction
 from six.moves import xrange


### PR DESCRIPTION
Using the ```ImportError``` exception was masking other problems in the solver wrapper. These made debugging harder, since errors were masked by simply saying that the solver was not available.

To address this, the exception ```SolverAPINotFound``` is introduced.