### PR TITLE
CI: Upgrade to Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
-
-sudo: false
+dist: trusty
 
 cache:
   apt: true
@@ -83,11 +82,10 @@ matrix:
 
 install:
   # This is for btor that fails to find the python 3 library to link
-  - "export LIBRARY_PATH=${LIBRARY_PATH}:/opt/python/3.4.2/lib"
-  - "export LIBRARY_PATH=${LIBRARY_PATH}:/opt/python/3.5.2/lib"
+  - "export LIBRARY_PATH=${LIBRARY_PATH}:/opt/python/3.5.0/lib"
   # For some reason, Travis CI cannot find the command python3.5-config.
   # Therefore, we force the path here
-  - if [ "${TRAVIS_PYTHON_VERSION}" == "3.5" ]; then export PATH=${PATH}:/opt/python/3.5.2/bin/ ; fi
+  - if [ "${TRAVIS_PYTHON_VERSION}" == "3.5" ]; then export PATH=${PATH}:/opt/python/3.5.0/bin/ ; fi
   - "pip install six"
   - if [ "${PYSMT_SOLVER}" == "all" ] || [ "${PYSMT_SOLVER}" == "btor" ]; then pip install cython; fi
   - "export BINDINGS_FOLDER=${HOME}/python_bindings/${PYSMT_SOLVER}"


### PR DESCRIPTION
This is needed to support both gmpy2 and dReal, since they both depend on libraries that are not available on Ubuntu 12.04, and we do not want to install them manually.