### PR TITLE
Improved handling of options in Solvers.

### DIFF
--- a/pysmt/shortcuts.py
+++ b/pysmt/shortcuts.py
@@ -383,11 +383,12 @@ def BVAShr(left, right):
 
 
 #### Shortcuts for Solvers Factory #####
-def Solver(quantified=False, name=None, logic=None):
+def Solver(quantified=False, name=None, logic=None, **kwargs):
     """Returns a solver."""
     return get_env().factory.Solver(quantified=quantified,
                                     name=name,
-                                    logic=logic)
+                                    logic=logic,
+                                    **kwargs)
 
 def UnsatCoreSolver(quantified=False, name=None, logic=None,
                     unsat_cores_mode="all"):

--- a/pysmt/smtlib/solver.py
+++ b/pysmt/smtlib/solver.py
@@ -41,20 +41,14 @@ class SmtLibSolver(Solver):
 
         # Initialize solver
         self.set_option(":print-success", "true")
-        self.set_option(":produce-models", "true")
+        if self.options.generate_models:
+            self.set_option(":produce-models", "true")
         # Redirect diagnostic output to stdout
         self.set_option(":diagnostic-output-channel", '"stdout"')
         if self.options is not None:
             for o,v in iteritems(self.options):
                 self.set_option(o,v)
         self.set_logic(logic)
-
-    def get_default_options(self, logic=None, user_options=None):
-        res = {}
-        for o,v in iteritems(user_options):
-            if o not in ["generate_models", "unsat_cores_mode"]:
-                res[o] = v
-        return res
 
     def set_option(self, name, value):
         self._send_silent_command(SmtLibCommand(smtcmd.SET_OPTION,

--- a/pysmt/solvers/bdd.py
+++ b/pysmt/solvers/bdd.py
@@ -35,7 +35,6 @@ from pysmt.solvers.qelim import QuantifierEliminator
 
 
 class BddOptions(SolverOptions):
-
     ## CUDD Reordering algorithms
     CUDD_REORDER_SAME, \
     CUDD_REORDER_NONE, \
@@ -62,37 +61,46 @@ class BddOptions(SolverOptions):
 
     CUDD_ALL_REORDERING_ALGORITHMS = range(1, 22)
 
-    def __init__(self,
-                 generate_models=True,
-                 unsat_cores_mode=None,
-                 static_ordering=None,
-                 dynamic_reordering=False,
-                 incremental=True,
-                 reordering_algorithm=CUDD_REORDER_SIFT):
+    VALID_OPTIONS = SolverOptions.VALID_OPTIONS + \
+                    [("static_ordering", None),
+                     ("dynamic_reordering", False),
+                     ("reordering_algorithm", CUDD_REORDER_SIFT),
+                    ]
 
-        if unsat_cores_mode is not None:
+    def __init__(self, **kwargs):
+        SolverOptions.__init__(self, **kwargs)
+
+        if self.unsat_cores_mode is not None:
             # Check if, for some reason, unsat cores are
             # required. In case, raise an error.
+            #
+            # TODO: This should be within the Solver, here we should
+            # only check that options are set and non-contraddicting.
+            #
             raise NotImplementedError("BddSolver does not "\
                                       "support unsat cores")
 
-        SolverOptions.__init__(self,
-                               generate_models=generate_models,
-                               unsat_cores_mode=None)
+    # @classmethod
+    # def from_base_options(cls, base_options):
+    #     generate_models=base_options.generate_models
+    #     unsat_cores_mode=base_options.unsat_cores_mode
+    #     incremental=base_options.incremental
+    #     return BddOptions(generate_models=generate_models,
+    #                       unsat_cores_mode=unsat_cores_mode,
+    #                       incremental=incremental)
 
-        self.static_ordering = static_ordering
-        self.dynamic_reordering = dynamic_reordering
-        self.reordering_algorithm = reordering_algorithm
 
 
 class BddSolver(Solver):
     LOGICS = [ pysmt.logics.QF_BOOL, pysmt.logics.BOOL ]
 
-    def __init__(self, environment, logic, user_options):
+    OptionsClass = BddOptions
+
+    def __init__(self, environment, logic, **options):
         Solver.__init__(self,
                         environment=environment,
                         logic=logic,
-                        user_options=user_options)
+                        **options)
 
         self.mgr = environment.formula_manager
         self.ddmanager = repycudd.DdManager()
@@ -121,13 +129,6 @@ class BddSolver(Solver):
 
         self.backtrack = []
         self.latest_model = None
-
-    def get_default_options(self, logic=None, user_options=None):
-        if user_options is not None:
-            return BddOptions(**user_options)
-        else:
-            return BddOptions()
-
 
     @clear_pending_pop
     def reset_assertions(self):

--- a/pysmt/solvers/bdd.py
+++ b/pysmt/solvers/bdd.py
@@ -67,6 +67,7 @@ class BddOptions(SolverOptions):
                  unsat_cores_mode=None,
                  static_ordering=None,
                  dynamic_reordering=False,
+                 incremental=True,
                  reordering_algorithm=CUDD_REORDER_SIFT):
 
         if unsat_cores_mode is not None:

