### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,10 +14,6 @@ pySMT: a Python API for SMT
            :target: https://pypi.python.org/pypi/pySMT/
            :alt: Latest PyPI version
 
-.. image:: https://img.shields.io/pypi/dm/pysmt.svg
-           :target: https://pypi.python.org/pypi/pySMT/
-           :alt: Monthly Downloads
-
 .. image:: https://img.shields.io/pypi/l/pysmt.svg
            :target: /LICENSE
            :alt: Apache License
@@ -108,9 +104,7 @@ following solvers are supported through native APIs:
 Additionally, you can use any SMT-LIB 2 compliant solver.
 
 PySMT assumes that the python bindings for the SMT Solver are
-installed and accessible from your ```PYTHONPATH```. For Yices 2 we
-rely on pyices (https://github.com/cheshire/pyices). For CUDD we use
-repycudd (https://github.com/pysmt/repycudd).
+installed and accessible from your ``PYTHONPATH``. 
 
 pySMT works on both Python 2 and Python 3. Some solvers support both
 versions (e.g., MathSAT) but in general, many solvers still support
@@ -128,7 +122,7 @@ be used to install the solvers: e.g.,
 
   $ pysmt-install --check
 
-will show you which solvers have been found in your ```PYTHONPATH```.
+will show you which solvers have been found in your ``PYTHONPATH``.
 PySMT does not depend directly on any solver, but if you want to
 perform solving, you need to have at least one solver installed. This
 can be used by PySMT via its native API, or passing through an SMT-LIB
@@ -145,14 +139,9 @@ refer to the documentation of each solver to understand how to install
 it with its python bindings. Nevertheless, we try to keep
 *pysmt/cmd/install.py* as readable and documented as possible.
 
-For CVC4 we have a patch that needs to be applied. The patches are
-available in the repository 'pysmt/solvers_patches' and should be
-applied against the following versions of the solvers:
+For Yices, picosat, and CUDD, we use external wrappers:
 
-- CVC4: Git revision 68f22235a62f5276b206e9a6692a85001beb8d42
-
-For picosat and cudd, we use custom wrappers:
-
+- pyices (https://github.com/cheshire/pyices)
 - repycudd (https://github.com/pysmt/repycudd)
 - pyPicoSAT (https://github.com/pysmt/pyPicoSAT)
 
@@ -160,22 +149,28 @@ For instruction on how to use any SMT-LIB complaint solver with pySMT
 see `examples/generic_smtlib.py </examples/generic_smtlib.py>`_
 
 The following table summarizes the features supported via pySMT for
-each of the available solvers. (We indicate with square brackets the
-features that are supported by the solver itself by not by the current
-wrapper used within pySMT).
+each of the available solvers.
 
-  =================   ==========   ==================   ==============   ==================   ==========
-  Solver              pySMT name   Supported Logics     Satisfiability   Model Construction   UNSAT-Core
-  =================   ==========   ==================   ==============   ==================   ==========
-  MathSAT             msat         QF_UFLIRA, QF_BV     Yes              Yes                  Yes
-  Z3                  z3           UFLIRA, QF_BV        Yes              Yes                  Yes
-  CVC4                cvc4         QF_UFLIRA, QF_BV     Yes              Yes                  No
-  Yices               yices        QF_UFLIRA, QF_BV     Yes              Yes                  No
-  SMT-Lib Interface   <custom>     UFLIRA, [QF_BV]      Yes              Yes                  No [Yes]
-  PicoSAT             picosat      QF_BOOL              Yes              Yes                  No [Yes]
-  Boolector           btor         QF_UFBV              Yes              Yes                  No
-  BDD (CUDD)          bdd          BOOL                 Yes              Yes                  No
-  =================   ==========   ==================   ==============   ==================   ==========
+ +------------------+------------+----------------------+------------+
+ | Solver           | pySMT name |  Supported Theories  | Quantifiers|
+ +==================+============+======================+============+
+ | MathSAT          |   msat     | UF, LIA, LRA, BV, AX |  No        |         
+ +------------------+------------+----------------------+------------+
+ | Z3               |   z3       | UF, LIA, LRA, BV, AX |  Yes       | 
+ +------------------+------------+----------------------+------------+
+ | CVC4             |   cvc4     | UF, LIA, LRA, BV, AX |  Yes       |
+ +------------------+------------+----------------------+------------+
+ | Yices            |   yices    | UF, LIA, LRA, BV     |  No        | 
+ +------------------+------------+----------------------+------------+
+ | SMT-Lib Interface|   <custom> | UF, LIA, LRA, BV, AX |  Yes       | 
+ +------------------+------------+----------------------+------------+
+ | PicoSAT          |   picosat  | [None]               |  No        | 
+ +------------------+------------+----------------------+------------+
+ | Boolector        |   btor     | UF, BV, AX           |  No        | 
+ +------------------+------------+----------------------+------------+
+ | BDD (CUDD)       |   bdd      | [None]               |  Yes       | 
+ +------------------+------------+----------------------+------------+
+
 
 The following table summarizes the features supported via pySMT for
 each of the available quantifier eliminators
@@ -189,8 +184,9 @@ each of the available quantifier eliminators
   BDD (CUDD)              bdd          BOOL
   =====================   ==========   ================
 
-The following table summarizes the features supported via pySMT for
-each of the available Craig interpolators
+Unsat-Core extraction is currently supported on: MathSAT and Z3.
+
+The following table summarizes the features supported via pySMT for each of the available Craig interpolators
 
   ============   ==========   =========================
   Interpolator   pySMT name   Supported Logics


### PR DESCRIPTION
- Removed bit about using a patch for CVC4. This is not true anymore, since the changes have been incorporated up-stream.
- Clarified when we use wrappers that are not part of the tool itself
- Improved table with theories including Arrays
- Remove pypi download counter badge, since it is not updated anymore
