### PR TITLE
Removed pylint star-args annotations

### DIFF
--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -261,7 +261,6 @@ class FreeVarsOracle(pysmt.walkers.DagWalker):
         # - Constants have no impact
         #
         self.set_function(self.walk_error, *op.ALL_TYPES)
-        #pylint: disable=star-args
         self.set_function(self.walk_simple_args, *DEPENDENCIES_SIMPLE_ARGS)
         self.set_function(self.walk_constant, *op.CONSTANTS)
         self.set_function(self.walk_quantifier, *op.QUANTIFIERS)

--- a/pysmt/solvers/bdd.py
+++ b/pysmt/solvers/bdd.py
@@ -123,7 +123,6 @@ class BddSolver(Solver):
 
     def get_default_options(self, logic=None, user_options=None):
         if user_options is not None:
-            #pylint: disable=star-args
             return BddOptions(**user_options)
         else:
             return BddOptions()

--- a/pysmt/solvers/btor.py
+++ b/pysmt/solvers/btor.py
@@ -157,7 +157,6 @@ class BTORConverter(Converter, DagWalker):
         return decl
 
     def walk_and(self, formula, args, **kwargs):
-        #pylint: disable=star-args
         assert len(args) >= 2
         res = self._btor.And(args[0], args[1])
         for conj in args[2:]:
@@ -165,7 +164,6 @@ class BTORConverter(Converter, DagWalker):
         return res
 
     def walk_or(self, formula, args, **kwargs):
-        #pylint: disable=star-args
         assert len(args) >= 2
         res = self._btor.Or(args[0], args[1])
         for disj in args[2:]:
@@ -206,7 +204,6 @@ class BTORConverter(Converter, DagWalker):
         return self._btor.Eq(*args)
 
     def walk_function(self, formula, args, **kwargs):
-        #pylint: disable=star-args
         _uf = self.declare_function(formula)
         return _uf(*args)
 

--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -265,7 +265,6 @@ class CVC4Converter(Converter, DagWalker):
         if name not in self.declared_vars:
             self.declare_variable(name)
         decl = self.declared_vars[name]
-        #pylint: disable=star-args
         return self.mkExpr(CVC4.APPLY_UF, decl, *args)
 
     def walk_bv_constant(self, formula, **kwargs):

--- a/pysmt/solvers/yices.py
+++ b/pysmt/solvers/yices.py
@@ -272,7 +272,6 @@ class YicesConverter(Converter, DagWalker):
         return self.walk(formula)
 
     def _to_term_array(self, arr):
-        #pylint: disable=star-args
         return (libyices.term_t * len(arr))(*arr)
 
     def _check_term_result(self, res):
@@ -591,7 +590,6 @@ class YicesConverter(Converter, DagWalker):
         elif tp.is_function_type():
             stps = [self._type_to_yices(x) for x in tp.param_types]
             rtp = self._type_to_yices(tp.return_type)
-            #pylint: disable=star-args
             arr = (libyices.type_t * len(stps))(*stps)
             return libyices.yices_function_type(len(stps),
                                                 arr,

--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -203,7 +203,6 @@ class Z3Solver(IncrementalTrackingSolver, UnsatCoreSolver,
                 self.push()
                 self.add_assertion(self.mgr.And(other_ass))
                 self.pending_pop = True
-            #pylint: disable=star-args
             res = self.z3.check(*bool_ass)
         else:
             res = self.z3.check()
@@ -477,11 +476,9 @@ class Z3Converter(Converter, DagWalker):
 
 
     def walk_and(self, formula, args, **kwargs):
-        #pylint: disable=star-args
         return z3.And(*args)
 
     def walk_or(self, formula, args, **kwargs):
-        #pylint: disable=star-args
         return z3.Or(*args)
 
     def walk_not(self, formula, args, **kwargs):
@@ -548,7 +545,6 @@ class Z3Converter(Converter, DagWalker):
                          args[0])
 
     def walk_plus(self, formula, args, **kwargs):
-        #pylint: disable=star-args
         return z3.Sum(*args)
 
     def walk_minus(self, formula, args, **kwargs):
@@ -564,7 +560,6 @@ class Z3Converter(Converter, DagWalker):
         return z3.ToReal(args[0])
 
     def walk_function(self, formula, args, **kwargs):
-        #pylint: disable=star-args
         f = formula.function_name()
         tp = f.symbol_type()
         sig = [self._type_to_z3(x) for x in tp.param_types]


### PR DESCRIPTION
Removed all annotations disabling linting of star-args that is now not a warning anymore in the new version of pylint