### PR TITLE
BUGFIX: fixed logic dumping in SmtLib

### DIFF
--- a/pysmt/logics.py
+++ b/pysmt/logics.py
@@ -468,6 +468,12 @@ QF_UF = Logic(name="QF_UF",
               quantifier_free=True,
               uninterpreted=True)
 
+UF = Logic(name="UF",
+           description=\
+"""Quantified formulas built over a signature of uninterpreted
+(i.e., free) sort and function symbols.""",
+           uninterpreted=True)
+
 
 QF_UFBV = Logic(name="QF_UFBV",
                 description=\
@@ -688,4 +694,13 @@ def get_closer_logic(supported_logics, logic):
     return min(res)
 
 def get_closer_pysmt_logic(target_logic):
+    """Returns the closer logic supported by PYSMT."""
     return get_closer_logic(PYSMT_LOGICS, target_logic)
+
+def get_closer_smtlib_logic(target_logic):
+    """Returns the closer logic supported by SMT-LIB 2.0."""
+    if target_logic == QF_BOOL:
+        return QF_UF
+    if target_logic == BOOL:
+        return LRA
+    return get_closer_logic(SMTLIB2_LOGICS, target_logic)

--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -23,7 +23,6 @@ import pysmt.smtlib.commands as smtcmd
 from pysmt.exceptions import UnknownSmtLibCommandError
 from pysmt.shortcuts import And
 from pysmt.smtlib.printers import SmtPrinter, SmtDagPrinter, quote
-from pysmt.utils import quote
 from pysmt.oracles import get_logic
 from pysmt.logics import get_closer_smtlib_logic
 

--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -25,7 +25,7 @@ from pysmt.shortcuts import And
 from pysmt.smtlib.printers import SmtPrinter, SmtDagPrinter, quote
 from pysmt.utils import quote
 from pysmt.oracles import get_logic
-from pysmt.logics import SMTLIB2_LOGICS, get_closer_logic
+from pysmt.logics import get_closer_smtlib_logic
 
 
 def check_sat_filter(log):
@@ -215,8 +215,7 @@ def smtlibscript_from_formula(formula):
 
     # Get the simplest SmtLib logic that contains the formula
     f_logic = get_logic(formula)
-    smt_logic = get_closer_logic(SMTLIB2_LOGICS, f_logic)
-
+    smt_logic = get_closer_smtlib_logic(f_logic)
     script.add(name=smtcmd.SET_LOGIC,
                args=[smt_logic])
 

--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -23,8 +23,9 @@ import pysmt.smtlib.commands as smtcmd
 from pysmt.exceptions import UnknownSmtLibCommandError
 from pysmt.shortcuts import And
 from pysmt.smtlib.printers import SmtPrinter, SmtDagPrinter, quote
-from pysmt.logics import UFLIRA
 from pysmt.utils import quote
+from pysmt.oracles import get_logic
+from pysmt.logics import SMTLIB2_LOGICS, get_closer_logic
 
 
 def check_sat_filter(log):
@@ -212,8 +213,12 @@ class SmtLibScript(object):
 def smtlibscript_from_formula(formula):
     script = SmtLibScript()
 
+    # Get the simplest SmtLib logic that contains the formula
+    f_logic = get_logic(formula)
+    smt_logic = get_closer_logic(SMTLIB2_LOGICS, f_logic)
+
     script.add(name=smtcmd.SET_LOGIC,
-               args=[UFLIRA])
+               args=[smt_logic])
 
     deps = formula.get_free_variables()
     # Declare all variables

--- a/pysmt/test/smtlib/test_parser_examples.py
+++ b/pysmt/test/smtlib/test_parser_examples.py
@@ -17,12 +17,12 @@
 #
 from six.moves import cStringIO
 
+import pysmt.logics as logics
 from pysmt.test import TestCase, skipIfNoSolverForLogic
 from pysmt.test.examples import get_example_formulae
 from pysmt.smtlib.parser import SmtLibParser
 from pysmt.smtlib.script import smtlibscript_from_formula
 from pysmt.shortcuts import Iff
-from pysmt.logics import QF_BV
 
 
 class TestSMTParseExamples(TestCase):
@@ -31,7 +31,7 @@ class TestSMTParseExamples(TestCase):
         fs = get_example_formulae()
 
         for (f_out, _, _, logic) in fs:
-            if logic == QF_BV:
+            if logic == logics.QF_BV:
                 # See test_parse_examples_bv
                 continue
             buf_out = cStringIO()
@@ -45,7 +45,7 @@ class TestSMTParseExamples(TestCase):
             self.assertEqual(f_in, f_out)
 
 
-    @skipIfNoSolverForLogic(QF_BV)
+    @skipIfNoSolverForLogic(logics.QF_BV)
     def test_parse_examples_bv(self):
         """For BV we represent a superset of the operators defined in SMT-LIB.
 
@@ -56,7 +56,7 @@ class TestSMTParseExamples(TestCase):
         fs = get_example_formulae()
 
         for (f_out, _, _, logic) in fs:
-            if logic != QF_BV:
+            if logic != logics.QF_BV:
                 continue
             buf_out = cStringIO()
             script_out = smtlibscript_from_formula(f_out)
@@ -74,7 +74,7 @@ class TestSMTParseExamples(TestCase):
         fs = get_example_formulae()
 
         for (f_out, _, _, logic) in fs:
-            if logic == QF_BV:
+            if logic == logics.QF_BV:
                 # See test_parse_examples_daggified_bv
                 continue
             buf_out = cStringIO()
@@ -86,12 +86,12 @@ class TestSMTParseExamples(TestCase):
             f_in = script_in.get_last_formula()
             self.assertEqual(f_in, f_out)
 
-    @skipIfNoSolverForLogic(QF_BV)
+    @skipIfNoSolverForLogic(logics.QF_BV)
     def test_parse_examples_daggified_bv(self):
         fs = get_example_formulae()
 
         for (f_out, _, _, logic) in fs:
-            if logic != QF_BV:
+            if logic != logics.QF_BV:
                 # See test_parse_examples_daggified
                 continue
             buf_out = cStringIO()
@@ -102,3 +102,29 @@ class TestSMTParseExamples(TestCase):
             script_in = parser.get_script(buf_in)
             f_in = script_in.get_last_formula()
             self.assertValid(Iff(f_in, f_out), f_in.serialize())
+
+    def test_dumped_logic(self):
+        # Dumped logic matches the logic in the example
+        fs = get_example_formulae()
+
+        for (f_out, _, _, logic) in fs:
+            buf_out = cStringIO()
+            script_out = smtlibscript_from_formula(f_out)
+            script_out.serialize(outstream=buf_out)
+
+            buf_in = cStringIO(buf_out.getvalue())
+            parser = SmtLibParser()
+            script_in = parser.get_script(buf_in)
+            for cmd in script_in:
+                if cmd.name == "set-logic":
+                    logic_in = cmd.args[0]
+                    if logic == logics.QF_BOOL:
+                        self.assertEqual(logic_in, logics.QF_UF)
+                    elif logic == logics.BOOL:
+                        self.assertEqual(logic_in, logics.LRA)
+                    else:
+                        self.assertEqual(logic_in, logic, script_in)
+                    break
+            else: # Loops exited normally
+                print("-"*40)
+                print(script_in)


### PR DESCRIPTION
The logic to be specified in the script was hardcoded as UFLIRA. Now, it is selected by analyzing the formula using the logic oracle.