--- a/pysmt/solvers/btor.py
+++ b/pysmt/solvers/btor.py
@@ -45,11 +45,11 @@ class BoolectorSolver(IncrementalTrackingSolver,
 
     LOGICS = [QF_BV, QF_UFBV]
 
-    def __init__(self, environment, logic, user_options):
+    def __init__(self, environment, logic, **options):
         IncrementalTrackingSolver.__init__(self,
                                            environment=environment,
                                            logic=logic,
-                                           user_options=user_options)
+                                           **options)
 
         self.btor = boolector.Boolector()
 

--- a/pysmt/solvers/btor.py
+++ b/pysmt/solvers/btor.py
@@ -52,8 +52,13 @@ class BoolectorSolver(IncrementalTrackingSolver,
                                            user_options=user_options)
 
         self.btor = boolector.Boolector()
+
+        self.btor.Set_opt("model_gen", 0)
+        # Disabling Incremental usage is not allowed.
+        # This needs to be set to 1
         self.btor.Set_opt("incremental", 1)
-        self.btor.Set_opt("model_gen", 1)
+        if self.options.generate_models:
+            self.btor.Set_opt("model_gen", 1)
         self.converter = BTORConverter(environment, self.btor)
         self.mgr = environment.formula_manager
         self.declarations = {}

--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -38,11 +38,11 @@ from pysmt.decorators import catch_conversion_error
 class CVC4Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
     LOGICS = PYSMT_QF_LOGICS
 
-    def __init__(self, environment, logic, user_options):
+    def __init__(self, environment, logic, **options):
         Solver.__init__(self,
                         environment=environment,
                         logic=logic,
-                        user_options=user_options)
+                        **options)
         self.em = CVC4.ExprManager()
         self.cvc4 = None
         self.declarations = None

--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -45,7 +45,13 @@ class CVC4Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
                         user_options=user_options)
         self.em = CVC4.ExprManager()
         self.cvc4 = CVC4.SmtEngine(self.em)
-        self.cvc4.setOption("produce-models", CVC4.SExpr("true"))
+        self.cvc4.setOption("produce-models", CVC4.SExpr("false"))
+        self.cvc4.setOption("incremental", CVC4.SExpr("false"))
+
+        if self.options.generate_models:
+            self.cvc4.setOption("produce-models", CVC4.SExpr("true"))
+        if self.options.incremental:
+            self.cvc4.setOption("incremental", CVC4.SExpr("true"))
 
         self.logic_name = str(logic)
         if self.logic_name == "QF_BOOL":
@@ -97,6 +103,12 @@ class CVC4Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
         return
 
     def push(self, levels=1):
+        if not self.options.incremental:
+            # The exceptions from CVC4 are not raised correctly
+            # (probably due to the wrapper)
+            # Therefore, we need to check that we can actually do a push
+            raise NotImplementedError("The solver is not incremental")
+
         for _ in xrange(levels):
             self.cvc4.push()
         return

--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -44,27 +44,25 @@ class CVC4Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
                         logic=logic,
                         user_options=user_options)
         self.em = CVC4.ExprManager()
