### PR TITLE
Installers: Make dependency from pip optional

### DIFF
--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -33,7 +33,7 @@ INSTALLERS = [Installer(MSatInstaller,    "5.3.9", {}),
               Installer(CVC4Installer,    "1.5-prerelease", {"git_version" : "c15ff43597b41ea457befecb1b0e2402e28cb523"}),
               Installer(YicesInstaller,   "2.4.2", {"yicespy_version": "22b94419522ba772a1cc1e72dbe84e01b8adc16d"}),
               Installer(BtorInstaller,    "2.2.0", {"lingeling_version": "bal"}),
-              Installer(PicoSATInstaller, "960", {}),
+              Installer(PicoSATInstaller, "960", {"pypicosat_minor_version" : "151030"}),
               Installer(CuddInstaller,    "2.0.3", {"git_version" : "75fe055c2a736a3ac3e971c1ade108b815edc96c"})]
 
 

--- a/pysmt/cmd/installers/pico.py
+++ b/pysmt/cmd/installers/pico.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 import sys, os
 import json
+import codecs
+
 from six.moves.urllib import request as urllib2
 
 from pysmt.cmd.installers.base import SolverInstaller, TemporaryPath
@@ -27,7 +29,9 @@ class PicoSATInstaller(SolverInstaller):
 
         self.complete_version = "%s.%s" % (solver_version, pypicosat_minor_version)
         pypi_link = "http://pypi.python.org/pypi/pyPicoSAT/%s/json" % self.complete_version
-        pypi_json = json.load(urllib2.urlopen(pypi_link))
+        response = urllib2.urlopen(pypi_link)
+        reader = codecs.getreader("utf-8")
+        pypi_json = json.load(reader(response))
 
         pypicosat_download_link = pypi_json["urls"][0]["url"]
         archive_name = pypi_json["urls"][0]["filename"]

--- a/pysmt/cmd/installers/pico.py
+++ b/pysmt/cmd/installers/pico.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import sys
-import pip
 
 from pysmt.cmd.installers.base import SolverInstaller, TemporaryPath
 
@@ -35,6 +34,11 @@ class PicoSATInstaller(SolverInstaller):
         pass # Nothing to unpack
 
     def compile(self):
+        try:
+            import pip
+        except ImportError:
+            print("Error: pip is required to install Picosat.")
+            exit(-1)
         pip.main(['install', '--target', self.bindings_dir, 'pypicosat'])
 
     def get_installed_version(self):


### PR DESCRIPTION
Picosat installer only checks pip availability when trying to install it. On systems that do not have pip, it is still possible to use install.py to check if Picosat is available.