### PR TITLE
Issue 152: Most General substitution

### DIFF
--- a/pysmt/environment.py
+++ b/pysmt/environment.py
@@ -43,7 +43,8 @@ class Environment(object):
     TypeCheckerClass = pysmt.type_checker.SimpleTypeChecker
     FormulaManagerClass = pysmt.formula.FormulaManager
     SimplifierClass = pysmt.simplifier.Simplifier
-    SubstituterClass = pysmt.substituter.Substituter
+    SubstituterClass = pysmt.substituter.MSSubstituter
+    #SubstituterClass = pysmt.substituter.MGSubstituter
     HRSerializerClass = pysmt.printers.HRSerializer
     QuantifierOracleClass = pysmt.oracles.QuantifierOracle
     TheoryOracleClass = pysmt.oracles.TheoryOracle

--- a/pysmt/substituter.py
+++ b/pysmt/substituter.py
@@ -15,25 +15,93 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+import warnings
+
 from six import iteritems
 
 import pysmt.walkers
 import pysmt.operators as op
 
-class Substituter(pysmt.walkers.DagWalker):
 
+class Substituter(pysmt.walkers.DagWalker):
+    """Performs substitution of a set of terms within a formula.
+
+    Let f be a formula ans subs be a map from formula to formula.
+    Substitution returns a formula f' in which all occurrences of the
+    keys of the map have been replaced by their value.
+
+    There are a few considerations to take into account:
+      - In which order to apply the substitution
+      - How to deal with quantified subformulas
+
+    The order in which we apply the substitutions gives raise to two
+    different approaches: Most General Substitution and Most Specific
+    Substitution. Lets consider the example:
+
+      f = (a & b)
+      subs = {a -> c, (c & b) -> d, (a & b) -> c}
+
+    With the Most General Substitution (MGS) we obtain:
+      f' = c
+    with the Most Specific Substitution (MSS) we obtain:
+      f' = d
+
+    The default behavior before version 0.5 was MSS. However, this
+    leads to unexpected results when dealing with literals, i.e.,
+    substitutions in which both x and Not(x) appear, do not work as
+    expected.  In case of doubt, it is recommended to issue two
+    separate calls to the substitution procedure.
+    """
     def __init__(self, env):
         pysmt.walkers.DagWalker.__init__(self, env=env, invalidate_memoization=True)
         self.manager = self.env.formula_manager
+        self.orig_subs = None
+        # We keep an internal copy of an IdentityDagWalker. This is
+        # used to rebuild expressions that are not affected by the
+        # substitution.
+        self._inner_idw = pysmt.walkers.IdentityDagWalker(env=self.env)
 
-        self.set_function(self.walk_identity, op.SYMBOL, op.REAL_CONSTANT,
-                          op.INT_CONSTANT, op.BOOL_CONSTANT, op.BV_CONSTANT)
+    def _get_key(self, formula, **kwargs):
+        return formula
 
+    def _push_with_children_to_stack(self, formula, **kwargs):
+        """Add children to the stack."""
+
+        # Deal with quantifiers
+        if formula.is_quantifier():
+            # 1. We create a new substitution in which we remove the
+            #    bound variables from the substitution map
+            substitutions = kwargs["substitutions"]
+            new_subs = {}
+            for k,v in iteritems(substitutions):
+                # If at least one bound variable is in the cone of k,
+                # we do not consider this substitution in the body of
+                # the quantifier.
+                if all(m not in formula.quantifier_vars()
+                       for m in k.get_free_variables()):
+                    new_subs[k] = v
+
+            # 2. We apply the substitution on the quantifier body with
+            #    the new 'reduced' map
+            sub = self.__class__(self.env)
+            res_formula = sub.substitute(formula.arg(0), new_subs)
+
+            # 3. We invoke the relevant function (walk_exists or
+            #    walk_forall) to compute the substitution
+            fun = self.functions[formula.node_type()]
+            res = fun(formula, args=[res_formula], **kwargs)
+
+            # 4. We memoize the result
+            key = self._get_key(formula, **kwargs)
+            self.memoization[key] = res
+        else:
+            pysmt.walkers.DagWalker._push_with_children_to_stack(self,
+                                                                 formula,
+                                                                 **kwargs)
 
     def substitute(self, formula, subs):
