### PR TITLE
Fixed issue #188

### DIFF
--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -169,6 +169,12 @@ class FormulaManager(object):
 
 
     def Function(self, vname, params):
+        """Returns the function application of vname to params.
+
+        Note: Applying a 0-arity function returns the function itself.
+        """
+        if len(params) == 0:
+            return vname
         assert len(params) == len(vname.symbol_type().param_types)
         n = self.create_node(node_type=op.FUNCTION,
                              args=tuple(params),

--- a/pysmt/test/test_formula.py
+++ b/pysmt/test/test_formula.py
@@ -410,6 +410,15 @@ class TestFormulaManager(TestCase):
         self.assertTrue(n.is_function_application())
         self.assertEqual(n.get_free_variables(), set([self.f, self.r, self.s]))
 
+    def test_0arity_function(self):
+        # Calling FunctionType on a 0-arity list of parameters returns
+        # the type itself.
+        t = FunctionType(REAL, [])
+        # After this call: t = REAL
+        # s1 is a symbol of type real
+        s1 = self.mgr.Symbol("s1", t)
+        s1b = self.mgr.Function(s1, [])
+        self.assertEqual(s1, s1b)
 
     def test_constant(self):
         n1 = self.mgr.Real(Fraction(100, 10))

--- a/pysmt/test/test_printing.py
+++ b/pysmt/test/test_printing.py
@@ -132,7 +132,7 @@ class TestPrinting(TestCase):
         f2_string = self.print_to_string(f2)
 
         self.assertEqual(f1_string, "(f1 p q)")
-        self.assertEqual(f2_string, "(f2)")
+        self.assertEqual(f2_string, "f2")
 
     def test_toreal(self):
         p = Symbol("p", INT)
@@ -173,7 +173,7 @@ class TestPrinting(TestCase):
     def test_examples(self):
         for i, (f, _, _, _) in enumerate(get_example_formulae()):
             self.assertTrue(len(str(f)) >= 1, str(f))
-            self.assertEquals(str(f), SERIALIZED_EXAMPLES[i])
+            self.assertEqual(str(f), SERIALIZED_EXAMPLES[i])
 
     def test_smart_serialize(self):
         x, y = Symbol("x"), Symbol("y")
@@ -181,13 +181,13 @@ class TestPrinting(TestCase):
         f = Implies(x, f1)
         substitutions = {f1: "f1"}  # Mapping FNode -> String
         res = smart_serialize(f, subs=substitutions)
-        self.assertEquals("(x -> f1)", res)
+        self.assertEqual("(x -> f1)", res)
 
         # If no smarties are provided, the printing is compatible
         # with standard one
         res = smart_serialize(f)
         self.assertIsNotNone(res)
-        self.assertEquals(str(f), res)
+        self.assertEqual(str(f), res)
 
         fvars = [Symbol("x%d" % i) for i in xrange(5)]
         ex = ExactlyOne(fvars)
@@ -195,7 +195,7 @@ class TestPrinting(TestCase):
         old_str = ex.serialize()
         smart_str = smart_serialize(ex, subs=substitutions)
         self.assertTrue(len(old_str) > len(smart_str))
-        self.assertEquals("ExactlyOne(x0,x1,x2,x3,x4)", smart_str)
+        self.assertEqual("ExactlyOne(x0,x1,x2,x3,x4)", smart_str)
 
 
 SERIALIZED_EXAMPLES = [

--- a/pysmt/typing.py
+++ b/pysmt/typing.py
@@ -186,14 +186,20 @@ class _BVType(PySMTType):
 
 # FunctionType is a Factory that returns a _FunctionType
 def FunctionType(return_type, param_types):
-    """Returns the singleton associated to the Function type with the given arguments.
+    """Returns the singleton of the Function type with the given arguments.
 
     This function takes care of building and registering the type
     whenever needed. To see the functions provided by the type look at
     _FunctionType
+
+    Note: If the list of parameters is empty, the function is
+    equivalent to the return type.
     """
     param_types = tuple(param_types)
     key = (return_type, param_types)
+    # 0-arity functions types are equivalent to the return type
+    if len(param_types) == 0:
+        return return_type
     if key in __CUSTOM_TYPES__:
         return  __CUSTOM_TYPES__[key]
 


### PR DESCRIPTION
- FunctionType with 0-arity is equivalent to the return type of the function
- Function application on a 0-arity function returns the symbol