### PR TITLE
Examples: SMT-LIB Parser

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -28,6 +28,11 @@ Bugfix:
   Fixed incorrect handling of UF with bool arguments when using
   MathSAT. The converter now takes care of rewriting the formula.
 
+Examples:
+
+* parallel.py: Shows how to use multi-processing to perform parallel and asynchronous solving
+* smtlib.py: Demonstrates how to perform SMT-LIB parsing, dumping and extension
+
 
 0.4.2: 2015-10-12 -- Boolector
 -----------------------------------------

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -15,3 +15,4 @@ pySMT. Suggested order:
 9. `allsmt.py </examples/allsmt.py>`_ : How to detect the logic of a formula and perform model enumeration.
 10. `sudoku/ </examples/sudoku/>`_ : Solves sudoku problems using a simple encoding using either QF_LIA or QF_BV
 11. `parallel.py </examples/parallel.py>`_ : Shows how to use multi-processing to perform parallel and asynchronous solving
+12. `smtlib.py </examples/smtlib.py>`_ : Demonstrates how to perform SMT-LIB parsing, dumping and extension

--- a/examples/smtlib.py
+++ b/examples/smtlib.py
@@ -1,0 +1,223 @@
+# The last part of the example requires a QF_LIA solver to be installed.
+#
+#
+# This example shows how to interact with files in the SMT-LIB
+# format. In particular:
+#
+# 1. How to read a file in SMT-LIB format
+# 2. How to write a file in SMT-LIB format
+# 3. Formulas and SMT-LIB script
+# 4. How to access annotations from SMT-LIB files
+# 5. How to extend the parser with custom commands
+#
+from six.moves import cStringIO # Py2-Py3 Compatibility
+
+from pysmt.smtlib.parser import SmtLibParser
+
+
+# To make the example self contained, we store the example SMT-LIB
+# script in a string.
+DEMO_SMTLIB=\
+"""
+(set-logic QF_LIA)
+(declare-fun p () Int)
+(declare-fun q () Int)
+(declare-fun x () Bool)
+(declare-fun y () Bool)
+(define-fun .def_1 () Bool (! (and x y) :cost 1))
+(assert (=> x (> p q)))
+(check-sat)
+(push)
+(assert (=> y (> q p)))
+(check-sat)
+(assert .def_1)
+(check-sat)
+(pop)
+(check-sat)
+"""
+
+# We read the SMT-LIB Script by creating a Parser.
+# From here we can get the SMT-LIB script.
+parser = SmtLibParser()
+
+# The method SmtLibParser.get_script takes a buffer in input. We use
+# cStringIO to simulate an open file.
+# See SmtLibParser.get_script_fname() if to pass the path of a file.
+script = parser.get_script(cStringIO(DEMO_SMTLIB))
+
+# The SmtLibScript provides an iterable representation of the commands
+# that are present in the SMT-LIB file.
+#
+# Printing a summary of the issued commands
+for cmd in script:
+    print(cmd.name)
+print("*"*50)
+
+# SmtLibScript provides some utilities to perform common operations: e.g,
+#
+# - Checking if a command is present
+assert script.contains_command("check-sat")
+# - Counting the occurrences of a command
+assert script.count_command_occurrences("assert") == 3
+# - Obtain all commands of a particular type
+decls = script.filter_by_command_name("declare-fun")
+for d in decls:
+    print(d)
+print("*"*50)
+
+# Most SMT-LIB scripts define a single SAT call. In these cases, the
+# result can be obtained by conjoining multiple assertions.  The
+# method to do that is SmtLibScript.get_strict_formula() that, raises
+# an exception if there are push/pop calls.  To obtain the formula at
+# the end of the execution of the Script (accounting for push/pop) we
+# use get_last_formula
+#
+f = script.get_last_formula()
+print(f)
+
+# Finally, we serialize the script back into SMT-Lib format.  This can
+# be dumped into a file (see SmtLibScript.to_file).  The flag daggify,
+# specifies whether the printing is done as a DAG or as a tree.
+
+buf_out = cStringIO()
+script.serialize(buf_out, daggify=True)
+print(buf_out.getvalue())
+
+print("*"*50)
+# Expressions can be annotated in order to provide additional
+# information. The semantic of annotations is solver/problem
+# dependent. For example, VMT uses annotations to identify two
+# expressions as 1) the Transition Relation and 2) Initial Condition
+#
+# Here we pretend that we make up a ficticious Weighted SMT format
+# and label .def1 with cost 1
+#
+# The class pysmt.smtlib.annotations.Annotations deals with the
+# handling of annotations.
+#
+ann = script.annotations
+print(ann.all_annotated_formulae("cost"))
+
+print("*"*50)
+
+# Annotations are part of the SMT-LIB standard, and are the
+# recommended way to perform inter-operable operations. However, in
+# many cases, we are interested in prototyping some algorithm/idea and
+# need to write the input files by hand. In those cases, using an
+# extended version of SMT-LIB usually provides a more readable input.
+# We provide now an example on how to define a symbolic transition
+# system as an extension of SMT-LIB.
+# (A more complete version of this example can be found in :
+#    pysmt.tests.smtlib.test_parser_extensibility.py)
+#
+EXT_SMTLIB="""\
+(declare-fun A () Bool)
+(declare-fun B () Bool)
+(init (and A B))
+(trans (=> A (next A)))
+(exit)
+"""
+
+# We define two new commands (init, trans) and a new
+# operator (next). In order to parse this file, we need to create a
+# sub-class of the SmtLibParser, and add handlers for he new commands
+# and operators.
+from pysmt.smtlib.script import SmtLibCommand
+
+class TSSmtLibParser(SmtLibParser):
+    def __init__(self, env=None, interactive=False):
+        SmtLibParser.__init__(self, env, interactive)
+
+        # Add new commands
+        #
+        # The mapping function takes care of consuming the command
+        # name from the input stream, e.g., '(init' . Therefore,
+        # _cmd_init will receive the rest of the stream, in our
+        # example, '(and A B)) ...'
+        self.commands["init"] = self._cmd_init
+        self.commands["trans"] = self._cmd_trans
+
+        # Remove unused commands
+        #
+        # If some commands are not compatible with the extension, they
+        # can be removed from the parser. If found, they will cause
+        # the raising of the exception UnknownSmtLibCommandError
+        del self.commands["check-sat"]
+        del self.commands["get-value"]
+        # ...
+
+        # Add 'next' function
+        #
+        # New operators can be added similarly as done for commands.
+        # e.g., 'next'. The helper function _operator_adapter,
+        # simplifies the writing of such extensions.  In this example,
+        # we will rewrite the content of the next without the need of
+        # introducing a new pySMT operator. If you are interested in a
+        # simple way of handling new operators in pySMT see
+        # pysmt.test.test_dwf.
+        self.interpreted["next"] = self._operator_adapter(self._next_var)
+
+    def _cmd_init(self, current, tokens):
+        # This cmd performs the parsing of:
+        #   <expr> )
+        # and returns a new SmtLibCommand
+        expr = self.get_expression(tokens)
+        self.consume_closing(tokens, current)
+        return SmtLibCommand(name="init", args=(expr,))
+
+    def _cmd_trans(self, current, tokens):
+        # This performs the same parsing as _cmd_init, but returns a
+        # different object. The parser is not restricted to return
+        # SmtLibCommand, but using them makes handling them
+        # afterwards easier.
+        expr = self.get_expression(tokens)
+        self.consume_closing(tokens, current)
+        return SmtLibCommand(name="trans", args=(expr,))
+
+    def _next_var(self, symbol):
+        # The function is called with the arguments obtained from
+        # parsing the rest of the SMT-LIB file. In this case, 'next'
+        # is a unary function, thus we have only 1 argument. 'symbol'
+        # is an FNode. We require that 'symbol' is _really_ a symbol:
+        if symbol.is_symbol():
+            name = symbol.symbol_name()
+            ty = symbol.symbol_type()
+            # The return type MUST be an FNode, because this is part
+            # of an expression.
+            return self.env.formula_manager.Symbol("next_" + name, ty)
+        else:
+            raise ValueError("'next' operator can be applied only to symbols")
+
+    def get_ts(self, script):
+        # New Top-Level command that takes a script stream in input.
+        # We return a pair (Init, Trans) that defines the symbolic
+        # transition system.
+        init = self.env.formula_manager.TRUE()
+        trans = self.env.formula_manager.TRUE()
+
+        for cmd in self.get_command_generator(script):
+            if cmd.name=="init":
+                init = cmd.args[0]
+            elif cmd.name=="trans":
+                trans = cmd.args[0]
+            else:
+                # Ignore other commands
+                pass
+
+        return (init, trans)
+
+# Time to try out the parser !!!
+#
+# First we check that the standard SMT-Lib parser cannot handle the new format.
+from pysmt.exceptions import UnknownSmtLibCommandError
+
+try:
+    parser.get_script(cStringIO(EXT_SMTLIB))
+except UnknownSmtLibCommandError as ex:
+    print("Unsupported command: %s" % ex)
+
+# The new parser can parse our example, and returns the (init, trans) pair
+ts_parser = TSSmtLibParser()
+init, trans = ts_parser.get_ts(cStringIO(EXT_SMTLIB))
+print("INIT: %s" % init.serialize())
+print("TRANS: %s" % trans.serialize())

