### PR TITLE
BUGFIX: Fix syntax error in Simplifier.walk_plus

### DIFF
--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -236,7 +236,7 @@ class Simplifier(pysmt.walkers.DagWalker):
         is_int = any(x.is_int_constant() for x in args)
         assert not (is_real and is_int)
 
-        if all(x.is_constant() for x in args, **kwargs):
+        if all(x.is_constant() for x in args):
             res = sum(x.constant_value() for x in args)
             if is_real:
                 return self.manager.Real(res)


### PR DESCRIPTION
Not sure what was the semantics of this line, but it was incorrect.
This was catched by python3.4 on macosx, not on linux... weird...