-        """Given a map ``subs`` of substitutions, replaces any subformula in
-        formula with the corresponding definition in subs.
-        """
+        """Replaces any subformula in formula with the definition in subs."""
+
         # Check that formula is a term
         if not formula.is_term():
             raise TypeError("substitute() can only be used on terms.")
@@ -57,254 +125,65 @@ class Substituter(pysmt.walkers.DagWalker):
                 raise TypeError(
                     "Value %d does not belong to the Formula Manager." % i)
 
-        return self.walk(formula, substitutions=subs)
+        self.orig_subs = subs
+        res = self.walk(formula, substitutions=subs)
+        self.orig_subs = None
+        return res
 
 
-    def _get_key(self, formula, **kwargs):
-        return formula
+class MGSubstituter(Substituter):
+    """Performs Most Specific Substitution.
 
+    This is the default behavior since version 0.5
+    """
+    def __init__(self, env):
+        Substituter.__init__(self, env=env)
+        self.set_function(self.walk_identity_or_replace, *op.all_types())
 
-    def _push_with_children_to_stack(self, formula, **kwargs):
-        """Add children to the stack."""
-
-        # Deal with quantifiers
-        if formula.is_quantifier():
-            # 1. We create a new substitution in which we remove the
-            #    bound variables from the substitution map
-            substitutions = kwargs["substitutions"]
-            new_subs = {}
-            for k,v in iteritems(substitutions):
-                # If at least one bound variable is in the cone of k,
-                # we do not consider this substitution in the body of
-                # the quantifier.
-                if all(m not in formula.quantifier_vars()
-                       for m in k.get_free_variables()):
-                    new_subs[k] = v
-
-            # 2. We apply the substitution on the quantifier body with
-            #    the new 'reduced' map
-            sub = Substituter(self.env)
-            res_formula = sub.substitute(formula.arg(0), new_subs)
-
-            # 3. We invoke the relevant function (walk_exists or
-            #    walk_forall) to compute the substitution
-            fun = self.functions[formula.node_type()]
-            res = fun(formula, args=[res_formula], **kwargs)
-
-            # 4. We memoize the result
-            key = self._get_key(formula, **kwargs)
-            self.memoization[key] = res
+    def walk_identity_or_replace(self, formula, args, **kwargs):
+        """
+        If the formula appears in the substitution, return the substitution.
+        Otherwise, rebuild the formula by calling the IdentityWalker.
+        """
+        if formula in self.orig_subs:
+            return self.orig_subs[formula]
         else:
-            pysmt.walkers.DagWalker._push_with_children_to_stack(self,
-                                                                 formula,
-                                                                 **kwargs)
+            # Call the function associated to type of 'formula'
+            # E.g., if formula is an And() it will call walk_and
+            # and rebuild the And expression with the new children
+            return self._inner_idw.functions[formula.node_type()](formula, args=args, **kwargs)
+
+# EOC MGSubstituter
 
 
-    def _substitute(self, formula, subs):
+class MSSubstituter(Substituter):
+    """Performs Most Specific Substitution.
+
+    This was the default beahvior before version 0.5
+    """
+
+    def __init__(self, env):
+        Substituter.__init__(self, env=env)
+        self.set_function(self.walk_replace, *op.all_types())
+
+    def substitute(self, formula, subs):
+        warnings.warn("MSSSubstituter will be deprecated in version 0.5\n"+\
+                      "You should test your code with pysmt.substituter.MGSSubstituter.",
+                      category=DeprecationWarning,
+                      stacklevel=2)
+        return Substituter.substitute(self, formula, subs)
+
+    def _substitute(self, formula):
         """Returns the substitution for formula, if one is defined, otherwise
         it defaults to the identify (formula).
 
         This is an helper function, to simplify the implementation of
         the walk_* functions.
         """
