### PR TITLE
EagerModel can now take a solver model in input.

### DIFF
--- a/pysmt/solvers/eager.py
+++ b/pysmt/solvers/eager.py
@@ -33,7 +33,7 @@ class EagerModel(Model):
             environment = get_env()
         Model.__init__(self, environment)
         self.environment = environment
-        self.assignment = assignment
+        self.assignment = dict(assignment)
         # Create a copy of the assignments to memoize completions
         self.completed_assignment = dict(self.assignment)
 

--- a/pysmt/test/test_eager_model.py
+++ b/pysmt/test/test_eager_model.py
@@ -18,9 +18,11 @@
 from six.moves import xrange
 
 from pysmt.test import TestCase, main
-from pysmt.shortcuts import And, Or, FALSE, TRUE, FreshSymbol
+from pysmt.shortcuts import And, Or, FALSE, TRUE, FreshSymbol, Solver
 from pysmt.solvers.eager import EagerModel
 from pysmt.typing import REAL, INT
+from pysmt.test import TestCase, skipIfSolverNotAvailable
+
 
 class TestEagerModel(TestCase):
 
@@ -89,6 +91,18 @@ class TestEagerModel(TestCase):
         model = EagerModel(assignment=d)
         self.assertTrue(x in model)
         self.assertFalse(z in model)
+
+    @skipIfSolverNotAvailable("z3")
+    def test_warp_solvermodel(self):
+        x, y, z = [FreshSymbol() for _ in xrange(3)]
+        with Solver(name='z3') as solver:
+            solver.add_assertion(And(x,y,z))
+            solver.solve()
+            z3_model = solver.get_model()
+            eager_model = EagerModel(z3_model)
+            for var, value  in eager_model:
+                self.assertIn(var, [x,y,z])
+                self.assertEquals(value, TRUE())
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This makes it possible to operate solver-specific models in a more uniform way.

In this way, we can keep using EagerModels, even if solvers provide their own Model Object.