### PR TITLE
Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ addons:
     - python3-all-dev
 
 python:
-#  - 2.7 # TO RE-ENABLE BEFORE MERGING TO MASTER
+  - 2.7
   - 3.5
   - pypy
 
@@ -65,9 +65,6 @@ matrix:
       env: PYSMT_SOLVER="z3_wrap"
 
   exclude:
-    - python: 3.5
-      env: PYSMT_SOLVER="all"
-
     - python: pypy
       env: PYSMT_SOLVER="msat"
     - python: pypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ addons:
     - python3-all-dev
 
 python:
-  - 2.7
-  - 3.4
+#  - 2.7 # TO RE-ENABLE BEFORE MERGING TO MASTER
+  - 3.5
   - pypy
 
 
@@ -65,13 +65,7 @@ matrix:
       env: PYSMT_SOLVER="z3_wrap"
 
   exclude:
-    - python: 3.4
-      env: PYSMT_SOLVER="cvc4"
-    - python: 3.4
-      env: PYSMT_SOLVER="yices"
-    - python: 3.4
-      env: PYSMT_SOLVER="bdd"
-    - python: 3.4
+    - python: 3.5
       env: PYSMT_SOLVER="all"
 
     - python: pypy
@@ -94,10 +88,10 @@ matrix:
 install:
   # This is for btor that fails to find the python 3 library to link
   - "export LIBRARY_PATH=${LIBRARY_PATH}:/opt/python/3.4.2/lib"
+  - "export LIBRARY_PATH=${LIBRARY_PATH}:/opt/python/3.5.2/lib"
   # For some reason, Travis CI cannot find the command python3.5-config.
   # Therefore, we force the path here
-  - if [ "${TRAVIS_PYTHON_VERSION}" == "3.5" ]; then export PATH=${PATH}:/opt/python/3.5.0/bin/ ; fi
-
+  - if [ "${TRAVIS_PYTHON_VERSION}" == "3.5" ]; then export PATH=${PATH}:/opt/python/3.5.2/bin/ ; fi
   - "pip install six"
   - if [ "${PYSMT_SOLVER}" == "all" ] || [ "${PYSMT_SOLVER}" == "btor" ]; then pip install cython; fi
   - "export BINDINGS_FOLDER=${HOME}/python_bindings/${PYSMT_SOLVER}"

--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -135,8 +135,9 @@ def parse_options():
                         type=str, default="~/.smt_solvers",
                         help='The folder to use for the installation')
 
+    py_bindings = "~/.smt_solvers/python-bindings-%d.%d" % sys.version_info[0:2]
     parser.add_argument('--bindings-path', dest='bindings_path',
-                        type=str, default="~/.smt_solvers/python_bindings",
+                        type=str, default=py_bindings,
                         help='The folder to use for the bindings')
 
     options = parser.parse_args()

--- a/pysmt/cmd/installers/base.py
+++ b/pysmt/cmd/installers/base.py
@@ -17,6 +17,7 @@ import sys
 import shutil
 import zipfile
 import tarfile
+import six
 
 from contextlib import contextmanager
 
@@ -200,7 +201,7 @@ class SolverInstaller(object):
             cmd = '{program}'
 
         if env_variables is not None:
