### PR TITLE
install.py: Improved installed solvers analysis

### DIFF
--- a/pysmt/cmd/installers/bdd.py
+++ b/pysmt/cmd/installers/bdd.py
@@ -69,15 +69,14 @@ class CuddInstaller(SolverInstaller):
 
     def get_installed_version(self):
         with TemporaryPath([self.bindings_dir]):
+            version = None
             try:
                 import repycudd
                 doc = repycudd.DOCSTRING
                 m = re.match(r"^PyCUDD (\d+\.\d+\.\d+).*", doc)
-                if m is None:
-                    return None
-                return m.group(1)
-            except ImportError:
+                if m is not None:
+                    version = m.group(1)
+            finally:
                 if "repycudd" in sys.modules:
                     del sys.modules["repycudd"]
-                return None
-        return None
+                return version

--- a/pysmt/cmd/installers/btor.py
+++ b/pysmt/cmd/installers/btor.py
@@ -58,17 +58,13 @@ class BtorInstaller(SolverInstaller):
 
     def get_installed_version(self):
         with TemporaryPath([self.bindings_dir]):
+            version = None
+            vfile = os.path.join(self.extract_path, "boolector", "VERSION")
             try:
                 import boolector
-
-                with open(os.path.join(self.extract_path, "boolector", "VERSION")) as f:
-                    return f.read().strip()
-
-            except ImportError:
+                with open(vfile) as f:
+                    version = f.read().strip()
+            finally:
                 if "boolector" in sys.modules:
                     del sys.modules["boolector"]
-                return None
-            except IOError:
-                return None
-
-        return None
+                return version

--- a/pysmt/cmd/installers/cvc4.py
+++ b/pysmt/cmd/installers/cvc4.py
@@ -62,10 +62,11 @@ class CVC4Installer(SolverInstaller):
 
     def get_installed_version(self):
         with TemporaryPath([self.bindings_dir]):
+            version = None
             try:
                 import CVC4
-                return CVC4.Configuration_getVersionString()
-            except ImportError:
+                version = CVC4.Configuration_getVersionString()
+            finally:
                 if "CVC4" in sys.modules:
                     del sys.modules["CVC4"]
-                return None
+                return version

--- a/pysmt/cmd/installers/msat.py
+++ b/pysmt/cmd/installers/msat.py
@@ -58,14 +58,14 @@ class MSatInstaller(SolverInstaller):
 
     def get_installed_version(self):
         with TemporaryPath([self.bindings_dir]):
+            version = None
             try:
                 import mathsat
                 version_str = mathsat.msat_get_version()
                 m = re.match(r"^MathSAT5 version (\d+\.\d+\.\d+) .*$", version_str)
-                if m is None:
-                    return None
-                return m.group(1)
-            except ImportError:
+                if m is not None:
+                    version = m.group(1)
+            finally:
                 if "mathsat" in sys.modules:
                     del sys.modules["mathsat"]
-                return None
+                return version

--- a/pysmt/cmd/installers/pico.py
+++ b/pysmt/cmd/installers/pico.py
@@ -39,10 +39,11 @@ class PicoSATInstaller(SolverInstaller):
 
     def get_installed_version(self):
         with TemporaryPath([self.bindings_dir]):
+            version = None
             try:
                 import picosat
-                return picosat.picosat_version()
-            except ImportError:
+                version = picosat.picosat_version()
+            finally:
                 if "picosat" in sys.modules:
                     del sys.modules["picosat"]
-                return None
+                return version

--- a/pysmt/cmd/installers/yices.py
+++ b/pysmt/cmd/installers/yices.py
@@ -73,14 +73,14 @@ class YicesInstaller(SolverInstaller):
 
     def get_installed_version(self):
         with TemporaryPath([self.bindings_dir]):
+            version = None
             try:
                 import yicespy
                 v = yicespy.__dict__['__YICES_VERSION']
                 m = yicespy.__dict__['__YICES_VERSION_MAJOR']
                 p = yicespy.__dict__['__YICES_VERSION_PATCHLEVEL']
-                return "%d.%d.%d" % (v, m, p)
-            except ImportError:
+                version = "%d.%d.%d" % (v, m, p)
+            finally:
                 if "yicespy" in sys.modules:
                     del sys.modules["yicespy"]
-                return None
-        return None
+                return version

--- a/pysmt/cmd/installers/z3.py
+++ b/pysmt/cmd/installers/z3.py
@@ -62,12 +62,12 @@ class Z3Installer(SolverInstaller):
 
     def get_installed_version(self):
         with TemporaryPath([self.bindings_dir]):
+            version = None
             try:
                 import z3
                 (major, minor, ver, _) = z3.get_version()
-                return "%d.%d.%d" % (major, minor, ver)
-            except ImportError:
+                version = "%d.%d.%d" % (major, minor, ver)
+            finally:
                 if "z3" in sys.modules:
                     del sys.modules["z3"]
-                return None
-        return None
+                return version

--- a/pysmt/factory.py
+++ b/pysmt/factory.py
@@ -412,6 +412,19 @@ class Factory(object):
         """
         return self._filter_solvers(self._all_unsat_core_solvers, logic=logic)
 
+    def all_interpolators(self, logic=None):
+        """
+        Returns a dict <solver_name, solver_class> including all and only
+        the solvers supporting interpolation and directly or
+        indirectly supporting the given logic.  A solver supports a
+        logic if either the given logic is declared in the LOGICS
+        class field or if a logic subsuming the given logic is
+        declared in the LOGICS class field.
+
+        If logic is None, the map will contain all the known solvers
+        """
+        return self._filter_solvers(self._all_interpolators, logic=logic)
+
 
 
     ##


### PR DESCRIPTION
- install.py --check  now takes into account the bindings_dir and prints the version of the installed solver
- There is a distinction btw installed solvers and solvers in the python's path.
- Qelim, Unsat-Core and Interpolants are also visualized (but not checked)

See issue #277 