### PR TITLE
Basic performance optimizations

### DIFF
--- a/pysmt/fnode.py
+++ b/pysmt/fnode.py
@@ -65,6 +65,7 @@ class FNode(object):
     The node_id is an integer uniquely identifying the node within the
     FormulaManager it belongs.
     """
+    __slots__ = ["_content", "_node_id"]
 
     def __init__(self, content, node_id):
         self._content = content

--- a/pysmt/test/test_formula.py
+++ b/pysmt/test/test_formula.py
@@ -610,7 +610,11 @@ class TestFormulaManager(TestCase):
 
         self.assertEqual(str(f), "(A & (! B))", str(f))
 
-        serialized = pickle.dumps(f)
+        # NOTE: We cannot use the textual format for pickle, because
+        # we are using slots. We can, however, use more advanced
+        # versions of pickle. Therefore, we specify here to use the
+        # latest protocol.
+        serialized = pickle.dumps(f, pickle.HIGHEST_PROTOCOL)
 
         f_new = pickle.loads(serialized)
         f_new = dst_mgr.normalize(f)

--- a/pysmt/walkers/dag.py
+++ b/pysmt/walkers/dag.py
@@ -85,7 +85,7 @@ class DagWalker(Walker):
            is computed and memoized.
         """
 
-        while len(self.stack) > 0 :
+        while self.stack:
             (was_expanded, formula) = self.stack.pop()
             if was_expanded:
                 self._compute_node_result(formula, **kwargs)
@@ -110,7 +110,7 @@ class DagWalker(Walker):
         return res
 
     def _get_key(self, formula, **kwargs):
-        if len(kwargs) == 0:
+        if not kwargs:
             return formula
         raise NotImplementedError("DagWalker should redefine '_get_key'" +
                                   " when using keywords arguments")


### PR DESCRIPTION
1. Avoid use of len() to test emptiness of a dictionary
   (DagWalker._get_key) and a list (DagWalker._process_stack)
   This leads to 75% less calls to len() and a 10% runtime improvement.

2. Use __slots__ for FNode. This leads to 30% memory reduction.