-        self.cvc4 = CVC4.SmtEngine(self.em)
-        self.cvc4.setOption("produce-models", CVC4.SExpr("false"))
-        self.cvc4.setOption("incremental", CVC4.SExpr("false"))
-
-        if self.options.generate_models:
-            self.cvc4.setOption("produce-models", CVC4.SExpr("true"))
-        if self.options.incremental:
-            self.cvc4.setOption("incremental", CVC4.SExpr("true"))
-
+        self.cvc4 = None
+        self.declarations = None
         self.logic_name = str(logic)
         if self.logic_name == "QF_BOOL":
             self.logic_name = "QF_LRA"
-        self.cvc4.setLogic(self.logic_name)
+
+        self.reset_assertions()
         self.converter = CVC4Converter(environment, cvc4_exprMgr=self.em)
-        self.declarations = set()
         return
 
     def reset_assertions(self):
         del self.cvc4
         self.cvc4 = CVC4.SmtEngine(self.em)
-        self.cvc4.setOption("produce-models", CVC4.SExpr("true"))
+        self.cvc4.setOption("produce-models", CVC4.SExpr("false"))
+        self.cvc4.setOption("incremental", CVC4.SExpr("false"))
+        if self.options.generate_models:
+            self.cvc4.setOption("produce-models", CVC4.SExpr("true"))
+        if self.options.incremental:
+            self.cvc4.setOption("incremental", CVC4.SExpr("true"))
         self.declarations = set()
         self.cvc4.setLogic(self.logic_name)
 

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -132,17 +132,17 @@ class MathSAT5Model(Model):
         """Returns whether the model contains a value for 'x'."""
         return x in (v for v, _ in self)
 
-
 class MathSAT5Solver(IncrementalTrackingSolver, UnsatCoreSolver,
                      SmtLibBasicSolver, SmtLibIgnoreMixin):
 
     LOGICS = PYSMT_QF_LOGICS
 
-    def __init__(self, environment, logic, user_options=None, debugFile=None):
+    def __init__(self, environment, logic, debugFile=None, **options):
+        # TODO: DebugFile should be an option
         IncrementalTrackingSolver.__init__(self,
                                            environment=environment,
                                            logic=logic,
-                                           user_options=user_options)
+                                           **options)
 
         self.msat_config = mathsat.msat_create_default_config(str(logic))
         self._prepare_config(self.options, debugFile)

--- a/pysmt/solvers/pico.py
+++ b/pysmt/solvers/pico.py
@@ -38,11 +38,11 @@ class PicosatSolver(Solver):
 
     LOGICS = [ pysmt.logics.QF_BOOL ]
 
-    def __init__(self, environment, logic, user_options):
+    def __init__(self, environment, logic, **options):
         Solver.__init__(self,
                         environment=environment,
                         logic=logic,
-                        user_options=user_options)
+                        **options)
 
         self.mgr = environment.formula_manager
         self.pico = picosat.picosat_init()

--- a/pysmt/solvers/solver.py
+++ b/pysmt/solvers/solver.py
@@ -41,7 +41,9 @@ class Solver(object):
     def get_default_options(self, logic=None, user_options=None):
         res = SolverOptions()
         if user_options is not None:
-            for k in ["generate_models", "unsat_cores_mode"]:
+            for k in ["generate_models",
+                      "unsat_cores_mode",
+                      "incremental"]:
                 if k in user_options:
                     setattr(res, k, user_options[k])
         return res
@@ -71,6 +73,7 @@ class Solver(object):
             self.add_assertion(formula)
             res = self.solve()
             self.pending_pop = True
+
         return res
 
     def is_valid(self, formula):
@@ -477,6 +480,8 @@ class Converter(object):
 
 class SolverOptions(object):
     """Abstract class to represent Solver Options."""
-    def __init__(self, generate_models=True, unsat_cores_mode=None):
+    def __init__(self, generate_models=True, unsat_cores_mode=None,
+                 incremental = False):
         self.generate_models = generate_models
         self.unsat_cores_mode = unsat_cores_mode
+        self.incremental = incremental

