### PR TITLE
BUGFIX: SMT-LIB define-fun serialization

### DIFF
--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -103,11 +103,12 @@ class SmtLibCommand(namedtuple('SmtLibCommand', ['name', 'args'])):
             params = " ".join(["(%s %s)" % (v, v.symbol_type()) for v in params_list])
             rtype = self.args[2]
             expr = self.args[3]
-            outstream.write("(%s %s (%s) %s %s)" % (self.name,
-                                                    name,
-                                                    params,
-                                                    rtype,
-                                                    expr))
+            outstream.write("(%s %s (%s) %s " % (self.name,
+                                                name,
+                                                params,
+                                                rtype))
+            printer.printer(expr)
+            outstream.write(")")
 
         elif self.name in [smtcmd.PUSH, smtcmd.POP]:
             outstream.write("(%s %d)" % (self.name, self.args[0]))

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -272,9 +272,7 @@ class TestRegressions(TestCase):
 
     def test_smtlib_info_quoting(self):
         cmd = SmtLibCommand(smtcmd.SET_INFO, [":source", "This\nis\nmultiline!"])
-        outstream = cStringIO()
-        cmd.serialize(outstream)
-        output = outstream.getvalue()
+        output = cmd.serialize_to_string()
         self.assertEqual(output, "(set-info :source |This\nis\nmultiline!|)")
 
     def test_parse_define_fun(self):
@@ -358,6 +356,16 @@ class TestRegressions(TestCase):
             self.assertTrue(s.solve())
             self.assertEqual(s.get_value(Select(x, BV(1, 16))), BV(1, 16))
             self.assertIsNotNone(s.get_value(x))
+
+
+    def test_smtlib_define_fun_serialization(self):
+        smtlib_input = "(define-fun init ((x Bool)) Bool (and x (and x (and x (and x (and x (and x x)))))))"
+        parser = SmtLibParser()
+        buffer_ = cStringIO(smtlib_input)
+        s = parser.get_script(buffer_)
+        for c in s:
+            res = c.serialize_to_string()
+        self.assertEqual(res, smtlib_input)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Serialization of the define-fun expression was using the HR String
representation, instead of calling the SmtLibPrinter.

This had two problems:

1. The expression was not valid SMT-Lib
2. The expression was being thresholded

I inspected the other cases, and this seems to be the only one in which
we were printing an expression.