### PR TITLE
MSat: Check if solver is configured for unsat-core

### DIFF
--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -131,6 +131,9 @@ class MathSAT5Model(Model):
         """Returns whether the model contains a value for 'x'."""
         return x in (v for v, _ in self)
 
+# EOC MathSAT5Model
+
+
 class MathSAT5Solver(IncrementalTrackingSolver, UnsatCoreSolver,
                      SmtLibBasicSolver, SmtLibIgnoreMixin):
 
@@ -272,8 +275,8 @@ class MathSAT5Solver(IncrementalTrackingSolver, UnsatCoreSolver,
     def get_unsat_core(self):
         """After a call to solve() yielding UNSAT, returns the unsat core as a
         set of formulae"""
+        self._check_unsat_core_config()
         if self.options.unsat_cores_mode == "all":
-            self._check_unsat_core_config()
 
             terms = mathsat.msat_get_unsat_core(self.msat_env())
             if terms is None:
@@ -286,8 +289,8 @@ class MathSAT5Solver(IncrementalTrackingSolver, UnsatCoreSolver,
     def get_named_unsat_core(self):
         """After a call to solve() yielding UNSAT, returns the unsat core as a
         dict of names to formulae"""
+        self._check_unsat_core_config()
         if self.options.unsat_cores_mode == "named":
-            self._check_unsat_core_config()
 
             assumptions = mathsat.msat_get_unsat_assumptions(self.msat_env())
             pysmt_assumptions = set(self.converter.back(t) for t in assumptions)

--- a/pysmt/test/test_unsat_cores.py
+++ b/pysmt/test/test_unsat_cores.py
@@ -18,9 +18,10 @@
 from pysmt.test import (TestCase, skipIfSolverNotAvailable,
                         skipIfNoUnsatCoreSolverForLogic, main)
 from pysmt.shortcuts import (get_unsat_core, And, Not, Symbol, UnsatCoreSolver,
-                             is_unsat)
+                             Solver, is_unsat)
 from pysmt.logics import QF_BOOL, QF_BV
-from pysmt.exceptions import SolverStatusError, SolverReturnedUnknownResultError
+from pysmt.exceptions import (SolverStatusError, SolverReturnedUnknownResultError,
+                              SolverNotConfiguredForUnsatCoresError)
 from pysmt.test.examples import get_example_formulae
 
 class TestUnsatCores(TestCase):
@@ -151,6 +152,18 @@ class TestUnsatCores(TestCase):
     @skipIfSolverNotAvailable("z3")
     def test_examples_z3(self):
         self._helper_check_examples("z3")
+
+
+    @skipIfSolverNotAvailable("msat")
+    def test_unsat_core_on_regular_solver(self):
+        x = Symbol("x")
+        with Solver(name="msat") as s:
+            s.add_assertion(x)
+            s.add_assertion(Not(x))
+            r = s.solve()
+            self.assertFalse(r)
+            with self.assertRaises(SolverNotConfiguredForUnsatCoresError):
+                s.get_unsat_core()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If the solver was not configured for unsat core, a call to get_unsat_core would lead to an infinite recursion between get_unsat_core and get_named_unsat_core.

This is fixed by checking the configuration of the solver as first thing in those functions.