--- a/pysmt/solvers/yices.py
+++ b/pysmt/solvers/yices.py
@@ -69,11 +69,11 @@ class YicesSolver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
 
     LOGICS = pysmt.logics.PYSMT_QF_LOGICS
 
-    def __init__(self, environment, logic, user_options):
+    def __init__(self, environment, logic, **options):
         Solver.__init__(self,
                         environment=environment,
                         logic=logic,
-                        user_options=user_options)
+                        **options)
 
         self.declarations = set()
 

--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -142,11 +142,11 @@ class Z3Solver(IncrementalTrackingSolver, UnsatCoreSolver,
 
     LOGICS = PYSMT_LOGICS
 
-    def __init__(self, environment, logic, user_options):
+    def __init__(self, environment, logic, **options):
         IncrementalTrackingSolver.__init__(self,
                                            environment=environment,
                                            logic=logic,
-                                           user_options=user_options)
+                                           **options)
         # Here we could use:
         # self.z3 = z3.SolverFor(str(logic))
         # But it seems to have problems with quantified formulae

--- a/pysmt/test/smtlib/parser_utils.py
+++ b/pysmt/test/smtlib/parser_utils.py
@@ -104,8 +104,7 @@ def execute_script_fname(smtfile, logic, expected_result):
     parser = SmtLibParser()
     script = parser.get_script_fname(smtfile)
     try:
-        log = script.evaluate(Solver(logic=logic,
-                                     options={"incremental": False}))
+        log = script.evaluate(Solver(logic=logic, incremental=False))
     except NoSolverAvailableError:
         raise SkipTest("No solver for logic %s." % logic)
 

--- a/pysmt/test/smtlib/parser_utils.py
+++ b/pysmt/test/smtlib/parser_utils.py
@@ -18,7 +18,7 @@
 import os
 
 from pysmt.test import SkipTest
-from pysmt.shortcuts import Solver, reset_env
+from pysmt.shortcuts import get_env, reset_env
 from pysmt.smtlib.parser import SmtLibParser
 from pysmt.smtlib.script import check_sat_filter
 from pysmt.logics import QF_LIA, QF_LRA, LRA, QF_UFLIRA, QF_UFBV, QF_BV
@@ -99,11 +99,13 @@ def execute_script_fname(smtfile, logic, expected_result):
     """Read and call a Solver to solve the instance"""
 
     reset_env()
+    Solver = get_env().factory.Solver
     assert os.path.exists(smtfile), smtfile
     parser = SmtLibParser()
     script = parser.get_script_fname(smtfile)
     try:
-        log = script.evaluate(Solver(logic=logic))
+        log = script.evaluate(Solver(logic=logic,
+                                     options={"incremental": False}))
     except NoSolverAvailableError:
         raise SkipTest("No solver for logic %s." % logic)
 

--- a/pysmt/test/test_bdd.py
+++ b/pysmt/test/test_bdd.py
@@ -15,11 +15,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import pysmt
 from pysmt.shortcuts import And, Not, Symbol, Bool, Exists, Solver
 from pysmt.shortcuts import get_env, qelim, Or
 from pysmt.test import TestCase, skipIfSolverNotAvailable, main
 from pysmt.test.examples import EXAMPLE_FORMULAS
+from pysmt.logics import BOOL
 
 class TestBdd(TestCase):
 
@@ -27,7 +27,7 @@ class TestBdd(TestCase):
     def setUp(self):
         self.x, self.y = Symbol("x"), Symbol("y")
 
