### PR TITLE
SMT-LIB: Improved parsing compliance wrt SMT-LIB 2 and 2.5

### DIFF
--- a/pysmt/smtlib/commands.py
+++ b/pysmt/smtlib/commands.py
@@ -17,33 +17,69 @@
 #
 """Defines constants for the commands of the SMT-LIB"""
 
-SET_INFO='set-info'
-RESET_ASSERTIONS='reset-assertions'
-GET_VALUE='get-value'
-SET_OPTION='set-option'
 ASSERT='assert'
 CHECK_SAT='check-sat'
-EXIT='exit'
-SET_LOGIC='set-logic'
-DECLARE_FUN='declare-fun'
+CHECK_SAT_ASSUMING='check-sat-assuming'
 DECLARE_CONST='declare-const'
+DECLARE_FUN='declare-fun'
+DECLARE_SORT='declare-sort'
 DEFINE_FUN='define-fun'
-PUSH='push'
+DEFINE_FUN_REC='define-fun-rec'
+DEFINE_FUNS_REC='define-funs-rec'
+DEFINE_SORT='define-sort'
+ECHO='echo'
+EXIT='exit'
+GET_ASSERTIONS='get-assertions'
+GET_ASSIGNMENT='get-assignment'
+GET_INFO='get-info'
+GET_MODEL='get-model'
+GET_OPTION='get-option'
+GET_PROOF='get-proof'
+GET_UNSAT_ASSUMPTIONS='get-unsat-assumptions'
+GET_UNSAT_CORE='get-unsat-core'
+GET_VALUE='get-value'
 POP='pop'
+PUSH='push'
+RESET='reset'
+RESET_ASSERTIONS='reset-assertions'
+SET_INFO='set-info'
+SET_LOGIC='set-logic'
+SET_OPTION='set-option'
 
+#
 
