### PR TITLE
Travis/test examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
   apt: true
   directories:
   - ${HOME}/.smt_solvers/btor
+  - ${HOME}/.smt_solvers/bdd
   - ${HOME}/.cache/pip
   - ${HOME}/python_bindings/all
   - ${HOME}/python_bindings/msat

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,12 +57,10 @@ env:
     - PYSMT_SOLVER="picosat"
     - PYSMT_SOLVER="btor"
     - PYSMT_SOLVER="msat_wrap"
+    - PYSMT_SOLVER="z3_wrap"
 
 matrix:
   fast_finish: true
-  include:
-    - python: 2.7
-      env: PYSMT_SOLVER="z3_wrap"
 
   exclude:
     - python: pypy
@@ -95,8 +93,11 @@ install:
   - "mkdir -p ${BINDINGS_FOLDER}"
   - "python install.py --confirm-agreement --bindings-path ${BINDINGS_FOLDER}"
   - "eval `python install.py --env --bindings-path ${BINDINGS_FOLDER}`"
+  - if [ "${PYSMT_SOLVER}" == "all" ] || [ "${PYSMT_SOLVER}" == "z3_wrap" ]; then python install.py --z3 --conf --force; cp -v $(find ~/.smt_solvers/ -name z3 -type f) pysmt/test/smtlib/bin/z3; chmod +x pysmt/test/smtlib/bin/z3; mv pysmt/test/smtlib/bin/z3.solver.sh.template pysmt/test/smtlib/bin/z3.solver.sh ; fi
+  - if [ "${PYSMT_SOLVER}" == "all" ] || [ "${PYSMT_SOLVER}" == "msat_wrap" ]; then python install.py --msat --conf --force; cp -v $(find ~/.smt_solvers/ -name mathsat -type f) pysmt/test/smtlib/bin/mathsat; mv pysmt/test/smtlib/bin/mathsat.solver.sh.template pysmt/test/smtlib/bin/mathsat.solver.sh ; fi
 
 script:
   - "echo ${PYTHONPATH}"
   - "python install.py --check"
   - "nosetests pysmt -v"
+  - if [ "${PYSMT_SOLVER}" == "all" ]; then python install.py --msat --conf --force; cp -v $(find ~/.smt_solvers/ -name mathsat -type f) /tmp/mathsat; (for ex in `ls examples/*.py`; do echo $ex; python $ex || exit $?; done); fi

--- a/examples/einstein.py
+++ b/examples/einstein.py
@@ -36,8 +36,8 @@
 #
 # The question is: who owns the fish?
 
-from pysmt.shortcuts import Symbol, ExactlyOne, Implies, Or, And, FALSE, Iff
-from pysmt.shortcuts import get_model, get_unsat_core, is_sat
+from pysmt.shortcuts import Symbol, ExactlyOne, Or, And, FALSE, Iff
+from pysmt.shortcuts import get_model, get_unsat_core, is_sat, is_unsat
 
 #
 # Lets start by expliciting all values for all dimensions
@@ -163,6 +163,7 @@ if model is None:
     # are satisfiable in isolation.
     assert is_sat(facts)
     assert is_sat(domain)
+    assert is_unsat(problem)
 
     # In isolation they are both fine, rules from both are probably
     # interacting.

--- a/examples/generic_smtlib.py
+++ b/examples/generic_smtlib.py
@@ -32,7 +32,7 @@ logics = [QF_UFLRA, QF_UFIDL] # Some of the supported logics
 env = get_env()
 
 # Add the solver to the environment
-env.factory.add_generic_solver(name, path,logics)
+env.factory.add_generic_solver(name, path, logics)
 
 r, s = Symbol("r", REAL), Symbol("s", REAL)
 p, q = Symbol("p", INT), Symbol("q", INT)

--- a/examples/infix_notation.py
+++ b/examples/infix_notation.py
@@ -4,14 +4,15 @@
 # 1. Enable and use infix notation
 # 2. Use a solver context
 #
-from pysmt.shortcuts import get_env, Solver
 from pysmt.shortcuts import Symbol, And, Plus, Int
+from pysmt.shortcuts import Solver
 from pysmt.typing import INT
 
 # Infix-Notation is automatically enabled whenever you import pysmt.shortcuts.
 #
 # To enable it without using shortcuts, do:
 #
+#   from pysmt.environment import get_env
 #   get_env().enable_infix_notation = True
 #
 # Similarly, you can disable infix_notation to prevent its accidental use.

