### PR TITLE
SizeOracle: Add MEASURE_BOOL_DAG measure

### DIFF
--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -41,11 +41,13 @@ class SizeOracle(pysmt.walkers.DagWalker):
     # - LEAVES     : counts the number of leaves in the formula seen as a tree
     # - DEPTH      : counts the maximum number of levels in the formula
     # - SYMBOLS    : counts the number of different symbols occurring in the formula
+    # - BOOL_DAG   : counts the dag size by considering theory atoms as leaf
     (MEASURE_TREE_NODES,
      MEASURE_DAG_NODES,
      MEASURE_LEAVES,
      MEASURE_DEPTH,
-     MEASURE_SYMBOLS) = range(5)
+     MEASURE_SYMBOLS,
+     MEASURE_BOOL_DAG) = range(6)
 
     def __init__(self, env=None):
         pysmt.walkers.DagWalker.__init__(self, env=env)
@@ -55,7 +57,9 @@ class SizeOracle(pysmt.walkers.DagWalker):
                          SizeOracle.MEASURE_DAG_NODES: self.walk_count_dag,
                          SizeOracle.MEASURE_LEAVES: self.walk_count_leaves,
                          SizeOracle.MEASURE_DEPTH: self.walk_count_depth,
-                         SizeOracle.MEASURE_SYMBOLS: self.walk_count_symbols}
+                         SizeOracle.MEASURE_SYMBOLS: self.walk_count_symbols,
+                         SizeOracle.MEASURE_BOOL_DAG: self.walk_count_bool_dag,
+                        }
 
 
     def set_walking_measure(self, measure):
@@ -63,13 +67,15 @@ class SizeOracle(pysmt.walkers.DagWalker):
             raise NotImplementedError
         self.set_function(self.measure_to_fun[measure], *op.ALL_TYPES)
 
-
     def _get_key(self, formula, measure, **kwargs):
-        # Memoize using a tuple (measure, formula)
+        """Memoize using a tuple (measure, formula)."""
         return (measure, formula)
 
-
     def get_size(self, formula, measure=None):
+        """Return the size of the formula according to the specified measure.
+
+        The default measure is MEASURE_TREE_NODES.
+        """
         if measure is None:
             # By default, count tree nodes
             measure = SizeOracle.MEASURE_TREE_NODES
@@ -78,10 +84,10 @@ class SizeOracle(pysmt.walkers.DagWalker):
         res = self.walk(formula, measure=measure)
 
         if measure == SizeOracle.MEASURE_DAG_NODES or \
-           measure == SizeOracle.MEASURE_SYMBOLS:
+           measure == SizeOracle.MEASURE_SYMBOLS or \
+           measure == SizeOracle.MEASURE_BOOL_DAG :
             return len(res)
         return res
-
 
     def walk_count_tree(self, formula, args, **kwargs):
         #pylint: disable=unused-argument
@@ -109,6 +115,11 @@ class SizeOracle(pysmt.walkers.DagWalker):
             return frozenset([formula]) | a_res
         return a_res
 
+    def walk_count_bool_dag(self, formula, args, measure, **kwargs):
+        #pylint: disable=unused-argument
+        if formula.is_theory_relation():
+            return frozenset([formula])
+        return frozenset([formula]) | frozenset([x for s in args for x in s])
 
 
 class QuantifierOracle(pysmt.walkers.DagWalker):

--- a/pysmt/test/test_size.py
+++ b/pysmt/test/test_size.py
@@ -15,7 +15,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from pysmt.shortcuts import *
+from pysmt.shortcuts import Symbol, Int, And, Or, Not, GT
+from pysmt.typing import INT
 from pysmt.oracles import SizeOracle
 from pysmt.test import TestCase, main
 from pysmt.test.examples import get_example_formulae
@@ -51,6 +52,13 @@ class TestSize(TestCase):
         self.assertEqual(f.size(SizeOracle.MEASURE_DEPTH), 3)
         self.assertEqual(f.size(SizeOracle.MEASURE_SYMBOLS), 1)
 
+    def test_bool_dag(self):
+        p = Symbol("p", INT)
+        x = Symbol("x")
+        f = Or(x, GT(p, Int(0)), And(x, x))
+        bool_dag = f.size(SizeOracle.MEASURE_BOOL_DAG)
+        self.assertEqual(bool_dag, 4)
+
     def test_examples(self):
         for (f, _, _, _) in get_example_formulae():
             tree_size = f.size(SizeOracle.MEASURE_TREE_NODES)
@@ -58,11 +66,12 @@ class TestSize(TestCase):
             leaves = f.size(SizeOracle.MEASURE_LEAVES)
             depth = f.size(SizeOracle.MEASURE_DEPTH)
             symbols = f.size(SizeOracle.MEASURE_SYMBOLS)
-
+            bool_dag = f.size(SizeOracle.MEASURE_BOOL_DAG)
             self.assertTrue(tree_size >= dag_size)
             self.assertTrue(dag_size >= depth)
             self.assertTrue(dag_size >= leaves)
             self.assertTrue(leaves >= symbols)
+            self.assertTrue(dag_size >= bool_dag)
 
     def test_error(self):
         varA = Symbol("A")


### PR DESCRIPTION
Measure the Boolean size of the formula. This is equivalent to replacing
every theory expression with a fresh boolean variable, and measuring the
DAG size of the formula.

This can be used to estimate the Boolean complexity of the SMT formula.