### PR TITLE
install.py: Avoid calling is_installed() after installation

### DIFF
--- a/pysmt/cmd/installers/base.py
+++ b/pysmt/cmd/installers/base.py
@@ -138,7 +138,7 @@ class SolverInstaller(object):
         self.compile()
         self.move()
 
-        return self.is_installed()
+        return
 
     def is_installed(self):
         """Checks if the solver is installed and usable"""


### PR DESCRIPTION
This avoids some problems when upgrading C-extensions.