--- a/examples/model_checking.py
+++ b/examples/model_checking.py
@@ -8,6 +8,8 @@
 #
 # [2] ...
 #
+from six.moves import xrange
+
 from pysmt.shortcuts import Symbol, Not, Equals, And, Times, Int, Plus, LE
 from pysmt.shortcuts import is_sat, is_unsat
 from pysmt.typing import INT

--- a/examples/parallel.py
+++ b/examples/parallel.py
@@ -27,7 +27,7 @@
 # only when using multiprocessing.
 # To disable the warning see the python module warnings.
 #
-from multiprocessing import Pool
+from multiprocessing import Pool, TimeoutError
 from time import sleep
 
 from pysmt.test.examples import get_example_formulae
@@ -92,7 +92,9 @@ else:
 
 # Create a formula
 big_f = And(f.expr for f in get_example_formulae() \
-            if not f.logic.theory.bit_vectors)
+            if not f.logic.theory.bit_vectors and \
+               not f.logic.theory.arrays and \
+                   f.logic.theory.linear)
 
 # Create keyword arguments for the function call.
 # This is the simplest way to pass multiple arguments to apply_async.
@@ -107,5 +109,9 @@ print("This is non-blocking...")
 # Get the result with a deadline.
 # See multiprocessing.pool.AsyncResult for more options
 sat_res = future_res_sat.get(10)  # Get result after 10 seconds or kill
-unsat_res = future_res_unsat.get(0) # No wait
+try:
+    unsat_res = future_res_unsat.get(0) # No wait
+except TimeoutError:
+    print("UNSAT result was not ready!")
+    unsat_res = None
 print(sat_res, unsat_res)

--- a/examples/sudoku/gui.py
+++ b/examples/sudoku/gui.py
@@ -48,7 +48,7 @@ class GridWindow(Gtk.Window):
         self.clear_button.connect("clicked", self.clear)
 
 
-    def clear(self, c):
+    def clear(self, c): # pylint: disable=unused-argument
         """Reset the view emptying all cells"""
         for lst in self.table:
             for entry in lst:

--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -172,9 +172,6 @@ def main():
     if mirror_url is not None:
         mirror_url += "/{archive_name}"
 
-    # Env variable controlling the solvers to be installed or checked
-    requested_solvers = get_requested_solvers()
-
     # This should work on any platform
     install_dir= os.path.expanduser(options.install_path)
     if not os.path.exists(install_dir):
@@ -189,8 +186,20 @@ def main():
     all_solvers = options.all_solvers
     for i in INSTALLERS:
         name = i.InstallerClass.SOLVER
-        if all_solvers or getattr(options, name) or name in requested_solvers:
+        if all_solvers or getattr(options, name):
             solvers_to_install.append(i)