-ALL_COMMANDS = [
-    SET_INFO,
-    RESET_ASSERTIONS,
-    GET_VALUE,
-    SET_OPTION,
-    ASSERT,
-    CHECK_SAT,
-    EXIT,
+SMT_LIB_2_0 = [
     SET_LOGIC,
+    SET_OPTION,
+    SET_INFO,
+    DECLARE_SORT,
+    DEFINE_SORT,
     DECLARE_FUN,
-    DECLARE_CONST,
     DEFINE_FUN,
     PUSH,
     POP,
+    ASSERT,
+    CHECK_SAT,
+    GET_ASSERTIONS,
+    GET_VALUE,
+    GET_MODEL,
+    GET_PROOF,
+    GET_UNSAT_CORE,
+    GET_INFO,
+    GET_OPTION,
+    EXIT,
 ]
+
+SMT_LIB_2_5 = SMT_LIB_2_0 + [
+    CHECK_SAT_ASSUMING,
+    DECLARE_CONST,
+    DEFINE_FUN_REC,
+    DEFINE_FUNS_REC,
+    ECHO,
+    GET_ASSIGNMENT,
+    GET_UNSAT_ASSUMPTIONS,
+    RESET,
+    RESET_ASSERTIONS,
+]
+
+ALL_COMMANDS = SMT_LIB_2_5

--- a/pysmt/smtlib/parser.py
+++ b/pysmt/smtlib/parser.py
@@ -985,7 +985,9 @@ class SmtLibParser(object):
 
     def _cmd_check_sat_assuming(self, current, tokens):
         """(check-sat-assuming (<prop_literal>*) ) """
-        return self._cmd_not_implemented(current, tokens)
+        params = self.parse_expr_list(tokens, current)
+        self.consume_closing(tokens, current)
+        return SmtLibCommand(current, params)
 
     def _cmd_define_fun_rec(self, current, tokens):
         """(define-fun-rec <fun_def>)"""

--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -110,11 +110,17 @@ class SmtLibCommand(namedtuple('SmtLibCommand', ['name', 'args'])):
         elif self.name in [smtcmd.PUSH, smtcmd.POP]:
             outstream.write("(%s %d)" % (self.name, self.args[0]))
 
+        elif self.name in smtcmd.ALL_COMMANDS:
+            raise NotImplementedError("'%s' is a valid SMT-LIB command "\
+                                      "but it is currently not supported. "\
+                                      "Please open a bug-report." % self.name)
+        else:
+            raise UnknownSmtLibCommandError(self.name)
+
     def serialize_to_string(self):
         buf = cStringIO()
         self.serialize(buf)
         return buf.getvalue()
-
 
 
 class SmtLibScript(object):
@@ -275,5 +281,9 @@ def evaluate_command(cmd, solver):
         (var, formals, typename, body) = cmd.args
         return solver.define_fun(var, formals, typename, body)
 
+    elif cmd.name in smtcmd.ALL_COMMANDS:
+        raise NotImplementedError("'%s' is a valid SMT-LIB command "\
+                                  "but it is currently not supported. "\
+                                  "Please open a bug-report." % cmd.name)
     else:
         raise UnknownSmtLibCommandError(cmd.name)

--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -285,6 +285,9 @@ def evaluate_command(cmd, solver):
         print(cmd.args[0])
         return None
 
+    elif cmd.name == smtcmd.CHECK_SAT_ASSUMING:
+        return solver.check_sat(cmd.args)
+
     elif cmd.name in smtcmd.ALL_COMMANDS:
         raise NotImplementedError("'%s' is a valid SMT-LIB command "\
                                   "but it is currently not supported. "\

--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -281,6 +281,10 @@ def evaluate_command(cmd, solver):
         (var, formals, typename, body) = cmd.args
         return solver.define_fun(var, formals, typename, body)
 
+    elif cmd.name == smtcmd.ECHO:
+        print(cmd.args[0])
+        return None
+
     elif cmd.name in smtcmd.ALL_COMMANDS:
         raise NotImplementedError("'%s' is a valid SMT-LIB command "\
                                   "but it is currently not supported. "\

--- a/pysmt/test/smtlib/test_smtlibscript.py
+++ b/pysmt/test/smtlib/test_smtlibscript.py
@@ -23,7 +23,7 @@ from pysmt.typing import REAL
 from pysmt.test import TestCase, main
 from pysmt.smtlib.script import SmtLibScript, SmtLibCommand
 from pysmt.smtlib.script import smtlibscript_from_formula, evaluate_command
-from pysmt.smtlib.parser import get_formula_strict, get_formula
+from pysmt.smtlib.parser import get_formula_strict, get_formula, SmtLibParser
 from pysmt.solvers.smtlib import SmtLibIgnoreMixin
 
 class TestSmtLibScript(TestCase):
@@ -126,6 +126,62 @@ class TestSmtLibScript(TestCase):
                          solver=mock)
 
 
+    def test_all_parsing(self):
+        # Create a small file that tests all commands of smt-lib 2
+        parser = SmtLibParser()
+
+        nie = 0
+        for cmd in DEMO_SMTSCRIPT:
+            try:
+                out = next(parser.get_command_generator(cStringIO(cmd)))
+                #print(out)
+            except NotImplementedError:
+                #print(cmd)
+                nie += 1
+        # There are currently 10 not-implemented commands
+        self.assertEquals(nie, 9)
+
+DEMO_SMTSCRIPT = [ "(declare-fun a () Bool)",
+                   "(declare-fun b () Bool)",
+                   "(declare-fun c () Bool)",
+                   "(assert true)",
+                   "(assert (not a))",
+                   "(check-sat)",
+                   "(check-sat-assuming (a b c))",
+                   "(check-sat-assuming ((not a) b (not c)))",
+                   "(declare-const d Bool)",
+                   "(declare-fun xyz (A B) C)", # Shouldn't this raise an error?
+                   "(declare-fun abc () Int)",
+                   "(declare-sort A 0)",
+                   "(define-fun f ((a Bool)) B a)",
+                   "(define-fun g ((a Bool)) B (f a))",
+                   "(define-fun-rec f ((a A)) B a)",
+                   "(define-fun-rec g ((a A)) B (g a))",
+                   """(define-funs-rec ((h ((a A)) B) (i ((a A)) B) )
+                                       ( (i a) (h a))
+                   )
+                   """,
+                   "(define-sort A () B)",
+                   "(define-sort A (B C) (Array B C))",
+                   "(echo 'hello world')",
+                   "(exit)",
+                   "(get-assertions)",
+                   "(get-assignment)",
+                   "(get-info :name)",
+                   "(get-model)",
+                   "(get-option :keyword)",
+                   "(get-proof)",
+                   "(get-unsat-assumptions)",
+                   "(get-unsat-core)",
+                   "(get-value (x y z))",
+                   "(pop 42)",
+                   "(push 42)",
+                   "(reset)",
+                   "(reset-assertions)",
+                   "(set-info :number 42)",
+                   "(set-logic QF_LIA)",
+                   "(set-option :produce-models true)",
+               ]
 
 if __name__ == "__main__":
     main()

--- a/pysmt/test/smtlib/test_smtlibscript.py
+++ b/pysmt/test/smtlib/test_smtlibscript.py
@@ -136,8 +136,8 @@ class TestSmtLibScript(TestCase):
                 next(parser.get_command_generator(cStringIO(cmd)))
             except NotImplementedError:
                 nie += 1
-        # There are currently 8 not-implemented commands
-        self.assertEquals(nie, 8)
+        # There are currently 6 not-implemented commands
+        self.assertEquals(nie, 6)
 
 DEMO_SMTSCRIPT = [ "(declare-fun a () Bool)",
                    "(declare-fun b () Bool)",

--- a/pysmt/test/smtlib/test_smtlibscript.py
+++ b/pysmt/test/smtlib/test_smtlibscript.py
@@ -133,13 +133,11 @@ class TestSmtLibScript(TestCase):
         nie = 0
         for cmd in DEMO_SMTSCRIPT:
             try:
-                out = next(parser.get_command_generator(cStringIO(cmd)))
-                #print(out)
+                next(parser.get_command_generator(cStringIO(cmd)))
             except NotImplementedError:
-                #print(cmd)
                 nie += 1
-        # There are currently 10 not-implemented commands
-        self.assertEquals(nie, 9)
+        # There are currently 8 not-implemented commands
+        self.assertEquals(nie, 8)
 
 DEMO_SMTSCRIPT = [ "(declare-fun a () Bool)",
                    "(declare-fun b () Bool)",
@@ -163,7 +161,7 @@ DEMO_SMTSCRIPT = [ "(declare-fun a () Bool)",
                    """,
                    "(define-sort A () B)",
                    "(define-sort A (B C) (Array B C))",
-                   "(echo 'hello world')",
+                   "(echo \"hello world\")",
                    "(exit)",
                    "(get-assertions)",
                    "(get-assignment)",


### PR DESCRIPTION
- Default parser now deals with SMT-LIB 2.5
- SmtLib20Parser can be used for strict SMT-LIB 2.0 compliance
- Improved handling of not implemented commands in parser
- Test and documentation

Some commands are still not supported by the parser.