### PR TITLE
Issue 228: Enable Infix Notation with shortcuts.py

### DIFF
--- a/examples/infix_notation.py
+++ b/examples/infix_notation.py
@@ -8,8 +8,14 @@ from pysmt.shortcuts import get_env, Solver
 from pysmt.shortcuts import Symbol, And, Plus, Int
 from pysmt.typing import INT
 
-# Infix-Notation is disable by default
-get_env().enable_infix_notation = True
+# Infix-Notation is automatically enabled whenever you import pysmt.shortcuts.
+#
+# To enable it without using shortcuts, do:
+#
+#   get_env().enable_infix_notation = True
+#
+# Similarly, you can disable infix_notation to prevent its accidental use.
+#
 
 hello = [Symbol(s, INT) for s in "hello"]
 world = [Symbol(s, INT) for s in "world"]

--- a/pysmt/decorators.py
+++ b/pysmt/decorators.py
@@ -18,7 +18,6 @@
 from functools import wraps
 import warnings
 
-import pysmt.shortcuts
 import pysmt.exceptions
 
 class deprecated(object):
@@ -72,7 +71,7 @@ def typecheck_result(f):
     @wraps(f)
     def typecheck_result_wrap(*args, **kwargs):
         res = f(*args, **kwargs)
-        pysmt.shortcuts.get_type(res)
+        res.get_type() # This raises an exception if an invalid type is found
     return typecheck_result_wrap
 
 def catch_conversion_error(f):

--- a/pysmt/shortcuts.py
+++ b/pysmt/shortcuts.py
@@ -34,6 +34,7 @@ import pysmt.typing as types
 import pysmt.configuration as config
 import pysmt.environment
 
+
 def get_env():
     """Returns the global environment."""
     return pysmt.environment.get_env()
@@ -41,6 +42,9 @@ def get_env():
 def reset_env():
     """Resets the global environment, and returns the new one."""
     return pysmt.environment.reset_env()
+
+# Enable by default infix notation
+get_env().enable_infix_notation = True
 
 ##### Shortcuts for FormulaManager #####
 def get_type(formula):
@@ -302,7 +306,6 @@ def BVSub(left, right):
     """Returns the difference of two BV."""
     return get_env().formula_manager.BVSub(left, right)
 
-
 def BVMul(left, right):
     """Returns the product of two BV."""
     return get_env().formula_manager.BVMul(left, right)
@@ -378,8 +381,6 @@ def BVAShr(left, right):
     """Returns the RIGHT arithmetic rotation of the left BV by the number
         of steps specified by the right BV."""
     return get_env().formula_manager.BVAShr(left, right)
-
-
 
 
 #### Shortcuts for Solvers Factory #####

--- a/pysmt/solvers/solver.py
+++ b/pysmt/solvers/solver.py
@@ -15,7 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import pysmt.shortcuts
 from pysmt.typing import BOOL
 from pysmt.exceptions import SolverReturnedUnknownResultError
 from six.moves import xrange
@@ -267,8 +266,7 @@ class Solver(object):
 
         Raises TypeError.
         """
-        t = pysmt.shortcuts.get_type(formula)
-        if t != BOOL:
+        if formula.get_type() != BOOL:
             raise TypeError("Argument must be boolean.")
 
 

--- a/pysmt/type_checker.py
+++ b/pysmt/type_checker.py
@@ -26,8 +26,6 @@ from six.moves import xrange
 
 import pysmt.walkers as walkers
 import pysmt.operators as op
-import pysmt.shortcuts
-
 from pysmt.typing import BOOL, REAL, INT, BVType
 
 
@@ -248,37 +246,33 @@ class SimpleTypeChecker(walkers.DagWalker):
 
 def assert_no_boolean_in_args(args):
     """ Enforces that the elements in args are not of BOOL type."""
-    get_type = pysmt.shortcuts.get_type
     for arg in args:
-        if (get_type(arg) == BOOL):
+        if (arg.get_type() == BOOL):
             raise TypeError("Boolean Expressions are not allowed in arguments")
 
 
 def assert_boolean_args(args):
     """ Enforces that the elements in args are of BOOL type. """
-    get_type = pysmt.shortcuts.get_type
     for arg in args:
-        t = get_type(arg)
+        t = arg.get_type()
         if (t != BOOL):
             raise TypeError("%s is not allowed in arguments" % t)
 
 
 def assert_same_type_args(args):
     """ Enforces that all elements in args have the same type. """
-    get_type = pysmt.shortcuts.get_type
-    ref_t = get_type(args[0])
+    ref_t = args[0].get_type()
     for arg in args[1:]:
-        t = get_type(arg)
+        t = arg.get_type()
         if (t != ref_t):
             raise TypeError("Arguments should be of the same type!\n" +
-                             str([str((a, get_type(a))) for a in args]))
+                             str([str((a, a.get_type())) for a in args]))
 
 
 def assert_args_type_in(args, allowed_types):
     """ Enforces that the type of the arguments is an allowed type """
-    get_type = pysmt.shortcuts.get_type
     for arg in args:
-        t = get_type(arg)
+        t = arg.get_type()
         if (t not in allowed_types):
             raise TypeError(
                 "Argument is of type %s, but one of %s was expected!\n" %


### PR DESCRIPTION
Infix notation is automatically enabled when importing shortcuts.py. Internal modules from pysmt should not import shortcuts, and thus still need to explicitely enable infix notation. However, from the user point of view, it becomes more immediate to use it.

There are still some dependencies with the global Type-checker, that we might want to address (however, they are sound).

Updated the example on infix notation accordingly.