### PR TITLE
Boolector: Updated to version 2.2.0

### DIFF
--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -32,7 +32,7 @@ INSTALLERS = [Installer(MSatInstaller,    "5.3.9", {}),
               Installer(Z3Installer,      "4.4.1", {}),
               Installer(CVC4Installer,    "1.5-prerelease", {"git_version" : "68f22235a62f5276b206e9a6692a85001beb8d42"}),
               Installer(YicesInstaller,   "2.4.1", {}),
-              Installer(BtorInstaller,    "2.1.1", {}),
+              Installer(BtorInstaller,    "2.2.0", {"lingeling_version": "bal"}),
               Installer(PicoSATInstaller, "960", {}),
               Installer(CuddInstaller,    "2.0.3", {"git_version" : "4861f4df8abc2ca205a6a09b30fdc8cfd29f6ebb"})]
 

--- a/pysmt/cmd/installers/btor.py
+++ b/pysmt/cmd/installers/btor.py
@@ -22,8 +22,9 @@ class BtorInstaller(SolverInstaller):
     SOLVER = "btor"
 
     def __init__(self, install_dir, bindings_dir, solver_version,
-                 mirror_link=None):
-        archive_name = "boolector-%s-with-lingeling-b85.tar.bz2" % solver_version
+                 mirror_link=None, lingeling_version=None):
+        archive_name = "boolector-%s-with-lingeling-%s.tar.bz2" % \
+                       (solver_version, lingeling_version)
         native_link = "http://fmv.jku.at/boolector/{archive_name}"
         SolverInstaller.__init__(self, install_dir=install_dir,
                                  bindings_dir=bindings_dir,


### PR DESCRIPTION
This also changes the BTOR installer interface to include the version of lingeling in the pkg name.