+        return self.orig_subs.get(formula, formula)
 
-        return subs.get(formula, formula)
+    def walk_replace(self, formula, args, **kwargs):
+        new_f = self._inner_idw.functions[formula.node_type()](formula, args=args, **kwargs)
+        return self._substitute(new_f)
 
-    def walk_and(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.And(args), substitutions)
-
-    def walk_or(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.Or(args), substitutions)
-
-    def walk_not(self, formula, args, substitutions, **kwargs):
-        assert len(args) == 1
-        return self._substitute(self.manager.Not(args[0]), substitutions)
-
-    def walk_equals(self, formula, args, substitutions, **kwargs):
-        assert len(args) == 2
-        sl = args[0]
-        sr = args[1]
-        return self._substitute(self.manager.Equals(sl, sr),
-                               substitutions)
-
-    def walk_iff(self, formula, args, substitutions, **kwargs):
-        assert len(args) == 2
-        sl = args[0]
-        sr = args[1]
-        return self._substitute(self.manager.Iff(sl, sr),
-                               substitutions)
-
-    def walk_implies(self, formula, args, substitutions, **kwargs):
-        assert len(args) == 2
-        sl = args[0]
-        sr = args[1]
-        return self._substitute(self.manager.Implies(sl, sr),
-                               substitutions)
-
-    def walk_ite(self, formula, args, substitutions, **kwargs):
-        assert len(args) == 3
-        si = args[0]
-        st = args[1]
-        se = args[2]
-        return self._substitute(self.manager.Ite(si, st, se),
-                               substitutions)
-
-    def walk_le(self, formula, args, substitutions, **kwargs):
-        assert len(args) == 2
-
-        sl = args[0]
-        sr = args[1]
-
-        return  self._substitute(self.manager.LE(sl, sr),
-                                substitutions)
-
-    def walk_lt(self, formula, args, substitutions, **kwargs):
-        assert len(args) == 2
-
-        sl = args[0]
-        sr = args[1]
-
-        return self._substitute(self.manager.LT(sl, sr),
-                               substitutions)
-
-
-    def walk_plus(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.Plus(args),
-                                substitutions)
-
-    def walk_times(self, formula, args, substitutions, **kwargs):
-        assert len(args) == 2
-        sl = args[0]
-        sr = args[1]
-
-        return self._substitute(self.manager.Times(sl, sr), substitutions)
-
-    def walk_minus(self, formula, args, substitutions, **kwargs):
-        assert len(args) == 2
-
-        sl = args[0]
-        sr = args[1]
-
-        return self._substitute(self.manager.Minus(sl, sr), substitutions)
-
-    def walk_toreal(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.ToReal(args[0]),
-                                substitutions)
-
-    def walk_identity(self, formula, args, substitutions, **kwargs):
-        assert len(args) == 0
-        return self._substitute(formula, substitutions)
-
-    def walk_forall(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.ForAll(formula.quantifier_vars(),
-                                                    args[0]),
-                                substitutions)
-
-    def walk_exists(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.Exists(formula.quantifier_vars(),
-                                                    args[0]),
-                                substitutions)
-
-    def walk_function(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.Function(formula.function_name(),
-                                                      args),
-                                substitutions)
-
-    def walk_bv_not(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVNot(args[0]), substitutions)
-
-    def walk_bv_and(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVAnd(args[0], args[1]),
-                                substitutions)
-
-    def walk_bv_or(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVOr(args[0], args[1]),
-                                substitutions)
-
-    def walk_bv_xor(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVXor(args[0]), substitutions)
-
-    def walk_bv_concat(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVConcat(args[0], args[1]),
-                                substitutions)
-
-    def walk_bv_extract(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVExtract(args[0],
-                                                       start=formula.bv_extract_start(),
-                                                       end=formula.bv_extract_end()),
-                                substitutions)
-
-    def walk_bv_ult(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVULT(args[0], args[1]),
-                                substitutions)
-
-    def walk_bv_ule(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVULE(args[0], args[1]),
-                                substitutions)
-
-    def walk_bv_neg(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVNeg(args[0]), substitutions)
-
-    def walk_bv_add(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVAdd(args[0], args[1]), substitutions)
-
-    def walk_bv_sub(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVSub(args[0], args[1]), substitutions)
-
-    def walk_bv_mul(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVMul(args[0], args[1]), substitutions)
-
-    def walk_bv_udiv(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVUDiv(args[0], args[1]), substitutions)
-
-    def walk_bv_urem(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVURem(args[0], args[1]), substitutions)
-
-    def walk_bv_lshl(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVLShl(args[0], args[1]),
-                                substitutions)
-
-    def walk_bv_lshr(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVLShr(args[0], args[1]),
-                                substitutions)
-
-    def walk_bv_rol(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVRol(args[0],
-                                                   formula.bv_rotation_step()),
-                                substitutions)
-
-    def walk_bv_ror(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVRor(args[0],
-                                                   formula.bv_rotation_step()),
-                                substitutions)
-
-    def walk_bv_zext(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVZExt(args[0],
-                                                    formula.bv_extend_step()),
-                                substitutions)
-
-    def walk_bv_sext(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVSExt(args[0],
-                                                    formula.bv_extend_step()),
-                                substitutions)
-
-    def walk_bv_sdiv(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVSDiv(args[0], args[1]), substitutions)
-
-    def walk_bv_srem(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVSRem(args[0], args[1]), substitutions)
-
-    def walk_bv_slt(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVSLT(args[0], args[1]), substitutions)
-
-    def walk_bv_sle(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVSLE(args[0], args[1]), substitutions)
-
-    def walk_bv_comp(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVComp(args[0], args[1]), substitutions)
-
-    def walk_bv_ashr(self, formula, args, substitutions, **kwargs):
-        return self._substitute(self.manager.BVAShr(args[0], args[1]), substitutions)
-
-
-# EOC Substituter
+# EOC MSSSubstituter

