### PR TITLE
YICES BUGFIX Fixed a failed assertion in Yices push method

### DIFF
--- a/pysmt/solvers/yices.py
+++ b/pysmt/solvers/yices.py
@@ -81,6 +81,7 @@ class YicesSolver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
         self.converter = YicesConverter(environment)
         self.mgr = environment.formula_manager
         self.model = None
+        self.failed_pushes = 0
         return
 
     @clear_pending_pop
@@ -97,7 +98,10 @@ class YicesSolver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
         self._assert_is_boolean(formula)
         term = self.converter.convert(formula)
         code = libyices.yices_assert_formula(self.yices, term)
-        assert code == 0, "Yices returned non-zero code (" + str(code) + "): " + str(formula)
+        if code != 0:
+            raise InternalSolverError("Yices returned non-zero code upon assert"\
+                                      ": %s (code: %s)" % \
+                                      (libyices.yices_error_string(), code))
 
     def get_model(self):
         assignment = {}
@@ -137,13 +141,28 @@ class YicesSolver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
     def push(self, levels=1):
         for _ in xrange(levels):
             c = libyices.yices_push(self.yices)
-            assert c == 0
+            if c != 0:
+                # 4 is STATUS_UNSAT
+                if libyices.yices_context_status(self.yices) == 4:
+                    # Yices fails to push if the context is in UNSAT state
+                    # (It makes no sense to conjoin formulae to False)
+                    # PySMT allows this and we support it by counting the
+                    # spurious push calls
+                    self.failed_pushes += 1
+                else:
+                    raise InternalSolverError("Error in push: %s" % \
+                                              libyices.yices_error_string())
 
     @clear_pending_pop
     def pop(self, levels=1):
         for _ in xrange(levels):
-            c = libyices.yices_pop(self.yices)
-            assert c == 0
+            if self.failed_pushes > 0:
+                self.failed_pushes -= 1
+            else:
+                c = libyices.yices_pop(self.yices)
+                if c != 0:
+                    raise InternalSolverError("Error in pop: %s" % \
+                                              libyices.yices_error_string())
 
     def print_model(self, name_filter=None):
         for var in self.declarations:
@@ -165,7 +184,10 @@ class YicesSolver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
             yval = libyices.yval_t()
             status = libyices.yices_get_value(self.model, titem,
                                               ctypes.byref(yval))
-            assert status == 0, "Failed to read the variable from the model"
+            if status != 0:
+                raise InternalSolverError("Failed to read the variable from " \
+                                          "the model: %s" % \
+                                          libyices.yices_error_string())
 
             if ty.is_int_type():
                 if libyices.yices_val_is_int64(self.model,
@@ -210,7 +232,10 @@ class YicesSolver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
             term,
             ctypes.byref(term_type)
         )
-        assert status == 0, "Failed to read the variable from the model"
+        if status != 0:
+            raise InternalSolverError("Failed to read the variable from " \
+                                      "the model: %s" % \
+                                      libyices.yices_error_string())
         return term_type.value
 
     def _get_yices_rational_value(self, term):
@@ -221,7 +246,11 @@ class YicesSolver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
             term,
             ctypes.byref(n),
             ctypes.byref(d))
-        assert status == 0, "Failed to read the variable from the model"
+
+        if status != 0:
+            raise InternalSolverError("Failed to read the variable from " \
+                                      "the model: %s" % \
+                                      libyices.yices_error_string())
         return Fraction(n.value, d.value)
 
 

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -20,7 +20,7 @@ from six.moves import xrange
 from six.moves import cStringIO
 
 from pysmt.shortcuts import (Real, Plus, Symbol, Equals, And, Bool, Or,
-                             Div, LT, LE, Int, ToReal, Iff, Exists, Times)
+                             Div, LT, LE, Int, ToReal, Iff, Exists, Times, FALSE)
 from pysmt.shortcuts import Solver, get_env, qelim, get_model, TRUE, ExactlyOne
 from pysmt.typing import REAL, BOOL, INT, FunctionType
 from pysmt.test import TestCase, skipIfSolverNotAvailable, skipIfNoSolverForLogic
@@ -289,6 +289,17 @@ class TestRegressions(TestCase):
         buffer_ = cStringIO(smtlib_input)
         parser.get_script(buffer_)
 
+    @skipIfSolverNotAvailable("yices")
+    def test_yices_push(self):
+        with Solver(name="yices") as solver:
+            solver.add_assertion(FALSE())
+            res = solver.solve()
+            self.assertFalse(res)
+            solver.push()
+            solver.add_assertion(TRUE())
+            res = solver.solve()
+            self.assertFalse(res)
+            solver.pop()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Yices does not support a push after a check_sat call that returned
UNSAT. I added a wrapping logic to handle this case that can arise in
practical applications.