### PR TITLE
Backported to python 2.6

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -1,6 +1,18 @@
 Change Log
 ==========
 
+0.4.3: XXX-XX-XX -- YYYYYY
+--------------------------
+
+Testing:
+
+* Introduced decorator pysmt.test.skipIfNoSMTWrapper
+
+* Tests do note explicitely depend anymore on unittest module.  All
+  tests that need to be executable only need to import
+  pysmt.test.main.
+
+
 0.4.2: 2015-10-12 -- Boolector
 -----------------------------------------
 

--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -15,6 +15,7 @@
 from six.moves.urllib import request as urllib2
 from six.moves import input
 
+import subprocess
 import os
 import tarfile
 import sys
@@ -116,8 +117,9 @@ def untar(fname, directory=".", mode='r:gz'):
 
 def unzip(fname, directory="."):
     """Unzips the given archive into the given directory"""
-    with zipfile.ZipFile(fname, "r") as myzip:
-        myzip.extractall(directory)
+    myzip = zipfile.ZipFile(fname, "r")
+    myzip.extractall(directory)
+    myzip.close()
 
 def download_patch(name, target):
     SOURCE_URL="https://raw.githubusercontent.com/pysmt/solvers_patches/master/"
@@ -368,7 +370,14 @@ def install_pycudd(options):
 
     # Build the pycudd
     # NOTE: -j is not supported by this building system
-    os.system("make -C %s -f %s" % (dir_path, makefile))
+    command = ['python%s-config' % get_python_version(), '--prefix']
+    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=None)
+    prefix = p.stdout.read()
+
+    if not prefix or len(prefix) == 0:
+        prefix = "/usr"
+    os.system("make -C %s -f %s PYTHON_VER=python%s" \
+              " PYTHON_LOC=%s" % (dir_path, makefile, get_python_version(), prefix))
 
     # Save the paths
     PATHS.append(dir_path)

--- a/pysmt/rewritings.py
+++ b/pysmt/rewritings.py
@@ -453,8 +453,8 @@ class PrenexNormalizer(DagWalker):
                 needs_rename = q_vars & reserved
                 if len(needs_rename) > 0:
                     # we need alpha-renaming: prepare the substitution map