--- a/pysmt/test/test_walkers.py
+++ b/pysmt/test/test_walkers.py
@@ -146,12 +146,17 @@ class TestWalkers(TestCase):
     def test_substitution_complex(self):
         x, y = FreshSymbol(REAL), FreshSymbol(REAL)
 
-        # y = 0 /\ Forall x. x > 3 /\ y < 2
+        # y = 0 /\ (Forall x. x > 3 /\ y < 2)
         f = And(Equals(y, Real(0)),
                 ForAll([x], And(GT(x, Real(3)), LT(y, Real(2)))))
 
-        subs = {y: Real(0),
-                ForAll([x], And(GT(x, Real(3)), LT(Real(0), Real(2)))): TRUE()}
+        if "MSS" in str(self.env.SubstituterClass):
+            subs = {y: Real(0),
+                    ForAll([x], And(GT(x, Real(3)), LT(Real(0), Real(2)))): TRUE()}
+        else:
+            assert "MGS" in str(self.env.SubstituterClass)
+            subs = {y: Real(0),
+                    ForAll([x], And(GT(x, Real(3)), LT(y, Real(2)))): TRUE()}
         f_subs = substitute(f, subs).simplify()
         self.assertEqual(f_subs, TRUE())
 


### PR DESCRIPTION
Made Substituter a super-class for:
 - MGSubstituter (Most General)
 - MSSubstituter (Most Specific)

This makes it possible to restore the previous behavior, by changing which one is instantiated by the environment.

**Note**: we only allow one global substituter, in order to ensure a consistent behavior. One could argue that an option to the ```substitute()``` function would be cleaner/nicer.

**This is a transitional commit** The default is still the old one (MSS), but a warning has been added in the substitute method.
