### PR TITLE
fixed a bug when printing arrays

### DIFF
--- a/pysmt/fnode.py
+++ b/pysmt/fnode.py
@@ -594,9 +594,10 @@ class FNode(object):
 
     def array_value_assigned_values_map(self):
         res = {}
-        args = self.args()
-        for i,c in enumerate(args[1::2]):
-            res[c] = args[i+1]
+        args_a = self.args()[1:-1:2]
+        args_b = self.args()[2::2]
+        for i in range(len(args_a)):
+            res[args_a[i]] = args_b[i]
         return res
 
     def array_value_default(self):


### PR DESCRIPTION
There was a bug when printing the values of Arrays.

```python
a = Array(INT, Int(0), {Int(1):Int(2)})
print a 
```

prints `Array{Int, Int}(0)[1 := 1]` instead of `Array{Int, Int}(0)[1 := 2]`