-        self.bdd_solver = Solver(logic=pysmt.logics.BOOL,
+        self.bdd_solver = Solver(logic=BOOL,
                                  name='bdd')
         self.bdd_converter = self.bdd_solver.converter
 
@@ -66,7 +66,7 @@ class TestBdd(TestCase):
     def test_examples_conversion(self):
         convert = self.bdd_converter.convert
         for example in EXAMPLE_FORMULAS:
-            if example.logic != pysmt.logics.BOOL:
+            if example.logic != BOOL:
                 continue
             expr = convert(example.expr)
             self.assertIsNotNone(expr)
@@ -74,9 +74,9 @@ class TestBdd(TestCase):
     @skipIfSolverNotAvailable("bdd")
     def test_examples_solving(self):
         for example in EXAMPLE_FORMULAS:
-            if example.logic != pysmt.logics.BOOL:
+            if example.logic != BOOL:
                 continue
-            solver = Solver(logic=pysmt.logics.BOOL,
+            solver = Solver(logic=BOOL,
                             name='bdd')
             solver.add_assertion(example.expr)
             if example.is_sat:
@@ -119,32 +119,30 @@ class TestBdd(TestCase):
 
     @skipIfSolverNotAvailable("bdd")
     def test_reordering(self):
-        from pysmt.solvers.bdd import BddSolver
-        with BddSolver(get_env(), pysmt.logics.BOOL,
-                       dynamic_reordering=True) as s:
+        with Solver(name="bdd", logic=BOOL,
+                    dynamic_reordering=True) as s:
             s.add_assertion(self.big_tree)
             self.assertTrue(s.solve())
 
     @skipIfSolverNotAvailable("bdd")
     def test_reordering_algorithms(self):
-        from pysmt.solvers.bdd import BddSolver, BddOptions
+        from pysmt.solvers.bdd import BddOptions
         for algo in BddOptions.CUDD_ALL_REORDERING_ALGORITHMS:
-            with BddSolver(get_env(), pysmt.logics.BOOL,
-                           dynamic_reordering=True,
-                           reordering_algorithm=algo) as s:
+            with Solver(name="bdd", logic=BOOL,
+                        dynamic_reordering=True,
+                        reordering_algorithm=algo) as s:
                 s.add_assertion(self.big_tree)
                 self.assertTrue(s.solve())
                 self.assertEquals(algo, s.ddmanager.ReorderingStatus()[1])
 
     @skipIfSolverNotAvailable("bdd")
     def test_fixed_ordering(self):
-        from pysmt.solvers.bdd import BddSolver
         f_order = [self.x, self.y]
         r_order = list(reversed(f_order))
 
         for order in [f_order, r_order]:
-            with BddSolver(get_env(), pysmt.logics.BOOL,
-                           static_ordering=order) as s:
+            with Solver(name="bdd", logic=BOOL,
+                        static_ordering=order) as s:
                 s.add_assertion(self.big_tree)
                 self.assertTrue(s.solve())
 
@@ -156,15 +154,13 @@ class TestBdd(TestCase):
 
     @skipIfSolverNotAvailable("bdd")
     def test_invalid_ordering(self):
-        from pysmt.solvers.bdd import BddSolver
         with self.assertRaises(ValueError):
-            BddSolver(get_env(), pysmt.logics.BOOL,
-                      static_ordering=[And(self.x, self.y), self.y])
+            Solver(name="bdd", logic=BOOL,
+                   static_ordering=[And(self.x, self.y), self.y])
 
     @skipIfSolverNotAvailable("bdd")
     def test_initial_ordering(self):
-        from pysmt.solvers.bdd import BddSolver
-        with BddSolver(get_env(), pysmt.logics.BOOL,
+        with Solver(name="bdd", logic=BOOL,
                        static_ordering=[self.x, self.y],
                        dynamic_reordering=True) as s:
             s.add_assertion(self.big_tree)

--- a/pysmt/test/test_bdd.py
+++ b/pysmt/test/test_bdd.py
@@ -21,7 +21,6 @@ from pysmt.shortcuts import get_env, qelim, Or
 from pysmt.test import TestCase, skipIfSolverNotAvailable, main
 from pysmt.test.examples import EXAMPLE_FORMULAS
 
-
 class TestBdd(TestCase):
 
     @skipIfSolverNotAvailable("bdd")
@@ -122,7 +121,7 @@ class TestBdd(TestCase):
     def test_reordering(self):
         from pysmt.solvers.bdd import BddSolver
         with BddSolver(get_env(), pysmt.logics.BOOL,
-                       {"dynamic_reordering" : True}) as s:
+                       dynamic_reordering=True) as s:
             s.add_assertion(self.big_tree)
             self.assertTrue(s.solve())
 
@@ -131,8 +130,8 @@ class TestBdd(TestCase):
         from pysmt.solvers.bdd import BddSolver, BddOptions
         for algo in BddOptions.CUDD_ALL_REORDERING_ALGORITHMS:
             with BddSolver(get_env(), pysmt.logics.BOOL,
-                           {"dynamic_reordering" : True,
-                            "reordering_algorithm" : algo}) as s:
+                           dynamic_reordering=True,
+                           reordering_algorithm=algo) as s:
                 s.add_assertion(self.big_tree)
                 self.assertTrue(s.solve())
                 self.assertEquals(algo, s.ddmanager.ReorderingStatus()[1])
@@ -145,7 +144,7 @@ class TestBdd(TestCase):
 
         for order in [f_order, r_order]:
             with BddSolver(get_env(), pysmt.logics.BOOL,
-                           {"static_ordering" : order}) as s:
+                           static_ordering=order) as s:
                 s.add_assertion(self.big_tree)
                 self.assertTrue(s.solve())
 
