### PR TITLE
Issue #220: Logic as String

### DIFF
--- a/pysmt/factory.py
+++ b/pysmt/factory.py
@@ -32,6 +32,7 @@ from pysmt.exceptions import (NoSolverAvailableError, SolverRedefinitionError,
 from pysmt.logics import QF_UFLIRA, LRA, QF_UFLRA
 from pysmt.logics import AUTO as AUTO_LOGIC
 from pysmt.logics import most_generic_logic, get_closer_logic
+from pysmt.logics import convert_logic_from_string
 from pysmt.oracles import get_logic
 from pysmt.solvers.qelim import ShannonQuantifierEliminator
 
@@ -132,13 +133,13 @@ class Factory(object):
                            logic=closer_logic)
 
     def get_interpolator(self, name=None, logic=None):
-        SolverClass, closer_logic = self._get_solver_class(
-            solver_list=self._all_interpolators,
-            solver_type="Interpolator",
-            preference_list=self.interpolation_preference_list,
-            default_logic=self._default_interpolation_logic,
-            name=name,
-            logic=logic)
+        SolverClass, closer_logic = \
+           self._get_solver_class(solver_list=self._all_interpolators,
+                                  solver_type="Interpolator",
+                                  preference_list=self.interpolation_preference_list,
+                                  default_logic=self._default_interpolation_logic,
+                                  name=name,
+                                  logic=logic)
 
         return SolverClass(environment=self.environment,
                            logic=closer_logic)
@@ -149,6 +150,7 @@ class Factory(object):
         if len(solver_list) == 0:
             raise NoSolverAvailableError("No %s is available" % solver_type)
 
+        logic = convert_logic_from_string(logic)
         if name is not None:
             if name not in solver_list:
                 raise NoSolverAvailableError("%s '%s' is not available" % \

--- a/pysmt/logics.py
+++ b/pysmt/logics.py
@@ -594,10 +594,18 @@ PYSMT_QF_LOGICS = frozenset(_l for _l in PYSMT_LOGICS if _l.quantifier_free)
 
 def get_logic_by_name(name):
     """Returns the Logic that matches the provided name."""
-
     for logic in LOGICS:
-        if logic.name == name: return logic
+        if logic.name.lower() == name.lower(): return logic
     raise UndefinedLogicError(name)
+
+def convert_logic_from_string(name):
+    """Helper function to parse function arguments.
+
+    This takes a logic or a string or None, and returns a logic or None.
+    """
+    if name is not None and type(name) == str:
+        name = get_logic_by_name(name)
+    return name
 
 def get_logic_name(quantifier_free=False,
                    arrays=False,

--- a/pysmt/logics.py
+++ b/pysmt/logics.py
@@ -19,8 +19,10 @@
 the SMTLIB and provides methods to compare and search for particular
 logics.
 """
+import six
 
 from pysmt.exceptions import UndefinedLogicError, NoLogicAvailableError
+
 
 class Theory(object):
     """Describes a theory similarly to the SMTLIB 2.0."""
@@ -603,7 +605,7 @@ def convert_logic_from_string(name):
 
     This takes a logic or a string or None, and returns a logic or None.
     """
-    if name is not None and type(name) == str:
+    if name is not None and isinstance(name, six.string_types):
         name = get_logic_by_name(name)
     return name
 

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -16,6 +16,7 @@
 #   limitations under the License.
 #
 from six.moves import xrange
+from six import PY2
 
 import pysmt.operators as op
 from pysmt.shortcuts import Symbol, FreshSymbol, And, Not, GT, Function, Plus
@@ -470,6 +471,9 @@ class TestBasic(TestCase):
     @skipIfNoSolverForLogic(QF_LRA)
     def test_logic_as_string(self):
         self.assertEqual(convert_logic_from_string("QF_LRA"), QF_LRA)
+        if PY2:
+            self.assertEqual(convert_logic_from_string(unicode("QF_LRA")),
+                             QF_LRA)
         with self.assertRaises(UndefinedLogicError):
             convert_logic_from_string("PAPAYA")
         self.assertIsNone(convert_logic_from_string(None))

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -28,8 +28,9 @@ from pysmt.test import main
 from pysmt.test.examples import get_example_formulae
 from pysmt.exceptions import (SolverReturnedUnknownResultError,
                               InternalSolverError, NoSolverAvailableError,
-                              ConvertExpressionError)
+                              ConvertExpressionError, UndefinedLogicError)
 from pysmt.logics import QF_UFLIRA, QF_BOOL, QF_LRA, AUTO
+from pysmt.logics import convert_logic_from_string
 
 class TestBasic(TestCase):
 
@@ -465,6 +466,20 @@ class TestBasic(TestCase):
         for sname in get_env().factory.all_solvers(logic=QF_BOOL):
             with self.assertRaises(ConvertExpressionError):
                 is_sat(invalid_node, solver_name=sname, logic=QF_BOOL)
+
+    @skipIfNoSolverForLogic(QF_LRA)
+    def test_logic_as_string(self):
+        self.assertEqual(convert_logic_from_string("QF_LRA"), QF_LRA)
+        with self.assertRaises(UndefinedLogicError):
+            convert_logic_from_string("PAPAYA")
+        self.assertIsNone(convert_logic_from_string(None))
+
+        x = Symbol("x")
+        self.assertTrue(is_sat(x, logic="QF_LRA"))
+        with self.assertRaises(UndefinedLogicError):
+            is_sat(x, logic="PAPAYA")
+        self.assertTrue(is_sat(x, logic=None))
+        self.assertTrue(is_sat(x))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Top level functions from Factory (and thus most shortcuts) can now
take a logic as a string. Instead of writing

  is_sat(f, logic=pysmt.logics.QF_LRA)

it is now possible to write:

  is_sat(f, logic="QF_LRA")

This is handled in Factory._get_solver_class(). Other code within
pySMT should always work under the assumption that logics are given as
a pysmt.logics object.