-                    sub = {v : self.mgr.FreshSymbol(v.symbol_type())
-                           for v in needs_rename}
+                    sub = dict((v,self.mgr.FreshSymbol(v.symbol_type()))
+                               for v in needs_rename)
                     sub_matrix = sub_matrix.substitute(sub)
 
                     # The new variables for this quantifiers will be

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -130,7 +130,7 @@ class MathSAT5Solver(IncrementalTrackingSolver, UnsatCoreSolver,
 
     def _named_assertions_map(self):
         if self.options.unsat_cores_mode == "named":
-            return {t[0] : (t[1],t[2]) for t in self.assertions}
+            return dict((t[0], (t[1],t[2])) for t in self.assertions)
         return None
 
     @clear_pending_pop
@@ -224,7 +224,8 @@ class MathSAT5Solver(IncrementalTrackingSolver, UnsatCoreSolver,
             return res
 
         else:
-            return {"_a%d" % i : f for i,f in enumerate(self.get_unsat_core())}
+            return dict(("_a%d" % i, f)
+                        for i,f in enumerate(self.get_unsat_core()))
 
     @clear_pending_pop
     def all_sat(self, important, callback):

--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -220,7 +220,7 @@ class Z3Solver(IncrementalTrackingSolver, UnsatCoreSolver,
 
     def _named_assertions_map(self):
         if self.options.unsat_cores_mode is not None:
-            return {t[0] : (t[1],t[2]) for t in self.assertions}
+            return dict((t[0], (t[1],t[2])) for t in self.assertions)
         return None
 
     def get_named_unsat_core(self):

--- a/pysmt/test/smtlib/parser_utils.py
+++ b/pysmt/test/smtlib/parser_utils.py
@@ -16,8 +16,8 @@
 #   limitations under the License.
 #
 import os
-import unittest
 
+from pysmt.test import SkipTest
 from pysmt.shortcuts import Solver, reset_env
 from pysmt.smtlib.parser import SmtLibParser
 from pysmt.smtlib.script import check_sat_filter
@@ -105,7 +105,7 @@ def execute_script_fname(smtfile, logic, expected_result):
     try:
         log = script.evaluate(Solver(logic=logic))
     except NoSolverAvailableError:
-        raise unittest.SkipTest("No solver for logic %s." % logic)
+        raise SkipTest("No solver for logic %s." % logic)
 
     res = check_sat_filter(log)
     if res:

--- a/pysmt/test/smtlib/test_annotations.py
+++ b/pysmt/test/smtlib/test_annotations.py
@@ -16,13 +16,12 @@
 #   limitations under the License.
 #
 import os
-import unittest
 
 from pysmt.test.smtlib.parser_utils import SMTLIB_DIR
 from pysmt.smtlib.parser import SmtLibParser
 from pysmt.smtlib.annotations import Annotations
 from pysmt.shortcuts import reset_env, Symbol
-from pysmt.test import TestCase
+from pysmt.test import TestCase, main
 
 class TestBasic(TestCase):
 
@@ -145,4 +144,4 @@ class TestBasic(TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    main()

--- a/pysmt/test/smtlib/test_generic_wrapper.py
+++ b/pysmt/test/smtlib/test_generic_wrapper.py
@@ -16,9 +16,8 @@
 #   limitations under the License.
 #
 import os
-import unittest
 
-from pysmt.test import TestCase
+from pysmt.test import TestCase, main, skipIfNoSMTWrapper
 from pysmt.shortcuts import get_env, Solver, is_valid, is_sat
 from pysmt.shortcuts import LE, LT, Real, GT, Int, Symbol, And, Not
 from pysmt.typing import BOOL, REAL, INT
@@ -27,17 +26,7 @@ from pysmt.exceptions import SolverRedefinitionError, NoLogicAvailableError
 
 from pysmt.test.examples import get_example_formulae
 
-
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-
-def any_wrapper():
-    """Check if at least one wrapper is available."""
-    return any(f.endswith(".solver.sh")
-               for _, _, fnames in os.walk(BASE_DIR)
-               for f in fnames)
-
-NO_WRAPPERS_AVAILABLE = not any_wrapper()
-
 
 class TestGenericWrapper(TestCase):
 
@@ -59,7 +48,7 @@ class TestGenericWrapper(TestCase):
                     self.all_solvers.append(f)
 
 
-    @unittest.skipIf(NO_WRAPPERS_AVAILABLE, "No wrapper available")
+    @skipIfNoSMTWrapper
     def test_generic_wrapper_basic(self):
         a = Symbol("A", BOOL)
         f = And(a, Not(a))
@@ -71,7 +60,7 @@ class TestGenericWrapper(TestCase):
                 self.assertFalse(res)
 
 
-    @unittest.skipIf(NO_WRAPPERS_AVAILABLE, "No wrapper available")
+    @skipIfNoSMTWrapper
     def test_generic_wrapper_model(self):
         a = Symbol("A", BOOL)
         b = Symbol("B", BOOL)
@@ -87,7 +76,7 @@ class TestGenericWrapper(TestCase):
                 self.assertTrue(s.get_py_value(a))
 
 
-    @unittest.skipIf(NO_WRAPPERS_AVAILABLE, "No wrapper available")
+    @skipIfNoSMTWrapper
     def test_generic_wrapper_eager_model(self):
         a = Symbol("A", BOOL)
         b = Symbol("B", BOOL)
@@ -105,7 +94,7 @@ class TestGenericWrapper(TestCase):
             self.assertTrue(model.get_value(a).is_true())
 
 
-    @unittest.skipIf(NO_WRAPPERS_AVAILABLE, "No wrapper available")
+    @skipIfNoSMTWrapper
     def test_examples(self):
         for n in self.all_solvers:
             with Solver(name=n) as solver:
@@ -133,7 +122,7 @@ class TestGenericWrapper(TestCase):
                                            [QF_UFLIRA])
 
 
-    @unittest.skipIf(NO_WRAPPERS_AVAILABLE, "No wrapper available")
+    @skipIfNoSMTWrapper
     def test_reals(self):
         f = And(LT(Symbol("x", REAL), Real(2)), LE(Symbol("x", REAL), Real(3)))
 
@@ -144,7 +133,7 @@ class TestGenericWrapper(TestCase):
                 self.assertTrue(res)
 
 
-    @unittest.skipIf(NO_WRAPPERS_AVAILABLE, "No wrapper available")
+    @skipIfNoSMTWrapper
     def test_ints(self):
         f = And(LT(Symbol("x", INT), Int(2)), GT(Symbol("x", INT), Int(2)))
 
@@ -155,4 +144,4 @@ class TestGenericWrapper(TestCase):
                 self.assertFalse(res)
 
 if __name__ == "__main__":
-    unittest.main()
+    main()

--- a/pysmt/test/smtlib/test_parser_extensibility.py
+++ b/pysmt/test/smtlib/test_parser_extensibility.py
@@ -18,7 +18,7 @@
 import collections
 from six.moves import cStringIO
 
-from pysmt.test import TestCase
+from pysmt.test import TestCase, main
 from pysmt.smtlib.parser import SmtLibParser
 from pysmt.exceptions import UnknownSmtLibCommandError
 
@@ -114,5 +114,4 @@ class TestParserExtensibility(TestCase):
 
 
 if __name__ == '__main__':
-    import unittest
-    unittest.main()
+    main()

--- a/pysmt/test/smtlib/test_parser_type_error.py
+++ b/pysmt/test/smtlib/test_parser_type_error.py
@@ -17,7 +17,7 @@
 #
 import os
 
-from pysmt.test import TestCase
+from pysmt.test import TestCase, main
 from pysmt.smtlib.parser import SmtLibParser
 
 class TestTypeError(TestCase):
@@ -32,5 +32,4 @@ class TestTypeError(TestCase):
 
 
 if __name__ == '__main__':
-    import unittest
-    unittest.main()
+    main()

--- a/pysmt/test/smtlib/test_smtlibscript.py
+++ b/pysmt/test/smtlib/test_smtlibscript.py
@@ -15,13 +15,12 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import unittest
 from six.moves import cStringIO
 
 import pysmt.smtlib.commands as smtcmd
 from pysmt.shortcuts import And, Or, Symbol, GT, Real, Not
 from pysmt.typing import REAL
-from pysmt.test import TestCase
+from pysmt.test import TestCase, main
 from pysmt.smtlib.script import SmtLibScript, SmtLibCommand
 from pysmt.smtlib.script import smtlibscript_from_formula, evaluate_command
 from pysmt.smtlib.parser import get_formula_strict, get_formula
@@ -129,4 +128,4 @@ class TestSmtLibScript(TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    main()

--- a/pysmt/test/test_back.py
+++ b/pysmt/test/test_back.py
@@ -15,11 +15,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import unittest
 from pysmt.shortcuts import FreshSymbol, GT, And, Plus, Real, Int, LE, Iff
 from pysmt.shortcuts import Solver
 from pysmt.typing import REAL, INT
-from pysmt.test import TestCase, skipIfSolverNotAvailable
+from pysmt.test import TestCase, skipIfSolverNotAvailable, main
 from pysmt.test.examples import get_example_formulae
 from pysmt.logics import QF_UFLIRA
 from pysmt.exceptions import NoSolverAvailableError
@@ -79,4 +78,4 @@ class TestBasic(TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    main()

--- a/pysmt/test/test_bdd.py
+++ b/pysmt/test/test_bdd.py
@@ -15,12 +15,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import unittest
-
 import pysmt
 from pysmt.shortcuts import And, Not, Symbol, Bool, Exists, Solver
 from pysmt.shortcuts import get_env, qelim, Or
-from pysmt.test import TestCase, skipIfSolverNotAvailable
+from pysmt.test import TestCase, skipIfSolverNotAvailable, main
 from pysmt.test.examples import EXAMPLE_FORMULAS
 
 class TestBdd(TestCase):
@@ -177,4 +175,4 @@ class TestBdd(TestCase):
             self.assertNotEquals(s.ddmanager.ReorderingStatus()[1], 0)
 
 if __name__ == '__main__':
-    unittest.main()
+    main()

--- a/pysmt/test/test_bv.py
+++ b/pysmt/test/test_bv.py
@@ -15,9 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import unittest
-
-from pysmt.test import TestCase, skipIfNoSolverForLogic
+from pysmt.test import TestCase, skipIfNoSolverForLogic, main
 from pysmt.shortcuts import Symbol, And, Symbol, Equals, TRUE
 from pysmt.shortcuts import get_env, is_sat, is_valid, get_model, is_unsat
 from pysmt.typing import BVType, BV32, BV128
@@ -238,4 +236,4 @@ class TestBV(TestCase):
         return
 
 if __name__ == "__main__":
-    unittest.main()
+    main()

--- a/pysmt/test/test_bv_simplification.py
+++ b/pysmt/test/test_bv_simplification.py
@@ -15,15 +15,13 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import unittest
-
 from six.moves import xrange
 
 from pysmt.shortcuts import Solver, BVAnd, BVOr, BVXor, BVConcat, BVULT, BVUGT, \
     BVULE, BVUGE, BVAdd, BVSub, BVMul, BVUDiv, BVURem, BVLShl, BVLShr, BVNot, \
     BVNeg, BVZExt, BVSExt, BVRor, BVRol, BV, BVExtract, BVSLT, BVSLE, BVComp, \
     BVSDiv, BVSRem, BVAShr
-from pysmt.test import TestCase, skipIfSolverNotAvailable
+from pysmt.test import TestCase, skipIfSolverNotAvailable, main
 
 
 class TestBvSimplification(TestCase):
@@ -98,4 +96,4 @@ class TestBvSimplification(TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    main()

--- a/pysmt/test/test_cnf.py
+++ b/pysmt/test/test_cnf.py
@@ -15,14 +15,13 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import unittest
 import os
 from nose.plugins.attrib import attr
 
 from pysmt.shortcuts import Implies, is_sat, is_valid, reset_env
 from pysmt.rewritings import CNFizer
 from pysmt.logics import QF_BOOL, QF_LRA, QF_LIA, QF_UFLIRA
-from pysmt.test import TestCase, skipIfNoSolverForLogic
+from pysmt.test import TestCase, skipIfNoSolverForLogic, main
 from pysmt.test.examples import EXAMPLE_FORMULAS
 from pysmt.test.smtlib.parser_utils import SMTLIB_TEST_FILES, SMTLIB_DIR
 from pysmt.smtlib.parser import get_formula_fname
@@ -92,4 +91,4 @@ class TestCnf(TestCase):
         self.assertEqual(res, res_is_sat)
 
 if __name__ == '__main__':
-    unittest.main()
+    main()

--- a/pysmt/test/test_configuration.py
+++ b/pysmt/test/test_configuration.py
@@ -24,7 +24,7 @@ from pysmt.configuration import (configure_environment,
                                  write_environment_configuration)
 from pysmt.environment import Environment
 
-from pysmt.test import TestCase
+from pysmt.test import TestCase, main
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -108,5 +108,4 @@ class TestConfiguration(TestCase):
 
 
 if __name__ == '__main__':
-    import unittest
-    unittest.main()
+    main()

--- a/pysmt/test/test_eager_model.py
+++ b/pysmt/test/test_eager_model.py
@@ -17,7 +17,7 @@
 #
 from six.moves import xrange
 
-from pysmt.test import TestCase
+from pysmt.test import TestCase, main
 from pysmt.shortcuts import And, Or, FALSE, TRUE, FreshSymbol
 from pysmt.solvers.eager import EagerModel
 from pysmt.typing import REAL, INT
@@ -91,5 +91,4 @@ class TestEagerModel(TestCase):
         self.assertFalse(z in model)
 
 if __name__ == '__main__':
-    import unittest
-    unittest.main()
+    main()

--- a/pysmt/test/test_env.py
+++ b/pysmt/test/test_env.py
@@ -15,11 +15,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import unittest
-
 from pysmt.shortcuts import Symbol
 import pysmt.factory
-from pysmt.test import TestCase
+from pysmt.test import TestCase, main
 from pysmt.typing import REAL
 from pysmt.environment import Environment, pop_env, push_env, get_env
 from pysmt.exceptions import NoSolverAvailableError
@@ -113,4 +111,4 @@ class TestEnvironment(TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    main()

--- a/pysmt/test/test_euf.py
+++ b/pysmt/test/test_euf.py
@@ -18,7 +18,7 @@
 from pysmt.shortcuts import *
 from pysmt.typing import INT, REAL, FunctionType
 from pysmt.logics import UFLRA, UFLIRA
-from pysmt.test import TestCase
+from pysmt.test import TestCase, main
 from pysmt.test import skipIfSolverNotAvailable, skipIfNoSolverForLogic
 
 
@@ -71,5 +71,4 @@ class TestEUF(TestCase):
                           f.simplify())
 
 if __name__ == '__main__':
-    import unittest
-    unittest.main()
+    main()

--- a/pysmt/test/test_formula.py
+++ b/pysmt/test/test_formula.py
@@ -25,7 +25,7 @@ from pysmt.shortcuts import Symbol, is_sat, Not, Implies, GT, Plus, Int, Real
 from pysmt.shortcuts import Minus, Times, Xor, And, Or, TRUE
 from pysmt.shortcuts import get_env
 from pysmt.environment import Environment
-from pysmt.test import TestCase, skipIfNoSolverForLogic
+from pysmt.test import TestCase, skipIfNoSolverForLogic, main
 from pysmt.logics import QF_BOOL
 from pysmt.exceptions import NonLinearError
 from pysmt.formula import FormulaManager
@@ -269,7 +269,7 @@ class TestFormulaManager(TestCase):
         n = self.mgr.Div(self.s, self.rconst)
         self.assertIsNotNone(n)
 
-        inv = self.mgr.Real((1, self.rconst.constant_value()))
+        inv = self.mgr.Real(Fraction(1) / self.rconst.constant_value())
         self.assertEqual(n, self.mgr.Times(self.s, inv))
 
     def test_equals(self):
@@ -548,7 +548,7 @@ class TestFormulaManager(TestCase):
                                      "to be 1")
 
 
-        c = f.substitute({symbols[i]: self.mgr.Int(i) for i in xrange(many)})
+        c = f.substitute(dict((symbols[i],self.mgr.Int(i)) for i in xrange(many)))
         self.assertEqual(c.simplify(), self.mgr.Bool(True),
                          "AllDifferent should be tautological for a set " \
                          "of different values")
@@ -757,5 +757,4 @@ class TestShortcuts(TestCase):
 
 
 if __name__ == '__main__':
-    import unittest
-    unittest.main()
+    main()

--- a/pysmt/test/test_int.py
+++ b/pysmt/test/test_int.py
@@ -17,7 +17,7 @@
 #
 from pysmt.shortcuts import *
 from pysmt.typing import INT, REAL
-from pysmt.test import TestCase, skipIfNoSolverForLogic
+from pysmt.test import TestCase, skipIfNoSolverForLogic, main
 from pysmt.logics import QF_LIA, QF_UFLIRA
 
 class TestLIA(TestCase):
@@ -51,5 +51,4 @@ class TestLIA(TestCase):
 
 
 if __name__ == '__main__':
-    import unittest
-    unittest.main()
+    main()

--- a/pysmt/test/test_interpolation.py
+++ b/pysmt/test/test_interpolation.py
@@ -15,14 +15,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import unittest
-
 from pysmt.shortcuts import *
-from pysmt.typing import REAL, BOOL, INT
-from pysmt.test import (TestCase, skipIfSolverNotAvailable)
-from pysmt.exceptions import (SolverReturnedUnknownResultError, \
-                              NoSolverAvailableError)
-from pysmt.logics import LRA, LIA, UFLIRA
+from pysmt.typing import REAL, INT
+from pysmt.test import TestCase, skipIfSolverNotAvailable, main
+from pysmt.exceptions import NoSolverAvailableError
+from pysmt.logics import UFLIRA
 
 
 class TestInterpolation(TestCase):
@@ -102,7 +99,7 @@ class TestInterpolation(TestCase):
             i = itp.binary_interpolant(a, b)
         else:
             i = itp.sequence_interpolant([a, b])
-            
+
         self.assertTrue(i is not None)
         if not binary:
             self.assertTrue(hasattr(i, '__len__'))
@@ -125,7 +122,7 @@ class TestInterpolation(TestCase):
             i = itp.binary_interpolant(a, b)
         else:
             i = itp.sequence_interpolant([a, b])
-            
+
         self.assertTrue(i is not None)
         if not binary:
             self.assertTrue(hasattr(i, '__len__'))
@@ -135,7 +132,7 @@ class TestInterpolation(TestCase):
         self.assertTrue(i.get_free_variables() == set([y]))
         self.assertValid(Implies(a, i))
         self.assertUnsat(And(i, b))
-        
+
 
 if __name__ == '__main__':
-    unittest.main()
+    main()

--- a/pysmt/test/test_lira.py
+++ b/pysmt/test/test_lira.py
@@ -17,7 +17,7 @@
 #
 from pysmt.shortcuts import *
 from pysmt.typing import INT, REAL, FunctionType
-from pysmt.test import TestCase
+from pysmt.test import TestCase, main
 from pysmt.logics import QF_UFLIRA, UFLIRA
 
 class TestLIRA(TestCase):
@@ -62,5 +62,4 @@ class TestLIRA(TestCase):
 
 
 if __name__ == '__main__':
-    import unittest
-    unittest.main()
+    main()

--- a/pysmt/test/test_logics.py
+++ b/pysmt/test/test_logics.py
@@ -15,8 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import unittest
-
 import pysmt.logics
 from pysmt.logics import get_logic_by_name, get_logic, most_generic_logic
 from pysmt.logics import PYSMT_LOGICS
@@ -24,9 +22,9 @@ from pysmt.logics import QF_LIA, LIA, UFLIRA, LRA, QF_UFLIRA, QF_BV
 from pysmt.exceptions import (UndefinedLogicError, NoSolverAvailableError,
                               NoLogicAvailableError)
 from pysmt.shortcuts import Solver, get_env
+from pysmt.test import TestCase, main
 
-
-class TestLogic(unittest.TestCase):
+class TestLogic(TestCase):
 
     def test_get_logic_by_name(self):
         for l in pysmt.logics.LOGICS:
@@ -135,4 +133,4 @@ class TestLogic(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    main()

--- a/pysmt/test/test_models.py
+++ b/pysmt/test/test_models.py
@@ -16,9 +16,9 @@
 #   limitations under the License.
 #
 from pysmt.shortcuts import Solver, Symbol, And, Real, GT, LT, Implies, FALSE
-from pysmt.shortcuts import get_env, get_model
+from pysmt.shortcuts import get_env
 from pysmt.typing import BOOL, REAL
-from pysmt.test import TestCase, skipIfNoSolverForLogic
+from pysmt.test import TestCase, skipIfNoSolverForLogic, main
 from pysmt.logics import QF_UFLIRA, QF_LRA, QF_BOOL
 from pysmt.solvers.eager import EagerModel
 
@@ -74,5 +74,4 @@ class TestModels(TestCase):
 
 
 if __name__ == '__main__':
-    import unittest
-    unittest.main()
+    main()

--- a/pysmt/test/test_oracles.py
+++ b/pysmt/test/test_oracles.py
@@ -15,12 +15,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import unittest
-
 from pysmt.shortcuts import get_env, get_free_variables
 from pysmt.shortcuts import Symbol, Implies, And, Not
 from pysmt.test.examples import EXAMPLE_FORMULAS
-from pysmt.test import TestCase
+from pysmt.test import TestCase, main
 from pysmt.oracles import get_logic
 from pysmt.typing import BOOL
 
@@ -68,4 +66,4 @@ class TestOracles(TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    main()

--- a/pysmt/test/test_printing.py
+++ b/pysmt/test/test_printing.py
@@ -15,7 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import unittest
 from six.moves import cStringIO
 from six.moves import xrange
 
@@ -26,7 +25,7 @@ from pysmt.shortcuts import Times, Minus, Equals, LE, LT, ToReal
 from pysmt.typing import REAL, INT, FunctionType
 from pysmt.smtlib.printers import SmtPrinter, SmtDagPrinter
 from pysmt.printers import smart_serialize
-from pysmt.test import TestCase
+from pysmt.test import TestCase, main
 from pysmt.test.examples import get_example_formulae
 
 
@@ -269,4 +268,4 @@ SERIALIZED_EXAMPLES = [
 
 
 if __name__ == '__main__':
-    unittest.main()
+    main()

--- a/pysmt/test/test_qe.py
+++ b/pysmt/test/test_qe.py
@@ -15,14 +15,12 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import unittest
-
 from pysmt.shortcuts import Symbol, ForAll, Exists, And, Iff, GE, LT, Real, Int
 from pysmt.shortcuts import Minus, Equals, Plus, ToReal, Implies, LE, TRUE, Not
 from pysmt.shortcuts import QuantifierEliminator
 from pysmt.shortcuts import is_sat, is_valid
 from pysmt.typing import REAL, BOOL, INT
-from pysmt.test import TestCase
+from pysmt.test import TestCase, main
 from pysmt.test import (skipIfNoSolverForLogic, skipIfNoQEForLogic,
                         skipIfQENotAvailable)
 from pysmt.test.examples import get_example_formulae
@@ -209,4 +207,4 @@ class TestQE(TestCase):
             self.assertEqual(satisfiability, s, f)
 
 if __name__ == '__main__':
-    unittest.main()
+    main()

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -23,6 +23,7 @@ from pysmt.shortcuts import (Real, Plus, Symbol, Equals, And, Bool, Or,
 from pysmt.shortcuts import Solver, get_env, qelim, get_model, TRUE, ExactlyOne
 from pysmt.typing import REAL, BOOL, INT, FunctionType
 from pysmt.test import TestCase, skipIfSolverNotAvailable, skipIfNoSolverForLogic
+from pysmt.test import main
 from pysmt.logics import QF_UFLIRA, QF_BOOL, LIA
 from pysmt.exceptions import ConvertExpressionError
 from pysmt.test.examples import get_example_formulae
@@ -263,5 +264,4 @@ class TestRegressions(TestCase):
 
 
 if __name__ == "__main__":
-    import unittest
-    unittest.main()
+    main()

--- a/pysmt/test/test_rewritings.py
+++ b/pysmt/test/test_rewritings.py
@@ -15,10 +15,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import unittest
-
 from pysmt.shortcuts import And, get_env, Iff, Or, is_valid, Symbol, Exists, Implies, ForAll, Not
-from pysmt.test import TestCase, skipIfNoSolverForLogic
+from pysmt.test import TestCase, skipIfNoSolverForLogic, main
 from pysmt.rewritings import prenex_normal_form, nnf, conjunctive_partition, aig
 from pysmt.rewritings import disjunctive_partition
 from pysmt.test.examples import get_example_formulae
@@ -119,4 +117,4 @@ class TestRewritings(TestCase):
                 self.assertTrue(ok, "Was: %s\n Got:%s" % (f, f_aig))
 
 if __name__ == "__main__":
-    unittest.main()
+    main()

--- a/pysmt/test/test_simplify.py
+++ b/pysmt/test/test_simplify.py
@@ -16,7 +16,7 @@
 #   limitations under the License.
 #
 from nose.plugins.attrib import attr
-from pysmt.test import TestCase, skipIfSolverNotAvailable
+from pysmt.test import TestCase, skipIfSolverNotAvailable, main
 from pysmt.test.examples import get_example_formulae
 from pysmt.environment import get_env
 
@@ -53,5 +53,4 @@ class TestSimplify(TestCase):
 
 
 if __name__ == '__main__':
-    import unittest
-    unittest.main()
+    main()

--- a/pysmt/test/test_size.py
+++ b/pysmt/test/test_size.py
@@ -15,11 +15,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import unittest
-
 from pysmt.shortcuts import *
 from pysmt.oracles import SizeOracle
-from pysmt.test import TestCase
+from pysmt.test import TestCase, main
 from pysmt.test.examples import get_example_formulae
 
 class TestSize(TestCase):
@@ -73,4 +71,4 @@ class TestSize(TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    main()

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -15,7 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import unittest
 from six.moves import xrange
 
 import pysmt.operators as op
@@ -25,6 +24,7 @@ from pysmt.shortcuts import Solver
 from pysmt.shortcuts import get_env, get_model, is_valid, is_sat, get_implicant
 from pysmt.typing import BOOL, REAL, FunctionType
 from pysmt.test import TestCase, skipIfSolverNotAvailable, skipIfNoSolverForLogic
+from pysmt.test import main
 from pysmt.test.examples import get_example_formulae
 from pysmt.exceptions import (SolverReturnedUnknownResultError,
                               InternalSolverError, NoSolverAvailableError,
@@ -433,4 +433,4 @@ class TestBasic(TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    main()

--- a/pysmt/test/test_typechecker.py
+++ b/pysmt/test/test_typechecker.py
@@ -24,7 +24,7 @@ from pysmt.shortcuts import (Symbol, And, Plus, Minus, Times, Equals, Or, Iff,
                              LE, LT, Not, GE, GT, Ite, Bool, Int, Real, Div,
                              Function)
 from pysmt.environment import get_env
-from pysmt.test import TestCase
+from pysmt.test import TestCase, main
 from pysmt.test.examples import get_example_formulae
 from pysmt.decorators import typecheck_result
 
@@ -192,5 +192,4 @@ class TestSimpleTypeChecker(TestCase):
             self.assertIs(f.get_type(), BOOL)
 
 if __name__ == '__main__':
-    import unittest
-    unittest.main()
+    main()

--- a/pysmt/test/test_unsat_cores.py
+++ b/pysmt/test/test_unsat_cores.py
@@ -15,10 +15,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import unittest
-
 from pysmt.test import (TestCase, skipIfSolverNotAvailable,
-                        skipIfNoUnsatCoreSolverForLogic)
+                        skipIfNoUnsatCoreSolverForLogic, main)
 from pysmt.shortcuts import (get_unsat_core, And, Not, Symbol, UnsatCoreSolver,
                              is_unsat)
 from pysmt.logics import QF_BOOL, QF_BV
@@ -149,4 +147,4 @@ class TestUnsatCores(TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    main()

--- a/pysmt/test/test_walkers.py
+++ b/pysmt/test/test_walkers.py
@@ -23,7 +23,7 @@ from pysmt.shortcuts import LT, GT, Plus, Minus, Equals
 from pysmt.shortcuts import get_env, substitute, TRUE
 from pysmt.typing import INT, BOOL, REAL, FunctionType
 from pysmt.walkers import TreeWalker, DagWalker, IdentityDagWalker
-from pysmt.test import TestCase
+from pysmt.test import TestCase, main
 from pysmt.formula import FormulaManager
 from pysmt.test.examples import get_example_formulae
 from pysmt.exceptions import UnsupportedOperatorError
@@ -195,5 +195,4 @@ class TestWalkers(TestCase):
 
 
 if __name__ == '__main__':
-    import unittest
-    unittest.main()
+    main()

--- a/travis.sh
+++ b/travis.sh
@@ -5,7 +5,7 @@ export CVC4_PYTHONPATH="${TRAVIS_BUILD_DIR}/.smt_solvers/CVC4_bin/share/pyshared
 export PICOSAT_PYTHONPATH="${TRAVIS_BUILD_DIR}/.smt_solvers/picosat-960:${TRAVIS_BUILD_DIR}/.smt_solvers/picosat-960/build/lib.linux-x86_64-${TRAVIS_PYTHON_VERSION}"
 export CUDD_PYTHONPATH="${TRAVIS_BUILD_DIR}/.smt_solvers/repycudd-4861f4df8abc2ca205a6a09b30fdc8cfd29f6ebb"
 export BTOR_PYTHONPATH="${TRAVIS_BUILD_DIR}/.smt_solvers/boolector-2.1.1-with-lingeling-b85/boolector"
-export YICES_PYTHONPATH="${TRAVIS_BUILD_DIR}/.smt_solvers/pyices-aa0b91c39aa00c19c2160e83aad822dc468ce328/build/lib.linux-x86_64-${TRAVIS_PYTHON_VERSION}:${HOME}/.local/lib/python2.7/site-packages"
+export YICES_PYTHONPATH="${TRAVIS_BUILD_DIR}/.smt_solvers/pyices-aa0b91c39aa00c19c2160e83aad822dc468ce328/build/lib.linux-x86_64-${TRAVIS_PYTHON_VERSION}:${HOME}/.local/lib/python${TRAVIS_PYTHON_VERSION}/site-packages"
 export MSAT_PYTHONPATH="${TRAVIS_BUILD_DIR}/.smt_solvers/mathsat-5.3.8-linux-x86_64/python:${TRAVIS_BUILD_DIR}/.smt_solvers/mathsat-5.3.8-linux-x86_64/python/build/lib.linux-x86_64-${TRAVIS_PYTHON_VERSION}"
 
 


### PR DESCRIPTION
Removed all obstacles to have pysmt working on python 2.6. Even if not officially supported, the changes are minimal. A dedicated branch "python26" is used to run the tests on Python 2.6 