@@ -155,25 +154,23 @@ class TestBdd(TestCase):
                     perm = s.ddmanager.ReadPerm(var_idx)
                     self.assertEqual(pos, perm)
 
-
-
     @skipIfSolverNotAvailable("bdd")
     def test_invalid_ordering(self):
         from pysmt.solvers.bdd import BddSolver
         with self.assertRaises(ValueError):
             BddSolver(get_env(), pysmt.logics.BOOL,
-                      {"static_ordering" : [And(self.x, self.y), self.y]})
-
+                      static_ordering=[And(self.x, self.y), self.y])
 
     @skipIfSolverNotAvailable("bdd")
     def test_initial_ordering(self):
         from pysmt.solvers.bdd import BddSolver
         with BddSolver(get_env(), pysmt.logics.BOOL,
-                       {"static_ordering" : [self.x, self.y],
-                        "dynamic_reordering" : True}) as s:
+                       static_ordering=[self.x, self.y],
+                       dynamic_reordering=True) as s:
             s.add_assertion(self.big_tree)
             self.assertTrue(s.solve())
             self.assertNotEquals(s.ddmanager.ReorderingStatus()[1], 0)
+
 
 if __name__ == '__main__':
     main()

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -112,7 +112,6 @@ class TestRegressions(TestCase):
         f_or_many = Or(ten_x)
         f_plus_many = LT(Plus(r,r,r,r,r,r,r,r,r,r,r), Real(0))
 
-
         for name in get_env().factory.all_solvers(logic=logics.QF_BOOL):
             self.assertSat(f_and_one, solver_name=name)
             self.assertSat(f_or_one, solver_name=name)

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -400,7 +400,6 @@ class TestBasic(TestCase):
 
         for sname in get_env().factory.all_solvers(logic=QF_UFLIRA):
             with Solver(name=sname) as solver:
-                print(sname)
                 # First hr
                 solver.add_assertion(f)
                 res = solver.solve()
@@ -485,6 +484,14 @@ class TestBasic(TestCase):
         self.assertTrue(is_sat(x, logic=None))
         self.assertTrue(is_sat(x))
 
+    @skipIfNoSolverForLogic(QF_BOOL)
+    def test_solver_options(self):
+        # Options are kwargs of the Solver() constructor.
+        solver = Solver(logic=QF_BOOL, incremental=True)
+        self.assertIsNotNone(solver)
+        # Options are enforced at construction time
+        with self.assertRaises(ValueError):
+            Solver(logic=QF_BOOL, invalid_option=False)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
!!! Breaking change !!!
Options are now free keyword arguments in the Solver() constructor.

- The parameter ```user_options``` has been removed
- The function ```get_default_options``` has been removed
- The class SolverOptions is used to validate these options. The rest of option handling has been simplified accordingly.

Calls to Factory methods now set meaningful defaults:

- Calls to Factory.is_* are setting the options for model generation and incrementality to False
- Calls to Factory.get_model are done enabling model generation, but disabling incrementality
- Factory.Solver, returns a solver with both model generation and incrementality enabled