-            for k,v in env_variables.iteritems():
+            for k,v in six.iteritems(env_variables):
                 cmd = "export %s='%s'; %s" % (k, v, cmd)
 
         os.system(cmd.format(directory=directory,

--- a/pysmt/cmd/installers/msat.py
+++ b/pysmt/cmd/installers/msat.py
@@ -40,6 +40,12 @@ class MSatInstaller(SolverInstaller):
 
 
     def compile(self):
+        # Download patched mathsat wrapper using SWIG3
+        # #255: This should be removed once PY3 compatibility is restore upstream
+        mathsat_wrap = "https://raw.githubusercontent.com/pysmt/solvers_patches/e1418d046a2f2f5ebb243e7167a6290e8e8b9b15/mathsat_python_wrap.c"
+        self.do_download(mathsat_wrap,
+                         os.path.join(self.python_bindings_dir, "mathsat_python_wrap.c"))
+        # End #255
         SolverInstaller.run_python("./setup.py build", self.python_bindings_dir)
 
 
@@ -54,6 +60,12 @@ class MSatInstaller(SolverInstaller):
             if f.endswith(".so"):
                 SolverInstaller.mv(os.path.join(sodir, f), self.bindings_dir)
         SolverInstaller.mv(os.path.join(pdir, "mathsat.py"), self.bindings_dir)
+
+        # Overwrite mathsat.py with PY3 compatible version
+        # #255: This should be removed once PY3 compatibility is restore upstream
+        mathsat_wrap = "https://raw.githubusercontent.com/pysmt/solvers_patches/e1418d046a2f2f5ebb243e7167a6290e8e8b9b15/mathsat.py"
+        self.do_download(mathsat_wrap,
+                         os.path.join(self.bindings_dir, "mathsat.py"))
 
 
     def get_installed_version(self):

--- a/pysmt/test/test_bdd.py
+++ b/pysmt/test/test_bdd.py
@@ -133,7 +133,7 @@ class TestBdd(TestCase):
                         reordering_algorithm=algo) as s:
                 s.add_assertion(self.big_tree)
                 self.assertTrue(s.solve())
-                self.assertEquals(algo, s.ddmanager.ReorderingStatus()[1])
+                self.assertEqual(algo, s.ddmanager.ReorderingStatus()[1])
 
     @skipIfSolverNotAvailable("bdd")
     def test_fixed_ordering(self):

--- a/pysmt/test/test_eager_model.py
+++ b/pysmt/test/test_eager_model.py
@@ -102,7 +102,7 @@ class TestEagerModel(TestCase):
             eager_model = EagerModel(z3_model)
             for var, value  in eager_model:
                 self.assertIn(var, [x,y,z])
-                self.assertEquals(value, TRUE())
+                self.assertEqual(value, TRUE())
 
 if __name__ == '__main__':
     main()

--- a/pysmt/test/test_formula.py
+++ b/pysmt/test/test_formula.py
@@ -948,7 +948,7 @@ class TestFormulaManager(TestCase):
         a1 = self.mgr.Array(INT, self.mgr.Int(0))
         a2 = self.mgr.Array(INT, self.mgr.Int(0),
                             {self.mgr.Int(12) : self.mgr.Int(0)})
-        self.assertEquals(a1, a2)
+        self.assertEqual(a1, a2)
 
 
 class TestShortcuts(TestCase):

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -221,7 +221,7 @@ class TestRegressions(TestCase):
         f1 = ExactlyOne(elems)
         f2 = ExactlyOne(e for e in elems)
 
-        self.assertEquals(f1, f2)
+        self.assertEqual(f1, f2)
 
     def test_determinism(self):
         def get_set(env):
@@ -247,7 +247,7 @@ class TestRegressions(TestCase):
                 # The ordering of the sets should be the same...
                 for i,f in enumerate(l1):
                     nf = new_env.formula_manager.normalize(f)
-                    self.assertEquals(nf, l_test[i])
+                    self.assertEqual(nf, l_test[i])
 
     def test_is_one(self):
         self.assertTrue(Int(1).is_one())
@@ -346,8 +346,8 @@ class TestRegressions(TestCase):
             x = Symbol("x", BVType(16))
             s.add_assertion(Equals(x, BV(1, 16)))
             self.assertTrue(s.solve())
-            self.assertEquals(s.get_value(Equals(x, BV(1, 16))), TRUE())
-            self.assertEquals(s.get_value(BVAdd(x, BV(1, 16))), BV(2, 16))
+            self.assertEqual(s.get_value(Equals(x, BV(1, 16))), TRUE())
+            self.assertEqual(s.get_value(BVAdd(x, BV(1, 16))), BV(2, 16))
 
     @skipIfSolverNotAvailable("btor")
     def test_btor_get_array_element(self):
@@ -356,7 +356,7 @@ class TestRegressions(TestCase):
             s.add_assertion(Equals(Select(x, BV(1, 16)), BV(1, 16)))
             s.add_assertion(Equals(Select(x, BV(2, 16)), BV(3, 16)))
             self.assertTrue(s.solve())
-            self.assertEquals(s.get_value(Select(x, BV(1, 16))), BV(1, 16))
+            self.assertEqual(s.get_value(Select(x, BV(1, 16))), BV(1, 16))
             self.assertIsNotNone(s.get_value(x))
 
 

--- a/pysmt/test/test_simplify.py
+++ b/pysmt/test/test_simplify.py
@@ -58,7 +58,7 @@ class TestSimplify(TestCase):
     def test_array_value(self):
         a1 = Array(INT, Int(0), {Int(12) : Int(10)})
         a2 = Store(Array(INT, Int(0)), Int(12), Int(10))
-        self.assertEquals(a1, a2.simplify())
+        self.assertEqual(a1, a2.simplify())
 
     @skipIfSolverNotAvailable("bdd")
     def test_bdd_simplify(self):

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -83,7 +83,7 @@ class TestBasic(TestCase):
         factory = get_env().factory
         factory.default_logic = QF_BOOL
 
-        self.assertEquals(factory.default_logic, QF_BOOL)
+        self.assertEqual(factory.default_logic, QF_BOOL)
         varA = Symbol("A", BOOL)
         varB = Symbol("B", BOOL)
 


### PR DESCRIPTION
This PR completes the support for python 3.5. With this, we support two versions of python: 2.7 and 3.5. All solvers have been extended/adjusted in order to work with python 3.5.