+
+    # Env variable controlling the solvers to be installed or checked
+    requested_solvers = get_requested_solvers()
+    if len(solvers_to_install) != 0 and len(requested_solvers) != 0:
+        print("Warning: Solvers specified on the command line, "
+              "ignoring env variable 'PYSMT_SOLVER'")
+    if len(solvers_to_install) == 0:
+        # No solver requested from cmd-line, checking ENV
+        for i in INSTALLERS:
+            name = i.InstallerClass.SOLVER
+            if name in requested_solvers:
+                solvers_to_install.append(i)
 
     if options.check:
         check_installed([x.InstallerClass.SOLVER for x in solvers_to_install],

--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from six.moves.urllib import request as urllib2
-from six.moves import input, xrange
+from six.moves import input
 
 import os
 import argparse

--- a/pysmt/cmd/installers/__init__.py
+++ b/pysmt/cmd/installers/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#pylint: disable=unused-import
 from pysmt.cmd.installers.msat import MSatInstaller
 from pysmt.cmd.installers.z3 import Z3Installer
 from pysmt.cmd.installers.cvc4 import CVC4Installer
@@ -20,3 +19,6 @@ from pysmt.cmd.installers.yices import YicesInstaller
 from pysmt.cmd.installers.btor import BtorInstaller
 from pysmt.cmd.installers.pico import PicoSATInstaller
 from pysmt.cmd.installers.bdd import CuddInstaller
+
+assert MSatInstaller and Z3Installer and CVC4Installer and YicesInstaller
+assert BtorInstaller and PicoSATInstaller and CuddInstaller

--- a/pysmt/cmd/installers/bdd.py
+++ b/pysmt/cmd/installers/bdd.py
@@ -79,4 +79,6 @@ class CuddInstaller(SolverInstaller):
             finally:
                 if "repycudd" in sys.modules:
                     del sys.modules["repycudd"]
+                # Return None, without raising an exception
+                # pylint: disable=lost-exception
                 return version

--- a/pysmt/cmd/installers/btor.py
+++ b/pysmt/cmd/installers/btor.py
@@ -61,10 +61,15 @@ class BtorInstaller(SolverInstaller):
             version = None
             vfile = os.path.join(self.extract_path, "boolector", "VERSION")
             try:
+                # The version is read from a file, but we first check
+                # if the module is installed
+                # pylint: disable=unused-import
                 import boolector
                 with open(vfile) as f:
                     version = f.read().strip()
             finally:
                 if "boolector" in sys.modules:
                     del sys.modules["boolector"]
+                # Return None, without raising an exception
+                # pylint: disable=lost-exception
                 return version

--- a/pysmt/cmd/installers/cvc4.py
+++ b/pysmt/cmd/installers/cvc4.py
@@ -69,4 +69,6 @@ class CVC4Installer(SolverInstaller):
             finally:
                 if "CVC4" in sys.modules:
                     del sys.modules["CVC4"]
+                # Return None, without raising an exception
+                # pylint: disable=lost-exception
                 return version

--- a/pysmt/cmd/installers/msat.py
+++ b/pysmt/cmd/installers/msat.py
@@ -80,4 +80,6 @@ class MSatInstaller(SolverInstaller):
             finally:
                 if "mathsat" in sys.modules:
                     del sys.modules["mathsat"]
+                # Return None, without raising an exception
+                # pylint: disable=lost-exception
                 return version

--- a/pysmt/cmd/installers/pico.py
+++ b/pysmt/cmd/installers/pico.py
@@ -46,4 +46,6 @@ class PicoSATInstaller(SolverInstaller):
             finally:
                 if "picosat" in sys.modules:
                     del sys.modules["picosat"]
+                # Return None, without raising an exception
+                # pylint: disable=lost-exception
                 return version

--- a/pysmt/cmd/installers/yices.py
+++ b/pysmt/cmd/installers/yices.py
@@ -83,4 +83,6 @@ class YicesInstaller(SolverInstaller):
             finally:
                 if "yicespy" in sys.modules:
                     del sys.modules["yicespy"]
+                # Return None, without raising an exception
+                # pylint: disable=lost-exception
                 return version

--- a/pysmt/cmd/installers/z3.py
+++ b/pysmt/cmd/installers/z3.py
@@ -70,4 +70,6 @@ class Z3Installer(SolverInstaller):
             finally:
                 if "z3" in sys.modules:
                     del sys.modules["z3"]
+                # Return None, without raising an exception
+                # pylint: disable=lost-exception
                 return version

--- a/pysmt/fnode.py
+++ b/pysmt/fnode.py
@@ -323,9 +323,14 @@ class FNode(object):
         """Test whether the node is a theory operator."""
         return self.node_type() in THEORY_OPERATORS
 
+    def is_ira_op(self):
+        """Test whether the node is an Int or Real Arithmetic operator."""
+        return self.node_type() in IRA_OPERATORS
+
+    @deprecated("is_isa_op")
     def is_lira_op(self):
-        """Test whether the node is a LIRA operator."""
-        return self.node_type() in LIRA_OPERATORS
+        """Test whether the node is a IRA operator."""
+        return self.node_type() in IRA_OPERATORS
 
     def is_bv_op(self):
         """Test whether the node is a BitVector operator."""

--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -34,12 +34,12 @@ from six.moves import xrange
 
 import pysmt.typing as types
 import pysmt.operators as op
-import pysmt.utils as utils
 
 from pysmt.utils import is_python_integer
 from pysmt.fnode import FNode, FNodeContent
-from pysmt.exceptions import NonLinearError, UndefinedSymbolError
+from pysmt.exceptions import UndefinedSymbolError
 from pysmt.walkers.identitydag import IdentityDagWalker
+
 
 class FormulaManager(object):
     """FormulaManager is responsible for the creation of all formulae."""

--- a/pysmt/numeral.py
+++ b/pysmt/numeral.py
@@ -1,5 +1,3 @@
-import warnings
-
 use_z3 = False
 try:
     import z3num

--- a/pysmt/rewritings.py
+++ b/pysmt/rewritings.py
@@ -22,7 +22,7 @@ This module defines some rewritings for pySMT formulae.
 from pysmt.walkers.dag import DagWalker
 import pysmt.typing as types
 import pysmt.operators as op
-import pysmt.environment
+
 
 class CNFizer(DagWalker):
 

--- a/pysmt/shortcuts.py
+++ b/pysmt/shortcuts.py
@@ -480,6 +480,7 @@ def get_unsat_core(clauses, solver_name=None, logic=None):
     """Similar to :py:func:`get_model` but returns the unsat core of the
     conjunction of the input clauses"""
     env = get_env()
+    clauses = list(clauses)
     if any(c not in env.formula_manager for c in clauses):
         warnings.warn("Warning: Contextualizing formula during get_model")
         clauses = [env.formula_manager.normalize(c) for c in clauses]

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -21,7 +21,6 @@ import pysmt.walkers
 import pysmt.operators as op
 import pysmt.typing as types
 from pysmt.utils import set_bit
-from pysmt.exceptions import ConvertExpressionError
 
 
 class Simplifier(pysmt.walkers.DagWalker):

--- a/pysmt/smtlib/parser.py
+++ b/pysmt/smtlib/parser.py
@@ -306,7 +306,6 @@ class SmtLibParser(object):
                             'select':self._operator_adapter(mgr.Select),
                             'store':self._operator_adapter(mgr.Store),
                             'as':self._enter_smtlib_as,
-                            '/':self._operator_adapter(mgr.Div),
                             }
 
         # Command tokens

