### PR TITLE
Created Apache Image and link to Apache 2.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -198,6 +198,9 @@ The following table summarizes the features supported via pySMT for each of the 
 
 License
 =======
+.. image:: https://www.apache.org/img/asf_logo.png
+           :target: https://www.apache.org/licenses/LICENSE-2.0
+           :alt: Apache 2.0 License
 
 pySMT is release under the APACHE 2.0 License.
 


### PR DESCRIPTION
Adds aesthetic improvement to the license portion of the readme.
Also provides a quick way to learn more about apache licensing, with a direct link to the site.