--- a/pysmt/smtlib/annotations.py
+++ b/pysmt/smtlib/annotations.py
@@ -15,7 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-
 from six import iteritems
 
 class Annotations(object):
@@ -104,6 +103,7 @@ class Annotations(object):
         """Checks if formula has at least one annotation"""
         return formula in self._annotations
 
+
     def __str__(self):
         res = ["Annotations: {"]
         for t, m in iteritems(self._annotations):
@@ -114,6 +114,7 @@ class Annotations(object):
                     res.append(str(v) + ", ")
                 res.append("} ")
         return "".join(res + ["}"])
+
 
     def __getitem__(self, formula):
         return self.annotations(formula)

--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -15,8 +15,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from six.moves import cStringIO
 from collections import namedtuple
+from six.moves import cStringIO
 from six.moves import xrange
 
 import pysmt.smtlib.commands as smtcmd
@@ -25,6 +25,7 @@ from pysmt.shortcuts import And
 from pysmt.smtlib.printers import SmtPrinter, SmtDagPrinter, quote
 from pysmt.logics import UFLIRA
 from pysmt.utils import quote
+
 
 def check_sat_filter(log):
     """
@@ -95,11 +96,19 @@ class SmtLibCommand(namedtuple('SmtLibCommand', ['name', 'args'])):
                                             type_str))
 
         elif self.name == smtcmd.DEFINE_FUN:
-            raise NotImplementedError
+            name = self.args[0]
+            params_list = self.args[1]
+            params = " ".join(["(%s %s)" % (v, v.symbol_type()) for v in params_list])
+            rtype = self.args[2]
+            expr = self.args[3]
+            outstream.write("(%s %s (%s) %s %s)" % (self.name,
+                                                    name,
+                                                    params,
+                                                    rtype,
+                                                    expr))
 
         elif self.name in [smtcmd.PUSH, smtcmd.POP]:
             outstream.write("(%s %d)" % (self.name, self.args[0]))
-
 
     def serialize_to_string(self):
         buf = cStringIO()

--- a/pysmt/test/smtlib/test_parser_examples.py
+++ b/pysmt/test/smtlib/test_parser_examples.py
@@ -42,7 +42,6 @@ class TestSMTParseExamples(TestCase):
             parser = SmtLibParser()
             script_in = parser.get_script(buf_in)
             f_in = script_in.get_last_formula()
-
             self.assertEqual(f_in, f_out)
 
 

--- a/pysmt/test/smtlib/test_parser_extensibility.py
+++ b/pysmt/test/smtlib/test_parser_extensibility.py
@@ -78,7 +78,6 @@ class TSSmtLibParser(SmtLibParser):
             return self.get_ts(script)
 
 
-
 class TestParserExtensibility(TestCase):
 
     def setUp(self):

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -30,6 +30,7 @@ from pysmt.exceptions import ConvertExpressionError
 from pysmt.test.examples import get_example_formulae
 from pysmt.environment import Environment
 from pysmt.rewritings import cnf_as_set
+from pysmt.smtlib.parser import SmtLibParser
 
 import pysmt.smtlib.commands as smtcmd
 from pysmt.smtlib.script import SmtLibCommand
@@ -273,6 +274,20 @@ class TestRegressions(TestCase):
         cmd.serialize(outstream)
         output = outstream.getvalue()
         self.assertEqual(output, "(set-info :source |This\nis\nmultiline!|)")
+
+    def test_parse_define_fun(self):
+        smtlib_input = "(declare-fun z () Bool)"\
+                       "(define-fun .def_1 ((z Bool)) Bool (and z z))"
+        parser = SmtLibParser()
+        buffer_ = cStringIO(smtlib_input)
+        parser.get_script(buffer_)
+
+    def test_parse_define_fun_bind(self):
+        smtlib_input = "(declare-fun y () Bool)"\
+                       "(define-fun .def_1 ((z Bool)) Bool (and z z))"
+        parser = SmtLibParser()
+        buffer_ = cStringIO(smtlib_input)
+        parser.get_script(buffer_)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This example covers the use of the SMT-LIB parsing functions in pySMT.
In particular, we discuss:

 - Read a file in SMT-LIB format
 - Write a file in SMT-LIB format
 - Manipulation of the SMT-LIB script object
 - Annotations
 - Parser extension with custom commands

This PR fixes also a bug in the parsing of parameters within define-fun.