--- a/pysmt/smtlib/solver.py
+++ b/pysmt/smtlib/solver.py
@@ -1,3 +1,18 @@
+# Copyright 2014 Andrea Micheli and Marco Gario
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
 from io import TextIOWrapper
 from subprocess import Popen, PIPE
 
@@ -30,6 +45,8 @@ class SmtLibSolver(Solver):
         self.args = args
         self.declared_vars = set()
         self.solver = Popen(args, stdout=PIPE, stderr=PIPE, stdin=PIPE)
+        # Give time to the process to start-up
+        time.sleep(0.01)
         self.parser = SmtLibParser(interactive=True)
         if PY2:
             self.solver_stdin = self.solver.stdin

--- a/pysmt/smtlib/solver.py
+++ b/pysmt/smtlib/solver.py
@@ -18,12 +18,11 @@ class SmtLibSolver(Solver):
     the executable. Interaction with the solver occurs via pipe.
     """
 
-    def __init__(self, args, environment, logic, user_options=None,
-                 LOGICS=None):
+    def __init__(self, args, environment, logic, LOGICS=None, **options):
         Solver.__init__(self,
                         environment,
-                        logic=logic,
-                        user_options=user_options)
+                        logic=logic)
+
         # Flag used to debug interaction with the solver
         self.dbg = False
 
@@ -45,9 +44,6 @@ class SmtLibSolver(Solver):
             self.set_option(":produce-models", "true")
         # Redirect diagnostic output to stdout
         self.set_option(":diagnostic-output-channel", '"stdout"')
-        if self.options is not None:
-            for o,v in iteritems(self.options):
-                self.set_option(o,v)
         self.set_logic(logic)
 
     def set_option(self, name, value):

--- a/pysmt/smtlib/solver.py
+++ b/pysmt/smtlib/solver.py
@@ -1,7 +1,7 @@
 from io import TextIOWrapper
 from subprocess import Popen, PIPE
 
-from six import iteritems, PY2
+from six import PY2
 
 import pysmt.smtlib.commands as smtcmd
 from pysmt.solvers.eager import EagerModel

--- a/pysmt/solvers/btor.py
+++ b/pysmt/solvers/btor.py
@@ -25,19 +25,14 @@ except ImportError:
     raise SolverAPINotFound
 
 
-from pysmt.solvers.solver import (IncrementalTrackingSolver, UnsatCoreSolver,
-                                  Model, Converter)
+from pysmt.solvers.solver import IncrementalTrackingSolver, Converter
 from pysmt.solvers.smtlib import SmtLibBasicSolver, SmtLibIgnoreMixin
 from pysmt.solvers.eager import EagerModel
 from pysmt.walkers import DagWalker
 from pysmt.exceptions import (SolverReturnedUnknownResultError,
-                              SolverNotConfiguredForUnsatCoresError,
-                              SolverStatusError,
                               ConvertExpressionError)
 from pysmt.decorators import clear_pending_pop, catch_conversion_error
 from pysmt.logics import QF_BV, QF_UFBV, QF_ABV, QF_AUFBV, QF_AX
-from pysmt.oracles import get_logic
-
 
 
 class BoolectorSolver(IncrementalTrackingSolver,

--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -15,7 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import warnings
 from fractions import Fraction
 from six.moves import xrange
 

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -15,8 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import re
-
 from warnings import warn
 from fractions import Fraction
 from six.moves import xrange

--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -28,7 +28,6 @@ from fractions import Fraction
 from six.moves import xrange
 
 import pysmt.typing as types
-import pysmt.operators as op
 from pysmt.solvers.solver import (IncrementalTrackingSolver, UnsatCoreSolver,
                                   Model, Converter)
 from pysmt.solvers.smtlib import SmtLibBasicSolver, SmtLibIgnoreMixin

--- a/pysmt/test/__init__.py
+++ b/pysmt/test/__init__.py
@@ -158,23 +158,6 @@ class skipIfNoQEForLogic(object):
         return wrapper
 
 
-def skipIfNoSMTWrapper(test_fun):
-    """Skip a test if there is no quantifier eliminator for the given logic."""
-    msg = "No SMT-Lib solver is available"
-    BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-    cond = any(f.endswith(".solver.sh")
-               for _, _, fnames in os.walk(BASE_DIR)
-               for f in fnames)
-
-    @unittest.skipIf(cond, msg)
-    @wraps(test_fun)
-    def wrapper(*args, **kwargs):
-        return test_fun(*args, **kwargs)
-    return wrapper
-
-
-
-
 # Export a main function
 main = unittest.main
 

--- a/pysmt/test/test_array.py
+++ b/pysmt/test/test_array.py
@@ -97,6 +97,12 @@ class TestArray(TestCase):
             Equals(nested_a, Array(Array(REAL, BV(0,8)),
                                    Array(INT, Int(7))))
 
+    def test_is_array_op(self):
+        a = Symbol("a", ARRAY_INT_INT)
+        store_ = Store(a, Int(10), Int(100))
+        select_ = Select(store_, Int(100))
+        self.assertTrue(store_.is_array_op())
+        self.assertTrue(select_.is_array_op())
 
 
 if __name__ == "__main__":

--- a/pysmt/test/test_bv.py
+++ b/pysmt/test/test_bv.py
@@ -86,6 +86,7 @@ class TestBV(TestCase):
         zero_xor_one = mgr.BVXor(zero, one)
 
         zero_xor_one.simplify()
+        self.assertTrue(zero_xor_one.is_bv_op())
         # print(zero_and_one)
         # print(zero_or_one)
         # print(zero_xor_one)

--- a/pysmt/test/test_formula.py
+++ b/pysmt/test/test_formula.py
@@ -109,6 +109,7 @@ class TestFormulaManager(TestCase):
         one = self.mgr.And(self.x)
         self.assertEqual(one, self.x)
 
+        self.assertTrue(n.is_bool_op())
 
     def test_or_node(self):
         n = self.mgr.Or(self.x, self.y)
@@ -130,6 +131,7 @@ class TestFormulaManager(TestCase):
         one = self.mgr.Or(self.x)
         self.assertEqual(one, self.x)
 
+        self.assertTrue(n.is_bool_op())
 
     def test_not_node(self):
         n = self.mgr.Not(self.x)
@@ -143,6 +145,7 @@ class TestFormulaManager(TestCase):
         self.assertEqual(len(args), 1)
 
         self.assertEqual(self.mgr.Not(n), self.x)
+        self.assertTrue(n.is_bool_op())
 
     def test_implies_node(self):
         n = self.mgr.Implies(self.x, self.y)
@@ -155,6 +158,7 @@ class TestFormulaManager(TestCase):
         self.assertEqual(self.x, args[0])
         self.assertEqual(self.y, args[1])
         self.assertEqual(len(args), 2)
+        self.assertTrue(n.is_bool_op())
 
     def test_iff_node(self):
         n = self.mgr.Iff(self.x, self.y)
@@ -167,7 +171,7 @@ class TestFormulaManager(TestCase):
         self.assertIn(self.x, args)
         self.assertIn(self.y, args)
         self.assertEqual(len(args), 2)
-
+        self.assertTrue(n.is_bool_op())
 
     def test_ge_node_type(self):
         with self.assertRaises(TypeError):
@@ -198,6 +202,8 @@ class TestFormulaManager(TestCase):
 
         n = self.mgr.GE(self.p, self.q)
         self.assertIsNotNone(n)
+        self.assertFalse(n.is_bool_op())
+        self.assertTrue(n.is_theory_relation())
 
     def test_minus_node(self):
         n = self.mgr.Minus(self.real_expr, self.real_expr)
@@ -222,10 +228,10 @@ class TestFormulaManager(TestCase):
 
         self.assertTrue(n.is_minus())
         self.assertEqual(n.get_free_variables(), set([self.p, self.q]))
+        self.assertTrue(n.is_theory_op())
 
         with self.assertRaises(TypeError):
             n = self.mgr.Minus(self.r, self.q)
-
 
     def test_times_node(self):
         n = self.mgr.Times(self.real_expr, self.rconst)
@@ -249,6 +255,7 @@ class TestFormulaManager(TestCase):
 
         n = self.mgr.Times(self.iconst, self.q)
         self.assertIsNotNone(n)
+        self.assertTrue(n.is_lira_op())
 
     def test_div_node(self):
         n = self.mgr.Div(self.real_expr, self.rconst)
@@ -279,6 +286,7 @@ class TestFormulaManager(TestCase):
 
         self.assertTrue(n.is_equals())
         self.assertEqual(n.get_free_variables(), set([self.p, self.q]))
+        self.assertTrue(n.is_theory_relation())
 
         with self.assertRaises(TypeError):
             n = self.mgr.Equals(self.p, self.r)
@@ -312,6 +320,7 @@ class TestFormulaManager(TestCase):
 
         n = self.mgr.GT(self.p, self.q)
         self.assertIsNotNone(n)
+        self.assertTrue(n.is_theory_relation())
 
     def test_le_node_type(self):
         with self.assertRaises(TypeError):
@@ -339,6 +348,7 @@ class TestFormulaManager(TestCase):
         self.assertIn(self.r, args)
         self.assertIn(self.s, args)
         self.assertEqual(len(args), 2)
+        self.assertTrue(n.is_theory_relation())
 
     def test_lt_node_type(self):
         with self.assertRaises(TypeError):
@@ -366,6 +376,7 @@ class TestFormulaManager(TestCase):
         self.assertIn(self.r, args)
         self.assertIn(self.s, args)
         self.assertEqual(len(args), 2)
+        self.assertTrue(n.is_theory_relation())
 
     def test_ite(self):
         n = self.mgr.Ite(self.x, self.y, self.x)
@@ -387,7 +398,6 @@ class TestFormulaManager(TestCase):
 
         with self.assertRaises(TypeError):
             self.mgr.Ite(self.x, self.p, self.r)
-
 
     def test_function(self):
         n = self.mgr.Function(self.f, [self.r, self.s])
@@ -460,7 +470,6 @@ class TestFormulaManager(TestCase):
 
         with self.assertRaises(TypeError):
             self.mgr.Plus()
-
 
         n1 = self.mgr.Plus([self.r, self.s])
         n2 = self.mgr.Plus(self.r, self.s)

--- a/pysmt/test/test_unsat_cores.py
+++ b/pysmt/test/test_unsat_cores.py
@@ -86,6 +86,13 @@ class TestUnsatCores(TestCase):
         self.assertIn(x, core)
         self.assertIn(Not(x), core)
 
+    @skipIfNoUnsatCoreSolverForLogic(QF_BOOL)
+    def test_generators_in_shortcuts(self):
+        flist = [Symbol("x"), Not(Symbol("x"))]
+        gen_f = (x for x in flist)
+        ucore = get_unsat_core(gen_f)
+        self.assertEqual(len(ucore), 2)
+
 
     @skipIfNoUnsatCoreSolverForLogic(QF_BOOL)
     def test_basic_named(self):

--- a/pysmt/typing.py
+++ b/pysmt/typing.py
@@ -53,6 +53,7 @@ class PySMTType(object):
         return False
 
     def is_bv_type(self, width=None):
+        #pylint: disable=unused-argument
         return False
 
     def is_function_type(self):


### PR DESCRIPTION
This fixes a few problems in the testing environment and updates the examples in ``examples/`` .

1. ``examples/`` are now being tested by Travis in the "all" configuration
2. SMT-LIB Wrappers were not being tested. This has now been fixed.

These two points revealed a few bugs related to the examples being outdated (or not py3 compatible).

The last commit changes install.py so that cmd-line option overrides env variable. First, I think that this is a better semantics. Second, this allows us to install a single solver in Travis, without the need of worrying about which configuration we are running.