### PR TITLE
Fixed handling of Context, exit() and __del__ within Solver.

### DIFF
--- a/pysmt/smtlib/solver.py
+++ b/pysmt/smtlib/solver.py
@@ -148,7 +148,7 @@ class SmtLibSolver(Solver):
                 assignment[s] = v
         return EagerModel(assignment=assignment, environment=self.environment)
 
-    def exit(self):
+    def _exit(self):
         self._send_command(SmtLibCommand(smtcmd.EXIT, []))
         self.solver_stdin.close()
         self.solver_stdout.close()

--- a/pysmt/solvers/btor.py
+++ b/pysmt/solvers/btor.py
@@ -123,10 +123,8 @@ class BoolectorSolver(IncrementalTrackingSolver,
         else:
             return self.mgr.Bool(bool(int(titem.assignment)))
 
-    def exit(self):
-        if not self._destroyed:
-            self._destroyed = True
-            del self.btor
+    def _exit(self):
+        del self.btor
 
 
 class BTORConverter(Converter, DagWalker):

--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -128,10 +128,8 @@ class CVC4Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
             res = self.environment.formula_manager.Real(Fraction(res.constant_value(), 1))
         return res
 
-    def exit(self):
-        if not self._destroyed:
-            self._destroyed = True
-            del self.cvc4
+    def _exit(self):
+        del self.cvc4
 
 
 class CVC4Converter(Converter, DagWalker):

--- a/pysmt/solvers/interpolation.py
+++ b/pysmt/solvers/interpolation.py
@@ -18,31 +18,42 @@
 
 class Interpolator(object):
 
+    def __init__(self):
+        self._destroyed = False
+
     def binary_interpolant(self, a, b):
-        """
-        Returns a binary interpolant for the pair (a, b), if And(a, b) is
+        """Returns a binary interpolant for the pair (a, b), if And(a, b) is
         unsatisfaiable, or None if And(a, b) is satisfiable.
+
         """
         raise NotImplementedError
-
 
     def sequence_interpolant(self, formulas):
-        """
-        Returns a sequence interpolant for the conjunction of formulas,
-        or None if the problem is satisfiable.
+        """Returns a sequence interpolant for the conjunction of formulas, or
+        None if the problem is satisfiable.
+
         """
         raise NotImplementedError
 
-
     def __enter__(self):
-        """ Manage entering a Context (i.e., with statement) """
+        """Manage entering a Context (i.e., with statement)"""
         return self
 
-
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """ Manage exiting from Context (i.e., with statement)
+        """Manage exiting from Context (i.e., with statement)
 
         The default behaviour is to explicitely destroy the interpolator to
         free the associated resources.
+
         """
-        del self
+        self.exit()
+
+    def exit(self):
+        """Destroys the solver and closes associated resources."""
+        if not self._destroyed:
+            self._exit()
+            self._destroyed = True
+
+    def _exit(self):
+        """Destroys the solver and closes associated resources."""
+        raise NotImplementedError

--- a/pysmt/solvers/pico.py
+++ b/pysmt/solvers/pico.py
@@ -22,9 +22,7 @@ try:
 except ImportError:
     raise SolverAPINotFound
 
-
 import pysmt.logics
-
 from pysmt import typing as types
 from pysmt.solvers.solver import Solver
 from pysmt.solvers.eager import EagerModel
@@ -33,6 +31,7 @@ from pysmt.decorators import clear_pending_pop, catch_conversion_error
 
 from six.moves import xrange
 from six import iteritems
+
 
 class PicosatSolver(Solver):
     """PicoSAT solver"""
@@ -163,7 +162,5 @@ class PicosatSolver(Solver):
         for _ in xrange(levels):
             picosat.picosat_pop(self.pico)
 
-    def exit(self):
-        if not self._destroyed:
-            self._destroyed = True
-            picosat.picosat_reset(self.pico)
+    def _exit(self):
+        picosat.picosat_reset(self.pico)

--- a/pysmt/solvers/yices.py
+++ b/pysmt/solvers/yices.py
@@ -59,8 +59,6 @@ init()
 def cleanup():
     libyices.yices_exit()
 
-
-
 # Yices constants
 STATUS_UNKNOWN = 2
 STATUS_SAT = 3
@@ -203,12 +201,8 @@ class YicesSolver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
             else:
                 raise NotImplementedError()
 
-
-    def exit(self):
-        if not self._destroyed:
-            libyices.yices_free_context(self.yices)
-            self._destroyed = True
-
+    def _exit(self):
+        libyices.yices_free_context(self.yices)
 
     def _get_yices_value(self, term, term_type, getter_func):
         status = getter_func(
@@ -229,7 +223,6 @@ class YicesSolver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
             ctypes.byref(d))
         assert status == 0, "Failed to read the variable from the model"
         return Fraction(n.value, d.value)
-
 
 
 class YicesConverter(Converter, DagWalker):


### PR DESCRIPTION
- Exiting from context was not closing the solver, and there was some
  confusion on when the resources were actually being closed (i.e., the 
  role of __del__)

- This commit removes the need of implementing __del__ in the solvers,
  and clarifies the semantics of Solver.exit().

- Solvers need to implement the internal method _exit(), closing open
  resources etc.

- The method Solver.exit() can be executed on a closed
  solver (following the API of files in Python).
  Solvers.exit() takes care of guaranteeing the unique execution.

- Interpolator and QuantifierEliminator have been extended in a
  similar way, by introducing an exit() method.

Thanks to **Alberto Griggio** for pointing out this problem.