### PR TITLE
Use solver_options to specify solver-dependent options

### DIFF
--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -34,7 +34,7 @@ INSTALLERS = [Installer(MSatInstaller,    "5.3.13", {}),
               Installer(CVC4Installer,    "1.5-prerelease", {"git_version" : "c15ff43597b41ea457befecb1b0e2402e28cb523"}),
               Installer(YicesInstaller,   "2.5.1", {"yicespy_version": "07439670a54d08a76cfb931194e1eaf07ea026a1"}),
               Installer(BtorInstaller,    "2.2.0", {"lingeling_version": "bal"}),
-              Installer(PicoSATInstaller, "960", {"pypicosat_minor_version" : "151030"}),
+              Installer(PicoSATInstaller, "960", {"pypicosat_minor_version" : "1610040816"}),
               Installer(CuddInstaller,    "2.0.3", {"git_version" : "75fe055c2a736a3ac3e971c1ade108b815edc96c"})]
 
 

--- a/pysmt/cmd/installers/cvc4.py
+++ b/pysmt/cmd/installers/cvc4.py
@@ -54,7 +54,10 @@ class CVC4Installer(SolverInstaller):
                               --with-antlr-dir={dir_path}/antlr-3.4 ANTLR={dir_path}/antlr-3.4/bin/antlr3;\
                   make; \
                   make install ".format(bin_path=self.bin_path, dir_path=self.extract_path)
-        SolverInstaller.run(config, directory=self.extract_path)
+        pyconfig = {"PYTHON_CONFIG": sys.executable+"-config"}
+        SolverInstaller.run(config,
+                            directory=self.extract_path,
+                            env_variables=pyconfig)
 
         # Fix the paths of the bindings
         SolverInstaller.run("cp CVC4.so.3.0.0 _CVC4.so",

--- a/pysmt/cmd/installers/cvc4.py
+++ b/pysmt/cmd/installers/cvc4.py
@@ -54,7 +54,10 @@ class CVC4Installer(SolverInstaller):
                               --with-antlr-dir={dir_path}/antlr-3.4 ANTLR={dir_path}/antlr-3.4/bin/antlr3;\
                   make; \
                   make install ".format(bin_path=self.bin_path, dir_path=self.extract_path)
-        pyconfig = {"PYTHON_CONFIG": sys.executable+"-config"}
+        if os.path.exists(sys.executable+"-config"):
+            pyconfig = {"PYTHON_CONFIG": sys.executable+"-config"}
+        else:
+            pyconfig = {}
         SolverInstaller.run(config,
                             directory=self.extract_path,
                             env_variables=pyconfig)

--- a/pysmt/configuration.py
+++ b/pysmt/configuration.py
@@ -70,7 +70,8 @@ def configure_environment(config_filename, environment):
 
         logics_string = config.get(s, "logics")
         if logics_string is None:
-            warn("Missing 'logics' value in definition of '%s' solver" % name)
+            warn("Missing 'logics' value in definition of '%s' solver" % name,
+                 stacklevel=2)
             continue
 
         logics = [get_logic_by_name(l) for l in logics_string.split()]
@@ -87,18 +88,21 @@ def configure_environment(config_filename, environment):
             elif infix.lower() == "false":
                 environment.enable_infix_notation = True
             else:
-                warn("Unknown value for 'use_infix_notation': %s" % infix)
+                warn("Unknown value for 'use_infix_notation': %s" % infix,
+                     stacklevel=2)
 
         if pref_list is not None:
             prefs = pref_list.split()
             for s in prefs:
                 if s not in factory.all_solvers():
-                    warn("Unknown solver '%s' in solver_preference_list" % s)
+                    warn("Unknown solver '%s' in solver_preference_list" % s,
+                         stacklevel=2)
 
             for s in factory.all_solvers():
                 if s not in prefs:
                     warn("Solver '%s' is not in the preference list, "\
-                         "and will be disabled." % s)
+                         "and will be disabled." % s,
+                         stacklevel=2)
 
             factory.set_solver_preference_list(prefs)
 

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -701,9 +701,10 @@ class BddSimplifier(Simplifier):
 
         Solver = self.env.factory.Solver
         if static_ordering is not None:
-            self.s = Solver(name="bdd", static_ordering=static_ordering)
+            solver_options={'static_ordering': static_ordering}
         else:
-            self.s = Solver(name="bdd", dynamic_reordering=True)
+            solver_options={'dynamic_reordering': True}
+        self.s = Solver(name="bdd", solver_options=solver_options)
         self.convert = self.s.converter.convert
         self.back = self.s.converter.back
         # Set methods for boolean_abstraction

--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -240,7 +240,8 @@ def smtlibscript_from_formula(formula):
     except NoLogicAvailableError:
         warnings.warn("The logic %s is not reducible to any SMTLib2 " \
                       "standard logic. Proceeding with non-standard " \
-                      "logic '%s'" % (f_logic, f_logic))
+                      "logic '%s'" % (f_logic, f_logic),
+                      stacklevel=3)
         smt_logic = f_logic
 
     script.add(name=smtcmd.SET_LOGIC,

--- a/pysmt/smtlib/solver.py
+++ b/pysmt/smtlib/solver.py
@@ -41,6 +41,7 @@ class SmtLibOptions(SolverOptions):
 
         if 'debug_interaction' in self.solver_options:
             self.debug_interaction = self.solver_options
+            del self.solver_options['debug_interaction']
 
     def __call__(self, solver):
         # These options are needed for the wrapper to work
@@ -104,13 +105,13 @@ class SmtLibSolver(Solver):
     def set_logic(self, logic):
         self._send_silent_command(SmtLibCommand(smtcmd.SET_LOGIC, [logic]))
 
-    def _debug(self, msg):
+    def _debug(self, msg, *format_args):
         if self.options.debug_interaction:
-            print(msg)
+            print(msg % format_args)
 
     def _send_command(self, cmd):
         """Sends a command to the STDIN pipe."""
-        self._debug("Sending: " + cmd.serialize_to_string())
+        self._debug("Sending: %s", cmd.serialize_to_string())
         cmd.serialize(self.solver_stdin, daggify=True)
         self.solver_stdin.write("\n")
         self.solver_stdin.flush()
@@ -123,13 +124,13 @@ class SmtLibSolver(Solver):
     def _get_answer(self):
         """Reads a line from STDOUT pipe"""
         res = self.solver_stdout.readline().strip()
-        if self.options.debug_interaction: print("Read: " + str(res))
+        self._debug("Read: %s", res)
         return res
 
     def _get_value_answer(self):
         """Reads and parses an assignment from the STDOUT pipe"""
         lst = self.parser.get_assignment_list(self.solver_stdout)
-        if self.options.debug_interaction: print("Read: " + str(lst))
+        self._debug("Read: %s", lst)
         return lst
 
     def _declare_variable(self, symbol):

--- a/pysmt/solvers/bdd.py
+++ b/pysmt/solvers/bdd.py
@@ -36,7 +36,22 @@ from pysmt.solvers.qelim import QuantifierEliminator
 
 
 class BddOptions(SolverOptions):
+    """Options for the BDD Solver.
+
+    * static_ordering: None, list of Symbols
+      Enable static ordering with the given list of symbols
+
+    * dynamic_reordering: True, False
+      Enable dynamic reordering
+
+    * reordering_algorithm: BddOptions.CUDD_ALL_REORDERING_ALGORITHMS
+      Specify which reordering algorithm to use when dynamic_reording
+      is enabled.
+
+    """
     ## CUDD Reordering algorithms
+    CUDD_ALL_REORDERING_ALGORITHMS = range(1,23)
+
     CUDD_REORDER_SAME, \
     CUDD_REORDER_NONE, \
     CUDD_REORDER_RANDOM, \
@@ -58,43 +73,70 @@ class BddOptions(SolverOptions):
     CUDD_REORDER_LINEAR, \
     CUDD_REORDER_LINEAR_CONVERGE, \
     CUDD_REORDER_LAZY_SIFT, \
-    CUDD_REORDER_EXACT = range(22)
+    CUDD_REORDER_EXACT = CUDD_ALL_REORDERING_ALGORITHMS
 
-    CUDD_ALL_REORDERING_ALGORITHMS = range(1, 22)
+    def __init__(self, **base_options):
+        SolverOptions.__init__(self, **base_options)
 
-    VALID_OPTIONS = SolverOptions.VALID_OPTIONS + \
-                    [("static_ordering", None),
-                     ("dynamic_reordering", False),
-                     ("reordering_algorithm", CUDD_REORDER_SIFT),
-                    ]
-
-    def __init__(self, **kwargs):
-        SolverOptions.__init__(self, **kwargs)
-
+        if self.random_seed is not None:
+            raise ValueError("'random_seed' option not supported.")
         if self.unsat_cores_mode is not None:
-            # Check if, for some reason, unsat cores are
-            # required. In case, raise an error.
-            #
-            # TODO: This should be within the Solver, here we should
-            # only check that options are set and non-contraddicting.
-            #
-            raise NotImplementedError("BddSolver does not "\
-                                      "support unsat cores")
+            raise ValueError("'unsat_cores_mode' option not supported.")
 
-    # @classmethod
-    # def from_base_options(cls, base_options):
-    #     generate_models=base_options.generate_models
-    #     unsat_cores_mode=base_options.unsat_cores_mode
-    #     incremental=base_options.incremental
-    #     return BddOptions(generate_models=generate_models,
-    #                       unsat_cores_mode=unsat_cores_mode,
-    #                       incremental=incremental)
+        for k,v in self.solver_options.items():
+            if k == "static_ordering":
+                if v is not None:
+                    try:
+                        valid = all(x.is_symbol(types.BOOL) for x in v)
+                    except:
+                        valid = False
+                    if not valid:
+                        raise ValueError("The BDD static ordering must be a " \
+                                         "list of Boolean variables")
+            elif k == "dynamic_reordering":
+                if v not in (True, False):
+                    raise ValueError("Invalid value %s for '%s'" % \
+                                     (str(k),str(v)))
+            elif k == "reordering_algorithm":
+                if v not in BddOptions.CUDD_ALL_REORDERING_ALGORITHMS:
+                    raise ValueError("Invalid value %s for '%s'" % \
+                                     (str(k),str(v)))
+            else:
+                raise ValueError("Unrecognized option '%s'." % k)
+            # Store option
+            setattr(self, k, v)
 
+        # Set Defaults
+        if not hasattr(self, "dynamic_reordering"):
+            self.dynamic_reordering = False
+        if not hasattr(self, "reordering_algorithm"):
+            if not self.dynamic_reordering:
+                self.reordering_algorithm = None
+            else:
+                self.reordering_algorithm = BddOptions.CUDD_REORDER_SIFT
+        if not hasattr(self, "static_ordering"):
+            self.static_ordering = None
+
+        # Consistency check
+        if not self.dynamic_reordering and self.reordering_algorithm is not None:
+            raise ValueError("reordering_algorithm requires dynamic_reordering.")
+
+    def __call__(self, solver):
+        # Impose initial ordering
+        if self.static_ordering is not None:
+            for var in self.static_ordering:
+                solver.declare_variable(var)
+        if self.dynamic_reordering:
+            solver.ddmanager.AutodynEnable(self.reordering_algorithm)
+        else:
+            solver.ddmanager.AutodynDisable()
+
+# EOC BddOptions
 
 
 class BddSolver(Solver):
+    """CUDD BDD Solver"""
     LOGICS = [ pysmt.logics.QF_BOOL, pysmt.logics.BOOL ]
-
     OptionsClass = BddOptions
 
     def __init__(self, environment, logic, **options):
@@ -107,19 +149,7 @@ class BddSolver(Solver):
         self.ddmanager = repycudd.DdManager()
         self.converter = BddConverter(environment=self.environment,
                                       ddmanager=self.ddmanager)
-
-        # Impose initial ordering
-        if self.options.static_ordering is not None:
-            for var in self.options.static_ordering:
-                if not var.is_symbol(types.BOOL):
-                    raise ValueError("The BDD static ordering must be a " \
-                                     "list of Boolean variables")
-                self.declare_variable(var)
-
-        if self.options.dynamic_reordering:
-            self.ddmanager.AutodynEnable(self.options.reordering_algorithm)
-        else:
-            self.ddmanager.AutodynDisable()
+        self.options(self)
 
         # This stack keeps a pair (Expr, Bdd), with the semantics that
         # the bdd at the i-th element of the list contains the bdd of

--- a/pysmt/solvers/btor.py
+++ b/pysmt/solvers/btor.py
@@ -25,7 +25,8 @@ except ImportError:
     raise SolverAPINotFound
 
 
-from pysmt.solvers.solver import IncrementalTrackingSolver, Converter
+from pysmt.solvers.solver import (IncrementalTrackingSolver,
+                                  Converter, SolverOptions)
 from pysmt.solvers.smtlib import SmtLibBasicSolver, SmtLibIgnoreMixin
 from pysmt.solvers.eager import EagerModel
 from pysmt.walkers import DagWalker
@@ -35,25 +36,53 @@ from pysmt.decorators import clear_pending_pop, catch_conversion_error
 from pysmt.logics import QF_BV, QF_UFBV, QF_ABV, QF_AUFBV, QF_AX
 
 
+class BoolectorOptions(SolverOptions):
+    def __init__(self, **base_options):
+        SolverOptions.__init__(self, **base_options)
+        if self.random_seed is not None:
+            raise ValueError("BTOR Does not support Random Seed setting.")
+
+        # Disabling Incremental usage is not allowed.
+        # This needs to be set to 1
+        self.incrementality = True
+
+    @staticmethod
+    def _set_option(btor, name, value):
+        try:
+            btor.Set_opt(name, value)
+        except TypeError:
+            raise ValueError("Error setting the option '%s=%s'" % (name,value))
+        except boolector.BoolectorException:
+            raise ValueError("Error setting the option '%s=%s'" % (name,value))
+
+    def __call__(self, solver):
+        if self.generate_models:
+            self._set_option(solver.btor, "model_gen", 1)
+        else:
+            self._set_option(solver.btor, "model_gen", 0)
+        if self.incrementality:
+            self._set_option(solver.btor, "incremental", 1)
+
+        for k,v in self.solver_options.items():
+            # Note: Options values in btor are mostly integers
+            self._set_option(solver.btor, str(k), v)
+
+# EOC BoolectorOptions
+
+
 class BoolectorSolver(IncrementalTrackingSolver,
                       SmtLibBasicSolver, SmtLibIgnoreMixin):
 
     LOGICS = [QF_BV, QF_UFBV, QF_ABV, QF_AUFBV, QF_AX]
+    OptionsClass = BoolectorOptions
 
     def __init__(self, environment, logic, **options):
         IncrementalTrackingSolver.__init__(self,
                                            environment=environment,
                                            logic=logic,
                                            **options)
-
         self.btor = boolector.Boolector()
-
-        self.btor.Set_opt("model_gen", 0)
-        # Disabling Incremental usage is not allowed.
-        # This needs to be set to 1
-        self.btor.Set_opt("incremental", 1)
-        if self.options.generate_models:
-            self.btor.Set_opt("model_gen", 1)
+        self.options(self)
         self.converter = BTORConverter(environment, self.btor)
         self.mgr = environment.formula_manager
         self.declarations = {}

--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -49,10 +49,7 @@ class CVC4Options(SolverOptions):
 
     @staticmethod
     def _set_option(cvc4, name, value):
-        try:
-            cvc4.setOption(name, CVC4.SExpr(value))
-        except CVC4.OptionException:
-            raise ValueError("Error setting the option '%s=%s'" % (name,value))
+        cvc4.setOption(name, CVC4.SExpr(value))
 
     def __call__(self, solver):
         self._set_option(solver.cvc4,

--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -49,7 +49,10 @@ class CVC4Options(SolverOptions):
 
     @staticmethod
     def _set_option(cvc4, name, value):
-        cvc4.setOption(name, CVC4.SExpr(value))
+        try:
+            cvc4.setOption(name, CVC4.SExpr(value))
+        except:
+            raise ValueError("Error setting the option '%s=%s'" % (name,value))
 
     def __call__(self, solver):
         self._set_option(solver.cvc4,
@@ -122,7 +125,7 @@ class CVC4Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
         else:
             try:
                 res = self.cvc4.checkSat()
-            except CVC4.LogicException as ex:
+            except:
                 raise InternalSolverError(ex.toString())
 
         # Convert returned type

--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -43,7 +43,7 @@ class CVC4Options(SolverOptions):
     def __init__(self, **base_options):
         SolverOptions.__init__(self, **base_options)
         # TODO: CVC4 Supports UnsatCore extraction
-        # but we did not wrapped it yet.
+        # but we did not wrapped it yet. (See #349)
         if self.unsat_cores_mode is not None:
             raise ValueError("'unsat_cores_mode' option not supported.")
 
@@ -126,7 +126,7 @@ class CVC4Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
             try:
                 res = self.cvc4.checkSat()
             except:
-                raise InternalSolverError(ex.toString())
+                raise InternalSolverError()
 
         # Convert returned type
         res_type = res.isSat()

--- a/pysmt/solvers/smtlib.py
+++ b/pysmt/solvers/smtlib.py
@@ -33,7 +33,6 @@ class SmtLibSolver(object):
         """
         raise NotImplementedError
 
-
     def declare_fun(self, symbol):
         """ Declare a function symbol.
 
@@ -73,7 +72,6 @@ class SmtLibSolver(object):
         """
         raise NotImplementedError
 
-
     def declare_sort(self, name, cardinality):
         """ Declares a new sort with the given name and cardinality.
 
@@ -83,7 +81,6 @@ class SmtLibSolver(object):
         """
         raise NotImplementedError
 
-
     def define_sort(self, name, args, sort_expr):
         """ Declares a symbol as an abreviation for a sort-expression.
 
@@ -91,7 +88,6 @@ class SmtLibSolver(object):
         :returns: None - might raise exception
         """
         raise NotImplementedError
-
 
     def assert_(self, expr, named=None):
         """ Assert the given expression.
@@ -103,14 +99,12 @@ class SmtLibSolver(object):
         """
         raise NotImplementedError
 
-
     def get_assertions(self):
         """ Returns a list of asserted expressions.
 
         Restrictions: Only after set-logic.
         """
         raise NotImplementedError
-
 
     def check_sat(self):
         """ Checks the satisfiability of the formula.
@@ -120,7 +114,6 @@ class SmtLibSolver(object):
         :returns: SAT, UNSAT, Unknown
         """
         raise NotImplementedError
-
 
     def get_proof(self):
         """ Returns a proof of unsatisfiability.
@@ -134,7 +127,6 @@ class SmtLibSolver(object):
         """
         raise NotImplementedError
 
-
     def get_unsat_core(self):
         """ Returns the unsat cores.
 
@@ -145,7 +137,6 @@ class SmtLibSolver(object):
         Note: Requires elements to be named.
         """
         raise NotImplementedError
-
 
     def get_values(self, exprs):
         """ Returns the value of the expressions if a model was found.
@@ -171,14 +162,12 @@ class SmtLibSolver(object):
         """
         raise NotImplementedError
 
-
     def push(self, levels=1):
         """ Push the current context of the given number of levels.
 
         Restrictions: after set-logic
         """
         raise NotImplementedError
-
 
     def pop(self, levels=1):
         """ Pop the context of the given number of levels.
@@ -187,11 +176,9 @@ class SmtLibSolver(object):
         """
         raise NotImplementedError
 
-
     def get_option(self, name):
         """ Gets the value of the given option from the solver."""
         raise NotImplementedError
-
 
     def set_option(self, name, value):
         """ Sets the given value for the option in the solver.
@@ -216,11 +203,9 @@ class SmtLibSolver(object):
         """
         raise NotImplementedError
 
-
     def get_info(self, name):
         """ Gets the value of a given information. """
         raise NotImplementedError
-
 
     def set_info(self, name, value):
         """ Sets the value for a given information.
@@ -235,7 +220,6 @@ class SmtLibSolver(object):
         * :all-statistics
         """
         raise NotImplementedError
-
 
     def exit(self):
         """Destroys the solver."""

--- a/pysmt/solvers/solver.py
+++ b/pysmt/solvers/solver.py
@@ -15,29 +15,74 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+import abc
+
 from pysmt.typing import BOOL
 from pysmt.exceptions import SolverReturnedUnknownResultError
 from six.moves import xrange
 
 
 class SolverOptions(object):
-    """Solver Options shared by most solvers."""
+    """Solver Options shared by most solvers.
 
-    VALID_OPTIONS = [("generate_models", True),
-                     ("unsat_cores_mode", None),
-                     ("incremental", True),
-    ]
+    * generate_models : True, False
+      Enable model generation. Needed for get_value, get_model etc.
 
-    def __init__(self, **kwargs):
-        for name, default in self.VALID_OPTIONS:
-            if name in kwargs:
-                setattr(self, name, kwargs[name])
-            else:
-                setattr(self, name, default)
+    * incremental: True, False
+      Enable incremental interface (push, pop)
 
-        for k in kwargs:
-            if k not in [n for (n, _) in self.VALID_OPTIONS]:
-                raise ValueError("Unrecognized option '%s'" % k)
+    * unsat_cores_mode: None, "named", "all"
+      Enable UNSAT core extraction using "named" or "all" strategy.
+
+    * random_seed: None, integer
+      Sets the random seed for the solver
+
+    * solver_options: dictionary
+      Provides solver specific options
+
+    """
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, generate_models=True, incremental=True,
+                 unsat_cores_mode=None, random_seed=None,
+                 solver_options=None):
+
+        if generate_models not in (True, False):
+            raise ValueError("Invalid value %s for 'generate_models'" \
+                             % generate_models)
+        self.generate_models = generate_models
+
+        if incremental not in (True, False):
+            raise ValueError("Invalid value %s for 'incremental'" \
+                             % incremental)
+        self.incremental = incremental
+
+        if unsat_cores_mode not in (None, "named", "all"):
+            raise ValueError("Invalid value %s for 'unsat_cores_mode'" \
+                             % unsat_cores_mode)
+        self.unsat_cores_mode = unsat_cores_mode
+
+        if random_seed is not None and type(random_seed) != int:
+            raise ValueError("Invalid value %s for 'random_seed'" \
+                             % random_seed)
+        self.random_seed = random_seed
+
+        if solver_options is not None:
+            try:
+                solver_options = dict(solver_options)
+            except:
+                raise ValueError("Invalid value %s for 'solver_options'" \
+                                 % solver_options)
+        else:
+            solver_options = dict()
+        self.solver_options = solver_options
+
+    @abc.abstractmethod
+    def __call__(self, solver):
+        """Handle the setting options within solver"""
+        raise NotImplementedError
+
+# EOC SolverOptions
 
 
 class Solver(object):
@@ -73,6 +118,13 @@ class Solver(object):
         assert formula in self.environment.formula_manager, \
                "Formula does not belong to the current Formula Manager"
 
+        if not self.options.incremental:
+            # If not incremental, we only need to assert and solve
+            self.add_assertion(formula)
+            return self.solve()
+
+        # Try to be incremental using push/pop but fallback to
+        # solving under assumption if push/pop is not implemented
         use_solving_under_assumption = False
         try:
             self.push()

--- a/pysmt/test/smtlib/test_generic_wrapper.py
+++ b/pysmt/test/smtlib/test_generic_wrapper.py
@@ -66,6 +66,19 @@ class TestGenericWrapper(TestCase):
                 self.assertFalse(res)
 
     @skipIf(len(ALL_WRAPPERS) == 0, "No wrapper available")
+    def test_generic_wrapper_enable_debug(self):
+        a = Symbol("A", BOOL)
+        f = And(a, Not(a))
+
+        for n in self.all_solvers:
+            with Solver(name=n, logic=QF_BOOL,
+                        solver_options={'debug_interaction':True}) as s:
+                s.add_assertion(f)
+                res = s.solve()
+                self.assertFalse(res)
+
+
+    @skipIf(len(ALL_WRAPPERS) == 0, "No wrapper available")
     def test_generic_wrapper_model(self):
         a = Symbol("A", BOOL)
         b = Symbol("B", BOOL)

--- a/pysmt/test/test_bdd.py
+++ b/pysmt/test/test_bdd.py
@@ -120,7 +120,7 @@ class TestBdd(TestCase):
     @skipIfSolverNotAvailable("bdd")
     def test_reordering(self):
         with Solver(name="bdd", logic=BOOL,
-                    dynamic_reordering=True) as s:
+                    solver_options={'dynamic_reordering': True}) as s:
             s.add_assertion(self.big_tree)
             self.assertTrue(s.solve())
 
@@ -129,8 +129,8 @@ class TestBdd(TestCase):
         from pysmt.solvers.bdd import BddOptions
         for algo in BddOptions.CUDD_ALL_REORDERING_ALGORITHMS:
             with Solver(name="bdd", logic=BOOL,
-                        dynamic_reordering=True,
-                        reordering_algorithm=algo) as s:
+                        solver_options={'dynamic_reordering': True,
+                                        'reordering_algorithm': algo}) as s:
                 s.add_assertion(self.big_tree)
                 self.assertTrue(s.solve())
                 self.assertEqual(algo, s.ddmanager.ReorderingStatus()[1])
@@ -142,7 +142,7 @@ class TestBdd(TestCase):
 
         for order in [f_order, r_order]:
             with Solver(name="bdd", logic=BOOL,
-                        static_ordering=order) as s:
+                        solver_options={'static_ordering': order}) as s:
                 s.add_assertion(self.big_tree)
                 self.assertTrue(s.solve())
 
@@ -156,13 +156,14 @@ class TestBdd(TestCase):
     def test_invalid_ordering(self):
         with self.assertRaises(ValueError):
             Solver(name="bdd", logic=BOOL,
-                   static_ordering=[And(self.x, self.y), self.y])
+                   solver_options={'static_ordering':
+                                   [And(self.x, self.y), self.y]})
 
     @skipIfSolverNotAvailable("bdd")
     def test_initial_ordering(self):
         with Solver(name="bdd", logic=BOOL,
-                       static_ordering=[self.x, self.y],
-                       dynamic_reordering=True) as s:
+                    solver_options={'static_ordering':[self.x, self.y],
+                                    'dynamic_reordering':True}) as s:
             s.add_assertion(self.big_tree)
             self.assertTrue(s.solve())
             self.assertNotEquals(s.ddmanager.ReorderingStatus()[1], 0)

--- a/pysmt/test/test_rewritings.py
+++ b/pysmt/test/test_rewritings.py
@@ -15,6 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from nose.plugins.attrib import attr
 from pysmt.shortcuts import (And, Iff, Or, Symbol, Implies, Not,
                              Exists, ForAll,
                              Times, Plus, Minus, Equals, Real,
@@ -166,27 +167,11 @@ class TestRewritings(TestCase):
         self.assertValid(Equals(fp, target), fp)
         self.assertTrue(fp.is_plus(), fp)
 
-
-    @skipIfNoSolverForLogic(QF_NIA)
-    def test_times_distributivity_smtlib_nia(self):
-        from pysmt.test.smtlib.parser_utils import formulas_from_smtlib_test_set
-        test_set = formulas_from_smtlib_test_set(logics=[QF_LIA, QF_NIA])
-        for (logic, fname, f, ex_res) in test_set:
-            print(fname)
-            td = TimesDistributor()
-            _ = td.walk(f)
-            for (old, new) in td.memoization.items():
-                if not old.is_times(): continue
-                if old is new: continue # Nothing changed
-                self.assertValid(Equals(old, new),
-                                 (old, new), solver_name="z3")
-
     @skipIfNoSolverForLogic(QF_NRA)
     def test_times_distributivity_smtlib_nra(self):
         from pysmt.test.smtlib.parser_utils import formulas_from_smtlib_test_set
         test_set = formulas_from_smtlib_test_set(logics=[QF_LRA, QF_NRA])
-        for (logic, fname, f, ex_res) in test_set:
-            print(fname)
+        for (_, fname, f, _) in test_set:
             td = TimesDistributor()
             _ = td.walk(f)
             for (old, new) in td.memoization.items():

--- a/pysmt/test/test_rewritings.py
+++ b/pysmt/test/test_rewritings.py
@@ -15,7 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from nose.plugins.attrib import attr
 from pysmt.shortcuts import (And, Iff, Or, Symbol, Implies, Not,
                              Exists, ForAll,
                              Times, Plus, Minus, Equals, Real,
@@ -26,7 +25,7 @@ from pysmt.rewritings import disjunctive_partition
 from pysmt.rewritings import TimesDistributor
 from pysmt.test.examples import get_example_formulae
 from pysmt.exceptions import SolverReturnedUnknownResultError
-from pysmt.logics import BOOL, QF_NRA, QF_LRA, QF_LIA, QF_NIA
+from pysmt.logics import BOOL, QF_NRA, QF_LRA, QF_LIA
 from pysmt.typing import REAL
 
 

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -549,20 +549,19 @@ class TestBasic(TestCase):
         from pysmt.solvers.pico import PicosatOptions
         from tempfile import TemporaryFile
         x, y = Symbol("x"), Symbol("y")
-        fout = TemporaryFile()
-        solver_options = {'preprocessing': False,
-                          'enable_trace_generation': False,
-                          'output': fout,
-                          'global_default_phase': PicosatOptions.GLOBAL_DEFAULT_PHASE_FALSE,
-                          'more_important_lit': [x],
-                          'less_important_lit': [y],
-                          'propagation_limit': 100,
-                          'verbosity': 1,
-                      }
-        with Solver(name='picosat', solver_options=solver_options) as s:
-            s.add_assertion(And(x,y))
-            s.solve()
-        fout.close()
+        with TemporaryFile() as fout:
+            solver_options = {'preprocessing': False,
+                              'enable_trace_generation': False,
+                              'output': fout,
+                              'global_default_phase': PicosatOptions.GLOBAL_DEFAULT_PHASE_FALSE,
+                              'more_important_lit': [x],
+                              'less_important_lit': [y],
+                              'propagation_limit': 100,
+                              'verbosity': 1,
+                          }
+            with Solver(name='picosat', solver_options=solver_options) as s:
+                s.add_assertion(And(x,y))
+                s.solve()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Options that are shared by multiple solvers are handled as keywords
arguments, but solver-dependent options are defined in the
solver_options dictionary:

  Solver(name='picosat', generate_models=True,
         solver_options={'propagation_limit': 100})

The goal is to clearly separate these two type of configurations.
The use of dictionary for solver_options, makes it simple to store
multiple configurations:

  Solver(name=sname, solver_options=myoptions[sname])

All solvers have been ported to this new strategy, by using a custom
SolverOptions object that is responsible for the definition, checking
and setting of the options. This object is used (for example) to
correctly setup the mathsat context.

Option "random_seed" is now supported by all the solvers (that do
support it).

Backwards Incompatible Changes:

* MathSAT5Solver option 'debugFile' has been removed. Use the
  solver option: "debug_api_call_trace_filename".

* BddSolver used to have the options as keyword
  arguments (static_ordering, dynamic_reordering etc). This is not
  supported anymore.