### PR TITLE
MathSAT Solver: exploiting the new API function msat_get_model()

### DIFF
--- a/examples/allsat.py
+++ b/examples/allsat.py
@@ -31,7 +31,7 @@ msat.add_assertion(f) # This is still at pySMT level
 result = []
 # Directly invoke the mathsat API !!!
 # The second term is a list of "important variables"
-mathsat.msat_all_sat(msat.msat_env,
+mathsat.msat_all_sat(msat.msat_env(),
       [converter.convert(x)],      # Convert the pySMT term into a MathSAT term
       lambda model : callback(model, converter, result))
 

--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -28,7 +28,7 @@ from pysmt.cmd.installers import CuddInstaller
 
 # Build a list of installers, one for each solver
 Installer = namedtuple("Installer", ["InstallerClass", "version", "extra_params"])
-INSTALLERS = [Installer(MSatInstaller,    "5.3.8", {}),
+INSTALLERS = [Installer(MSatInstaller,    "5.3.9", {}),
               Installer(Z3Installer,      "4.4.1", {}),
               Installer(CVC4Installer,    "1.5-prerelease", {"git_version" : "68f22235a62f5276b206e9a6692a85001beb8d42"}),
               Installer(YicesInstaller,   "2.3.0", {}),

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -34,9 +34,8 @@ from pysmt.oracles import get_logic
 import pysmt.operators as op
 from pysmt import typing as types
 from pysmt.solvers.solver import (IncrementalTrackingSolver, UnsatCoreSolver,
-                                  Converter)
+                                  Model, Converter)
 from pysmt.solvers.smtlib import SmtLibBasicSolver, SmtLibIgnoreMixin
-from pysmt.solvers.eager import EagerModel
 from pysmt.walkers import DagWalker
 from pysmt.exceptions import (SolverReturnedUnknownResultError,
                               SolverNotConfiguredForUnsatCoresError,
@@ -46,6 +45,88 @@ from pysmt.decorators import clear_pending_pop, catch_conversion_error
 from pysmt.solvers.qelim import QuantifierEliminator
 from pysmt.solvers.interpolation import Interpolator
 from pysmt.walkers.identitydag import IdentityDagWalker
+
+
+class _MSatEnvWrapper(object):
+    "A simple wrapper for msat_env objects with explicit reference counting"
+
+    __slots__ = ['msat_env', 'refs']
+
+    def __init__(self, msat_env):
+        self.msat_env = msat_env
+        self.refs = 1
+
+    def ref(self):
+        self.refs += 1
+        return self
+
+    def unref(self):
+        assert self.refs > 0
+        self.refs -= 1
+        if not self.refs:
+            mathsat.msat_destroy_env(self.msat_env)
+
+    def __call__(self):
+        return self.msat_env
+
+
+class MathSAT5Model(Model):
+
+    def __init__(self, environment, msat_env_wrapper):
+        Model.__init__(self, environment)
+        self.msat_env = msat_env_wrapper
+        self.converter = MSatConverter(environment, self.msat_env())
+        self.msat_model = None
+        msat_model = mathsat.msat_get_model(self.msat_env())
+        if mathsat.MSAT_ERROR_MODEL(msat_model):
+            msat_msg = mathsat.msat_last_error_message(self.msat_env())
+            raise InternalSolverError(msat_msg)
+        self.msat_model = msat_model
+
+    def __del__(self):
+        if self.msat_model is not None:
+            mathsat.msat_destroy_model(self.msat_model)
+        self.msat_env.unref()
+
+    def get_value(self, formula, model_completion=True):
+        titem = self.converter.convert(formula)
+        msat_res = mathsat.msat_model_eval(self.msat_model, titem)
+        if mathsat.MSAT_ERROR_TERM(msat_res):
+            raise InternalSolverError("get model value")
+        val = self.converter.back(msat_res)
+        if self.environment.stc.get_type(formula).is_real_type() and \
+               val.is_int_constant():
+            val = self.environment.formula_manager.Real(val.constant_value())
+        return val
+
+    def iterator_over(self, language):
+        for x in language:
+            yield x, self.get_value(x, model_completion=True)
+
+    def __iter__(self):
+        """Overloading of iterator from Model.  We iterate only on the
+        variables defined in the assignment.
+        """
+        it = mathsat.msat_model_create_iterator(self.msat_model)
+        if mathsat.MSAT_ERROR_MODEL_ITERATOR(it):
+            raise InternalSolverError("model iteration")
+
+        while mathsat.msat_model_iterator_has_next(it):
+            t, v = mathsat.msat_model_iterator_next(it)
+            if mathsat.msat_term_is_constant(self.msat_env(), t):
+                pt = self.converter.back(t)
+                pv = self.converter.back(v)
+                if self.environment.stc.get_type(pt).is_real_type() and \
+                       pv.is_int_constant():
+                    pv = self.environment.formula_manager.Real(
+                        pv.constant_value())
+                yield (pt, pv)
+
+        mathsat.msat_destroy_model_iterator(it)
+
+    def __contains__(self, x):
+        """Returns whether the model contains a value for 'x'."""
+        return x in (v for v, _ in self)
 
 
 class MathSAT5Solver(IncrementalTrackingSolver, UnsatCoreSolver,
@@ -62,6 +143,7 @@ class MathSAT5Solver(IncrementalTrackingSolver, UnsatCoreSolver,
         self.msat_config = mathsat.msat_create_default_config(str(logic))
         self._prepare_config(self.options, debugFile)
         self.msat_env = mathsat.msat_create_env(self.msat_config)
+        self.msat_env_wrapper = _MSatEnvWrapper(self.msat_env)
 
         self.realType = mathsat.msat_get_rational_type(self.msat_env)
         self.intType = mathsat.msat_get_integer_type(self.msat_env)
@@ -265,43 +347,14 @@ class MathSAT5Solver(IncrementalTrackingSolver, UnsatCoreSolver,
 
         titem = self.converter.convert(item)
         tval = mathsat.msat_get_model_value(self.msat_env, titem)
-
-        if mathsat.msat_term_is_number(self.msat_env, tval):
-            rep = mathsat.msat_term_repr(tval)
-            if self.environment.stc.get_type(item).is_real_type():
-                match = re.match(r"(-?\d+)/(\d+)", rep)
-                if match is not None:
-                    return self.mgr.Real((int(match.group(1)),
-                                          int(match.group(2))))
-                else:
-                    return self.mgr.Real(int(rep))
-            elif self.environment.stc.get_type(item).is_int_type():
-                return self.mgr.Int(int(rep))
-            else:
-                assert self.environment.stc.get_type(item).is_bv_type()
-                # MathSAT representation is <value>_<width>
-                value, width = rep.split("_")
-                return self.mgr.BV(int(value), int(width))
-
-        else:
-            assert mathsat.msat_term_is_true(self.msat_env, tval) or \
-                mathsat.msat_term_is_false(self.msat_env, tval)
-            bval = (mathsat.msat_term_is_true(self.msat_env, tval) == 1)
-            return self.mgr.Bool(bval)
+        val = self.converter.back(tval)
+        if self.environment.stc.get_type(item).is_real_type() and \
+               val.is_int_constant():
+            val = self.mgr.Real(val.constant_value())
+        return val
 
     def get_model(self):
-        assignment = {}
-        msat_iterator = mathsat.msat_create_model_iterator(self.msat_env)
-        while mathsat.msat_model_iterator_has_next(msat_iterator):
-            term, value = mathsat.msat_model_iterator_next(msat_iterator)
-            pysmt_term = self.converter.back(term)
-            pysmt_value = self.converter.back(value)
-            if self.environment.stc.get_type(pysmt_term).is_real_type() and \
-               pysmt_value.is_int_constant():
-                pysmt_value = self.mgr.Real(pysmt_value.constant_value())
-            assignment[pysmt_term] = pysmt_value
-        mathsat.msat_destroy_model_iterator(msat_iterator)
-        return EagerModel(assignment=assignment, environment=self.environment)
+        return MathSAT5Model(self.environment, self.msat_env_wrapper.ref())
 
     def _exit(self):
         mathsat.msat_destroy_env(self.msat_env)


### PR DESCRIPTION
This extends the patch by @agriggio (PR #208) that introduces the new MathSAT5Model object.

We introduce the class ```MSatEnv``` that is used to manage the msat_environment object. In this way, it is possible to decouple the Solver from the Environment, and let the ```MathSAT5Model``` keep an internal reference to the ```MSatEnv``` that survives after the Solver has been closed.

This changes the way that mathsat api functions are called! 

