### PR TITLE
Coverage via Coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = pysmt/cmd/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,3 +97,7 @@ install:
 
 script:
   - "./ci/travis_script.sh"
+
+success:
+  - coveralls
+#

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,10 @@ pySMT: a Python API for SMT
            :target: https://travis-ci.org/pysmt/pysmt
            :alt: Build Status
 
+.. image:: https://coveralls.io/repos/github/pysmt/pysmt/badge.svg
+           :target: https://coveralls.io/github/pysmt/pysmt
+           :alt: Coverage
+
 .. image:: https://readthedocs.org/projects/pysmt/badge/?version=latest
            :target: https://pysmt.readthedocs.io/en/latest/
            :alt: Documentation Status

--- a/ci/travis_install.sh
+++ b/ci/travis_install.sh
@@ -36,6 +36,7 @@ pip install six
 if [ "${PYSMT_SOLVER}" == "all" ] || [ "${PYSMT_SOLVER}" == "btor" ];
 then
     pip install cython;
+    pip install python-coveralls;
 fi
 
 if [ "${PYSMT_GMPY}" == "TRUE" ];

--- a/ci/travis_script.sh
+++ b/ci/travis_script.sh
@@ -30,8 +30,13 @@ python install.py --check
 
 #
 # Run the test suite
-#
-nosetests pysmt -v
+#  * Coverage is enabled only on master / all
+if [ "${TRAVIS_BRANCH}" == "master" ] && [ "${PYSMT_SOLVER}" == "all" ];
+then
+  nosetests pysmt -v --with-coverage --cover-package=pysmt
+else
+  nosetests pysmt -v
+fi
 
 #
 # Test examples in examples/ folder


### PR DESCRIPTION
Run coverage analysis using coveralls.io .

This is enabled only on master (both PR and push) and for the 'all' configuration, only. This is because enabling coverage tracking slows down the tests quite a bit.