### PR TITLE
Walker Refactoring

### DIFF
--- a/examples/ltl.py
+++ b/examples/ltl.py
@@ -1,0 +1,180 @@
+# Linear Temporal Logic
+#
+# This example shows how to extend pySMT in order to support
+# additional operators. This can be achieved without modifying the
+# pySMT source code.
+#
+# We use LTL as an example, and we define some basic operators.
+#
+
+# First we need to define the new operators, or "node types"
+from pysmt.operators import new_node_type
+
+LTL_X = new_node_type(node_str="LTL_X")
+LTL_Y = new_node_type(node_str="LTL_Y")
+LTL_Z = new_node_type(node_str="LTL_Z")
+LTL_F = new_node_type(node_str="LTL_F")
+LTL_G = new_node_type(node_str="LTL_G")
+LTL_O = new_node_type(node_str="LTL_O")
+LTL_H = new_node_type(node_str="LTL_H")
+LTL_U = new_node_type(node_str="LTL_U")
+LTL_S = new_node_type(node_str="LTL_S")
+ALL_LTL = (LTL_X, LTL_Y, LTL_Z,
+           LTL_F, LTL_G, LTL_O, LTL_H,
+           LTL_U, LTL_S)
+
+# The FormulaManager needs to be extended to be able to use these
+# operators. Notice that additional checks, and some simplifications
+# can be performed at construction time. We keep this example simple.
+import pysmt.environment
+import pysmt.formula
+
+class FormulaManager(pysmt.formula.FormulaManager):
+    """Extension of FormulaManager to handle LTL Operators."""
+    def X(self, formula):
+        return self.create_node(node_type=LTL_X, args=(formula,))
+
+    def Y(self, formula):
+        return self.create_node(node_type=LTL_Y, args=(formula,))
+
+    def Z(self, formula):
+        return self.create_node(node_type=LTL_Z, args=(formula,))
+
+    def F(self, formula):
+        return self.create_node(node_type=LTL_F, args=(formula,))
+
+    def G(self, formula):
+        return self.create_node(node_type=LTL_G, args=(formula,))
+
+    def O(self, formula):
+        return self.create_node(node_type=LTL_O, args=(formula,))
+
+    def H(self, formula):
+        return self.create_node(node_type=LTL_H, args=(formula,))
+
+    def S(self, left, right):
+        return self.create_node(node_type=LTL_S, args=(left, right))
+
+    def U(self, left, right):
+        return self.create_node(node_type=LTL_U, args=(left, right))
+
+    # We can also add syntactic sugar, by creating constructors that
+    # are not mapped directly to a new node type. For example X^n:
+    def Xn(self, n, formula):
+        X_ = self.X
+        res = formula
+        for _ in range(n):
+            res = X_(res)
+        return res
+
+#
+# For the system to work, we need to extend a few walkers.
+#
+
+# The first extension is the TypeChecker. The typechecker provides
+# several convenience methods for many types of operators. In this
+# case, all the LTL operators have boolean argument and boolean return
+# value, therefore we map them all to walk_bool_to_bool.
+#
+# This is an example of how to extend an existing class
+# (SimpleTypeChecker) in order to deal with new node-types, by calling
+# an existing method (walk_bool_to_bool).
+from pysmt.type_checker import SimpleTypeChecker
+SimpleTypeChecker.set_handler(SimpleTypeChecker.walk_bool_to_bool, *ALL_LTL)
+
+from pysmt.oracles import FreeVarsOracle
+FreeVarsOracle.set_handler(FreeVarsOracle.walk_simple_args, *ALL_LTL)
+
+# An alternative approach is to subclass the walker that we are
+# interested in. For example, the HRPrinter has utility methods for
+# the nary operators. For the unary operators, we define a unique
+# function.  The walk_* method that we override needs to have the same
+# name as the string used in new_node_type (lowercase): for LTL_G, we
+# override walk_ltl_g.
+
+import pysmt.printers
+from pysmt.walkers.generic import handles
+LTL_TYPE_TO_STR = { LTL_X: "X", LTL_Y: "Y", LTL_Z: "Z",
+                    LTL_F: "F", LTL_G: "F", LTL_O: "O", LTL_H: "H"}
+
+class HRPrinter(pysmt.printers.HRPrinter):
+    def walk_ltl_s(self, formula):
+        return self.walk_nary(formula, " S ")
+
+    def walk_ltl_u(self, formula):
+        return self.walk_nary(formula, " U ")
+
+    @handles(LTL_X, LTL_Y, LTL_Z, LTL_F, LTL_G, LTL_O, LTL_H)
+    def walk_ltl(self, formula):
+        node_type = formula.node_type()
+        op_symbol = LTL_TYPE_TO_STR[node_type]
+        self.stream.write("(%s " % op_symbol)
+        yield formula.arg(0)
+        self.stream.write(")")
+
+# EOC HRPrinter
+
+class HRSerializer(pysmt.printers.HRSerializer):
+    PrinterClass = HRPrinter
+
+# EOC HRSerialize
+
+# Finally, a third option is to define new methods and attach them to
+# existing classes. We do so for the IdentityDagWalker
+from pysmt.walkers import IdentityDagWalker
+
+def walk_ltl_x(self, formula, args, **kwargs): return self.mgr.X(args[0])
+def walk_ltl_y(self, formula, args, **kwargs): return self.mgr.Y(args[0])
+def walk_ltl_u(self, formula, args, **kwargs): return self.mgr.U(args[0], args[1])
+def walk_ltl_s(self, formula, args, **kwargs): return self.mgr.S(args[0], args[1])
+def walk_ltl_f(self, formula, args, **kwargs): return self.mgr.F(args[0])
+def walk_ltl_g(self, formula, args, **kwargs): return self.mgr.G(args[0])
+def walk_ltl_o(self, formula, args, **kwargs): return self.mgr.O(args[0])
+def walk_ltl_h(self, formula, args, **kwargs): return self.mgr.H(args[0])
+
+IdentityDagWalker.set_handler(walk_ltl_x, LTL_X)
+IdentityDagWalker.set_handler(walk_ltl_y, LTL_Y)
+IdentityDagWalker.set_handler(walk_ltl_u, LTL_U)
+IdentityDagWalker.set_handler(walk_ltl_s, LTL_S)
+IdentityDagWalker.set_handler(walk_ltl_f, LTL_F)
+IdentityDagWalker.set_handler(walk_ltl_g, LTL_G)
+IdentityDagWalker.set_handler(walk_ltl_o, LTL_O)
+IdentityDagWalker.set_handler(walk_ltl_h, LTL_H)
+# EOC IdentityDagWalker
+
+from pysmt.environment import Environment, pop_env, get_env
+from pysmt.environment import push_env as pysmt_push_env
+
+class EnvironmentLTL(Environment):
+    """Extension of pySMT environment."""
+    # Only specify new classes. Classes that have been extended
+    # directly do not need to be redefined here (e.g., TypeChecker)
+    FormulaManagerClass = FormulaManager
+    HRSerializerClass = HRSerializer
+
+# EOC EnvironmentLTL
+
+
+def push_env(env=None):
+    """Overload push_env to default to the new Environment class."""
+    if env is None:
+        env = EnvironmentLTL()
+    return pysmt_push_env(env=env)
+
+def reset_env():
+    """Overload reset_env to use the new push_env()."""
+    pop_env()
+    push_env()
+    return get_env()
+
+# Create the default environment
+reset_env()
+
+
+if __name__ == "__main__":
+    with EnvironmentLTL() as env:
+        mgr = env.formula_manager
+        f = mgr.X(mgr.Symbol("x"))
+        g = mgr.G(f)
+        print(g)
+        print(g.get_free_variables())

--- a/pysmt/fnode.py
+++ b/pysmt/fnode.py
@@ -861,4 +861,5 @@ def _mgr():
 def _is_bv(node):
     """Aux function to check if a fnode is a BV."""
     return (node.is_symbol() and node.symbol_type().is_bv_type()) or \
+            node.node_type() is BV_CONSTANT or\
             node.node_type() in BV_OPERATORS

--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -978,7 +978,7 @@ class FormulaContextualizer(IdentityDagWalker):
         IdentityDagWalker.__init__(self, env=env)
         self.type_normalize = self.env.type_manager.normalize
 
-    def walk_symbol(self, formula, **kwargs):
+    def walk_symbol(self, formula, args, **kwargs):
         # Recreate the Symbol taking into account the type information
         ty = formula.symbol_type()
         newty = self.type_normalize(ty)
@@ -989,3 +989,9 @@ class FormulaContextualizer(IdentityDagWalker):
         assign = dict(zip(args[1::2], args[2::2]))
         ty = self.type_normalize(formula.array_value_index_type())
         return self.mgr.Array(ty, args[0], assign)
+
+    def walk_function(self, formula, args, **kwargs):
+        # We re-create the symbol name
+        old_name = formula.function_name()
+        new_name = self.walk_symbol(old_name, None)
+        return self.mgr.Function(new_name, args)

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -32,7 +32,7 @@ from pysmt import typing as types
 from pysmt.logics import Logic, Theory, get_closer_pysmt_logic
 
 
-class SizeOracle(pysmt.walkers.DagWalker):
+class SizeOracle(walkers.DagWalker):
     """Evaluates the size of a formula"""
 
     # Counting type can be:
@@ -50,7 +50,7 @@ class SizeOracle(pysmt.walkers.DagWalker):
      MEASURE_BOOL_DAG) = range(6)
 
     def __init__(self, env=None):
-        pysmt.walkers.DagWalker.__init__(self, env=env)
+        walkers.DagWalker.__init__(self, env=env)
 
         self.measure_to_fun = \
                         {SizeOracle.MEASURE_TREE_NODES: self.walk_count_tree,
@@ -122,42 +122,28 @@ class SizeOracle(pysmt.walkers.DagWalker):
         return frozenset([formula]) | frozenset([x for s in args for x in s])
 
 
-class QuantifierOracle(pysmt.walkers.DagWalker):
-    def __init__(self, env=None):
-        pysmt.walkers.DagWalker.__init__(self, env=env)
-
-        # Propagate truth value, and force False when a Quantifier
-        # is found.
-        self.set_function(self.walk_all, *op.ALL_TYPES)
-        self.set_function(self.walk_false, op.FORALL, op.EXISTS)
-
+class QuantifierOracle(walkers.DagWalker):
     def is_qf(self, formula):
         """ Returns whether formula is Quantifier Free. """
         return self.walk(formula)
 
+    # Propagate truth value, but force False if a Quantifier is found.
+    @walkers.handles(set(op.ALL_TYPES) - op.QUANTIFIERS)
+    def walk_all(self, formula, args, **kwargs):
+        return walkers.DagWalker.walk_all(self, formula, args, **kwargs)
+
+    @walkers.handles(op.QUANTIFIERS)
+    def walk_false(self, formula, args, **kwargs):
+        return walkers.DagWalker.walk_false(self, formula, args, **kwargs)
 
 # EOC QuantifierOracle
 
 
-class TheoryOracle(pysmt.walkers.DagWalker):
-    def __init__(self, env=None):
-        pysmt.walkers.DagWalker.__init__(self, env=env)
+class TheoryOracle(walkers.DagWalker):
 
-        self.set_function(self.walk_combine, op.AND, op.OR, op.NOT, op.IMPLIES,
-                          op.IFF, op.LE, op.LT, op.FORALL, op.EXISTS, op.MINUS,
-                          op.ITE, op.ARRAY_SELECT, op.ARRAY_STORE)
-        # Just propagate BV
-        self.set_function(self.walk_combine, *op.BV_OPERATORS)
-
-        self.set_function(self.walk_constant, op.REAL_CONSTANT, op.BOOL_CONSTANT,
-                          op.INT_CONSTANT, op.BV_CONSTANT)
-        self.set_function(self.walk_symbol, op.SYMBOL)
-        self.set_function(self.walk_function, op.FUNCTION)
-        self.set_function(self.walk_lira, op.TOREAL)
-        self.set_function(self.walk_times, op.TIMES)
-        self.set_function(self.walk_plus, op.PLUS)
-        self.set_function(self.walk_equals, op.EQUALS)
-        self.set_function(self.walk_array_value, op.ARRAY_VALUE)
+    def get_theory(self, formula):
+        """Returns the thoery for the formula."""
+        return self.walk(formula)
 
     def _theory_from_type(self, ty):
         theory = None
@@ -178,20 +164,25 @@ class TheoryOracle(pysmt.walkers.DagWalker):
             theory = Theory(uninterpreted=True)
         return theory
 
+    @walkers.handles(op.RELATIONS)
+    @walkers.handles(op.BOOL_OPERATORS)
+    @walkers.handles(op.BV_OPERATORS)
+    @walkers.handles(op.ITE, op.ARRAY_SELECT, op.ARRAY_STORE, op.MINUS)
     def walk_combine(self, formula, args, **kwargs):
-        #pylint: disable=unused-argument
         """Combines the current theory value of the children"""
+        #pylint: disable=unused-argument
         if len(args) == 1:
             return args[0].copy()
-
         theory_out = args[0]
         for t in args[1:]:
             theory_out = theory_out.combine(t)
         return theory_out
 
+    @walkers.handles(op.REAL_CONSTANT, op.BOOL_CONSTANT)
+    @walkers.handles(op.INT_CONSTANT, op.BV_CONSTANT)
     def walk_constant(self, formula, args, **kwargs):
-        #pylint: disable=unused-argument
         """Returns a new theory object with the type of the constant."""
+        #pylint: disable=unused-argument
         if formula.is_real_constant():
             theory_out = Theory(real_arithmetic=True, real_difference=True)
         elif formula.is_int_constant():
@@ -201,18 +192,18 @@ class TheoryOracle(pysmt.walkers.DagWalker):
         else:
             assert formula.is_bool_constant()
             theory_out = Theory()
-
         return theory_out
 
     def walk_symbol(self, formula, args, **kwargs):
-        #pylint: disable=unused-argument
         """Returns a new theory object with the type of the symbol."""
+        #pylint: disable=unused-argument
         f_type = formula.symbol_type()
         theory_out = self._theory_from_type(f_type)
         return theory_out
 
     def walk_function(self, formula, args, **kwargs):
         """Extends the Theory with UF."""
+        #pylint: disable=unused-argument
         if len(args) == 1:
             theory_out = args[0].copy()
         elif len(args) > 1:
@@ -221,10 +212,10 @@ class TheoryOracle(pysmt.walkers.DagWalker):
                 theory_out = theory_out.combine(t)
         else:
             theory_out = Theory()
-
         theory_out.uninterpreted = True
         return theory_out
 
+    @walkers.handles(op.TOREAL)
     def walk_lira(self, formula, args, **kwargs):
         #pylint: disable=unused-argument
         """Extends the Theory with LIRA."""
@@ -257,9 +248,6 @@ class TheoryOracle(pysmt.walkers.DagWalker):
         assert not theory_out.integer_difference
         return theory_out
 
-    def walk_equals(self, formula, args, **kwargs):
-        return self.walk_combine(formula, args)
-
     def walk_array_value(self, formula, args, **kwargs):
         # First, we combine all the theories of all the indexes and values
         theory_out = self.walk_combine(formula, args)
@@ -289,10 +277,6 @@ class TheoryOracle(pysmt.walkers.DagWalker):
         theory_out = theory_out.set_difference_logic(False)
         return theory_out
 
-    def get_theory(self, formula):
-        """Returns the thoery for the formula."""
-        return self.walk(formula)
-
 # EOC TheoryOracle
 
 
@@ -300,31 +284,19 @@ class TheoryOracle(pysmt.walkers.DagWalker):
 DEPENDENCIES_SIMPLE_ARGS = (set(op.ALL_TYPES) - \
                            (set([op.SYMBOL, op.FUNCTION]) | op.QUANTIFIERS | op.CONSTANTS))
 
-class FreeVarsOracle(pysmt.walkers.DagWalker):
-    def __init__(self, env=None):
-        pysmt.walkers.DagWalker.__init__(self, env=env)
-
-        # We have only few categories for this walker.
-        #
-        # - Simple Args simply need to combine the cone/dependencies
-        #   of the children.
-        # - Quantifiers need to exclude bounded variables
-        # - Constants have no impact
-        #
-        self.set_function(self.walk_error, *op.ALL_TYPES)
-        self.set_function(self.walk_simple_args, *DEPENDENCIES_SIMPLE_ARGS)
-        self.set_function(self.walk_constant, *op.CONSTANTS)
-        self.set_function(self.walk_quantifier, *op.QUANTIFIERS)
-
-        # These are the only 2 cases that can introduce elements.
-        self.set_function(self.walk_symbol, op.SYMBOL)
-        self.set_function(self.walk_function, op.FUNCTION)
-
+class FreeVarsOracle(walkers.DagWalker):
+    # We have only few categories for this walker.
+    #
+    # - Simple Args simply need to combine the cone/dependencies
+    #   of the children.
+    # - Quantifiers need to exclude bounded variables
+    # - Constants have no impact
 
     def get_free_variables(self, formula):
         """Returns the set of Symbols appearing free in the formula."""
         return self.walk(formula)
 
+    @walkers.handles(DEPENDENCIES_SIMPLE_ARGS)
     def walk_simple_args(self, formula, args, **kwargs):
         #pylint: disable=unused-argument
         res = set()
@@ -332,6 +304,7 @@ class FreeVarsOracle(pysmt.walkers.DagWalker):
             res.update(arg)
         return frozenset(res)
 
+    @walkers.handles(op.QUANTIFIERS)
     def walk_quantifier(self, formula, args, **kwargs):
         #pylint: disable=unused-argument
         return args[0].difference(formula.quantifier_vars())
@@ -340,6 +313,7 @@ class FreeVarsOracle(pysmt.walkers.DagWalker):
         #pylint: disable=unused-argument
         return frozenset([formula])
 
+    @walkers.handles(op.CONSTANTS)
     def walk_constant(self, formula, args, **kwargs):
         #pylint: disable=unused-argument
         return frozenset()
@@ -352,48 +326,46 @@ class FreeVarsOracle(pysmt.walkers.DagWalker):
 
 # EOC FreeVarsOracle
 
-class AtomsOracle(pysmt.walkers.DagWalker):
+
+class AtomsOracle(walkers.DagWalker):
     """This class returns the set of Boolean atoms involved in a formula
     A boolean atom is either a boolean variable or a theory atom
     """
-    def __init__(self, env=None):
-        pysmt.walkers.DagWalker.__init__(self, env=env)
-
-        # We have the following categories for this walker.
-        #
-        # - Boolean operators, e.g. and, or, not...
-        # - Theory operators, e.g. +, -, bvshift
-        # - Theory relations, e.g. ==, <=
-        # - ITE terms
-        # - Symbols
-        # - Constants
-        #
-        self.set_function(self.walk_error, *op.ALL_TYPES)
-        self.set_function(self.walk_bool_op, *op.BOOL_CONNECTIVES)
-        self.set_function(self.walk_bool_op, *op.QUANTIFIERS)
-        self.set_function(self.walk_constant, *op.CONSTANTS)
-        self.set_function(self.walk_theory_op, *op.THEORY_OPERATORS)
-        self.set_function(self.walk_theory_relation, *op.RELATIONS)
-
-        self.set_function(self.walk_symbol, op.SYMBOL)
-        self.set_function(self.walk_function, op.FUNCTION)
-        self.set_function(self.walk_ite, op.ITE)
-
+    # We have the following categories for this walker.
+    #
+    # - Boolean operators, e.g. and, or, not...
+    # - Theory operators, e.g. +, -, bvshift
+    # - Theory relations, e.g. ==, <=
+    # - ITE terms
+    # - Symbols
+    # - Constants
+    #
 
     def get_atoms(self, formula):
         """Returns the set of atoms appearing in the formula."""
         return self.walk(formula)
 
+    @walkers.handles(op.BOOL_CONNECTIVES)
+    @walkers.handles(op.QUANTIFIERS)
     def walk_bool_op(self, formula, args, **kwargs):
         #pylint: disable=unused-argument
         return frozenset(x for a in args for x in a)
 
+    @walkers.handles(op.RELATIONS)
     def walk_theory_relation(self, formula, **kwargs):
         #pylint: disable=unused-argument
         return frozenset([formula])
 
+    @walkers.handles(op.THEORY_OPERATORS)
     def walk_theory_op(self, formula, **kwargs):
         #pylint: disable=unused-argument
+        return None
+
+    @walkers.handles(op.CONSTANTS)
+    def walk_constant(self, formula, **kwargs):
+        #pylint: disable=unused-argument
+        if formula.is_bool_constant():
+            return frozenset()
         return None
 
     def walk_symbol(self, formula, **kwargs):
@@ -406,12 +378,6 @@ class AtomsOracle(pysmt.walkers.DagWalker):
             return frozenset([formula])
         return None
 
-    def walk_constant(self, formula, **kwargs):
-        #pylint: disable=unused-argument
-        if formula.is_bool_constant():
-            return frozenset()
-        return None
-
     def walk_ite(self, formula, args, **kwargs):
         #pylint: disable=unused-argument
         if any(a is None for a in args):
@@ -420,6 +386,7 @@ class AtomsOracle(pysmt.walkers.DagWalker):
         else:
             return frozenset(x for a in args for x in a)
 
+# EOC AtomsOracle
 
 
 def get_logic(formula, env=None):

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -24,7 +24,7 @@ properties of formulae.
 """
 
 import pysmt
-import pysmt.walkers
+import pysmt.walkers as walkers
 import pysmt.operators as op
 
 from pysmt import typing as types
@@ -215,8 +215,7 @@ class TheoryOracle(walkers.DagWalker):
         theory_out.uninterpreted = True
         return theory_out
 
-    @walkers.handles(op.TOREAL)
-    def walk_lira(self, formula, args, **kwargs):
+    def walk_toreal(self, formula, args, **kwargs):
         #pylint: disable=unused-argument
         """Extends the Theory with LIRA."""
         theory_out = args[0].copy()

--- a/pysmt/rewritings.py
+++ b/pysmt/rewritings.py
@@ -81,11 +81,6 @@ class CNFizer(DagWalker):
             conj.append(self.mgr.Or(clause))
         return self.mgr.And(conj)
 
-    @deprecated("No Alternative")
-    def printer(self, _cnf):
-        print(self.serialize(_cnf))
-        return
-
     def serialize(self, _cnf):
         clauses = []
         for clause in _cnf:

--- a/pysmt/smtlib/printers.py
+++ b/pysmt/smtlib/printers.py
@@ -21,7 +21,7 @@ from six.moves import xrange, cStringIO
 
 import pysmt.operators as op
 from pysmt.environment import get_env
-from pysmt.walkers import TreeWalker, DagWalker
+from pysmt.walkers import TreeWalker, DagWalker, handles
 from pysmt.utils import quote
 
 
@@ -33,52 +33,6 @@ class SmtPrinter(TreeWalker):
         self.write = self.stream.write
         self.mgr = get_env().formula_manager
 
-        self.set_function(partial(self._walk_nary, "and"), op.AND)
-        self.set_function(partial(self._walk_nary, "or"), op.OR)
-        self.set_function(partial(self._walk_nary, "not"), op.NOT)
-        self.set_function(partial(self._walk_nary, "=>"), op.IMPLIES)
-        self.set_function(partial(self._walk_nary, "="), op.IFF)
-        self.set_function(partial(self._walk_nary, "+"), op.PLUS)
-        self.set_function(partial(self._walk_nary, "-"), op.MINUS)
-        self.set_function(partial(self._walk_nary, "*"), op.TIMES)
-        self.set_function(partial(self._walk_nary, "="), op.EQUALS)
-        self.set_function(partial(self._walk_nary, "<="), op.LE)
-        self.set_function(partial(self._walk_nary, "<"), op.LT)
-        self.set_function(partial(self._walk_nary, "ite"), op.ITE)
-        self.set_function(partial(self._walk_nary, "to_real"), op.TOREAL)
-        self.set_function(partial(self._walk_nary, "/"), op.DIV)
-        self.set_function(partial(self._walk_nary, "pow"), op.POW)
-
-        self.set_function(partial(self._walk_nary, "bvand"), op.BV_AND)
-        self.set_function(partial(self._walk_nary, "bvor"), op.BV_OR)
-        self.set_function(partial(self._walk_nary, "bvnot"), op.BV_NOT)
-        self.set_function(partial(self._walk_nary, "bvxor"), op.BV_XOR)
-        self.set_function(partial(self._walk_nary, "bvadd"), op.BV_ADD)
-        self.set_function(partial(self._walk_nary, "bvsub"), op.BV_SUB)
-        self.set_function(partial(self._walk_nary, "bvneg"), op.BV_NEG)
-        self.set_function(partial(self._walk_nary, "bvmul"), op.BV_MUL)
-        self.set_function(partial(self._walk_nary, "bvudiv"), op.BV_UDIV)
-        self.set_function(partial(self._walk_nary, "bvurem"), op.BV_UREM)
-        self.set_function(partial(self._walk_nary, "bvshl"), op.BV_LSHL)
-        self.set_function(partial(self._walk_nary, "bvlshr"), op.BV_LSHR)
-        self.set_function(partial(self._walk_nary, "bvult"), op.BV_ULT)
-        self.set_function(partial(self._walk_nary, "bvule"), op.BV_ULE)
-        self.set_function(partial(self._walk_nary, "bvslt"), op.BV_SLT)
-        self.set_function(partial(self._walk_nary, "bvsle"), op.BV_SLE)
-        self.set_function(partial(self._walk_nary, "concat"), op.BV_CONCAT)
-        self.set_function(partial(self._walk_nary, "bvcomp"), op.BV_COMP)
-        self.set_function(partial(self._walk_nary, "bvashr"), op.BV_ASHR)
-        self.set_function(partial(self._walk_nary, "bvsdiv"), op.BV_SDIV)
-        self.set_function(partial(self._walk_nary, "bvsrem"), op.BV_SREM)
-        self.set_function(self.walk_bv_extract, op.BV_EXTRACT)
-        self.set_function(self.walk_bv_rotate, op.BV_ROR)
-        self.set_function(self.walk_bv_rotate, op.BV_ROL)
-        self.set_function(self.walk_bv_extend, op.BV_ZEXT)
-        self.set_function(self.walk_bv_extend, op.BV_SEXT)
-
-        self.set_function(partial(self._walk_nary, "select"), op.ARRAY_SELECT)
-        self.set_function(partial(self._walk_nary, "store"), op.ARRAY_STORE)
-
     def printer(self, f):
         self.walk(f)
 
@@ -86,19 +40,57 @@ class SmtPrinter(TreeWalker):
         """This is a complete printer"""
         raise NotImplementedError
 
-    def _walk_nary(self, operator, formula):
+    def walk_nary(self, formula, operator):
         self.write("(%s" % operator)
         for s in formula.args():
             self.write(" ")
             yield s
         self.write(")")
 
+    def walk_and(self, formula): return self.walk_nary(formula, "and")
+    def walk_or(self, formula): return self.walk_nary(formula, "or")
+    def walk_not(self, formula): return self.walk_nary(formula, "not")
+    def walk_implies(self, formula): return self.walk_nary(formula, "=>")
+    def walk_iff(self, formula): return self.walk_nary(formula, "=")
+    def walk_plus(self, formula): return self.walk_nary(formula, "+")
+    def walk_minus(self, formula): return self.walk_nary(formula, "-")
+    def walk_times(self, formula): return self.walk_nary(formula, "*")
+    def walk_equals(self, formula): return self.walk_nary(formula, "=")
+    def walk_le(self, formula): return self.walk_nary(formula, "<=")
+    def walk_lt(self, formula): return self.walk_nary(formula, "<")
+    def walk_ite(self, formula): return self.walk_nary(formula, "ite")
+    def walk_toreal(self, formula): return self.walk_nary(formula, "to_real")
+    def walk_div(self, formula): return self.walk_nary(formula, "/")
+    def walk_pow(self, formula): return self.walk_nary(formula, "pow")
+    def walk_bv_and(self, formula): return self.walk_nary(formula, "bvand")
+    def walk_bv_or(self, formula): return self.walk_nary(formula, "bvor")
+    def walk_bv_not(self, formula): return self.walk_nary(formula, "bvnot")
+    def walk_bv_xor(self, formula): return self.walk_nary(formula, "bvxor")
+    def walk_bv_add(self, formula): return self.walk_nary(formula, "bvadd")
+    def walk_bv_sub(self, formula): return self.walk_nary(formula, "bvsub")
+    def walk_bv_neg(self, formula): return self.walk_nary(formula, "bvneg")
+    def walk_bv_mul(self, formula): return self.walk_nary(formula, "bvmul")
+    def walk_bv_udiv(self, formula): return self.walk_nary(formula, "bvudiv")
+    def walk_bv_urem(self, formula): return self.walk_nary(formula, "bvurem")
+    def walk_bv_lshl(self, formula): return self.walk_nary(formula, "bvshl")
+    def walk_bv_lshr(self, formula): return self.walk_nary(formula, "bvlshr")
+    def walk_bv_ult(self, formula): return self.walk_nary(formula, "bvult")
+    def walk_bv_ule(self, formula): return self.walk_nary(formula, "bvule")
+    def walk_bv_slt(self, formula): return self.walk_nary(formula, "bvslt")
+    def walk_bv_sle(self, formula): return self.walk_nary(formula, "bvsle")
+    def walk_bv_concat(self, formula): return self.walk_nary(formula, "concat")
+    def walk_bv_comp(self, formula): return self.walk_nary(formula, "bvcomp")
+    def walk_bv_ashr(self, formula): return self.walk_nary(formula, "bvashr")
+    def walk_bv_sdiv(self, formula): return self.walk_nary(formula, "bvsdiv")
+    def walk_bv_srem(self, formula): return self.walk_nary(formula, "bvsrem")
+    def walk_array_select(self, formula): return self.walk_nary(formula, "select")
+    def walk_array_store(self, formula): return self.walk_nary(formula, "store")
 
     def walk_symbol(self, formula):
         self.write(quote(formula.symbol_name()))
 
     def walk_function(self, formula):
-        return self._walk_nary(formula.function_name(), formula)
+        return self.walk_nary(formula, formula.function_name())
 
     def walk_int_constant(self, formula):
         if formula.constant_value() < 0:
@@ -155,6 +147,7 @@ class SmtPrinter(TreeWalker):
         yield formula.arg(0)
         self.write(")")
 
+    @handles(op.BV_ROR, op.BV_ROL)
     def walk_bv_rotate(self, formula):
         if formula.is_bv_ror():
             rotate_type = "rotate_right"
@@ -166,6 +159,7 @@ class SmtPrinter(TreeWalker):
         yield formula.arg(0)
         self.write(")")
 
+    @handles(op.BV_ZEXT, op.BV_SEXT)
     def walk_bv_extend(self, formula):
         if formula.is_bv_zext():
             extend_type = "zero_extend"
@@ -205,52 +199,6 @@ class SmtDagPrinter(DagWalker):
         self.names = None
         self.mgr = get_env().formula_manager
 
-        self.set_function(partial(self._walk_nary, "and"), op.AND)
-        self.set_function(partial(self._walk_nary, "or"), op.OR)
-        self.set_function(partial(self._walk_nary, "not"), op.NOT)
-        self.set_function(partial(self._walk_nary, "=>"), op.IMPLIES)
-        self.set_function(partial(self._walk_nary, "="), op.IFF)
-        self.set_function(partial(self._walk_nary, "+"), op.PLUS)
-        self.set_function(partial(self._walk_nary, "-"), op.MINUS)
-        self.set_function(partial(self._walk_nary, "*"), op.TIMES)
-        self.set_function(partial(self._walk_nary, "pow"), op.POW)
-        self.set_function(partial(self._walk_nary, "="), op.EQUALS)
-        self.set_function(partial(self._walk_nary, "<="), op.LE)
-        self.set_function(partial(self._walk_nary, "<"), op.LT)
-        self.set_function(partial(self._walk_nary, "ite"), op.ITE)
-        self.set_function(partial(self._walk_nary, "to_real"), op.TOREAL)
-        self.set_function(partial(self._walk_nary, "/"), op.DIV)
-
-        self.set_function(partial(self._walk_nary, "bvand"), op.BV_AND)
-        self.set_function(partial(self._walk_nary, "bvor"), op.BV_OR)
-        self.set_function(partial(self._walk_nary, "bvnot"), op.BV_NOT)
-        self.set_function(partial(self._walk_nary, "bvxor"), op.BV_XOR)
-        self.set_function(partial(self._walk_nary, "bvadd"), op.BV_ADD)
-        self.set_function(partial(self._walk_nary, "bvsub"), op.BV_SUB)
-        self.set_function(partial(self._walk_nary, "bvneg"), op.BV_NEG)
-        self.set_function(partial(self._walk_nary, "bvmul"), op.BV_MUL)
-        self.set_function(partial(self._walk_nary, "bvudiv"), op.BV_UDIV)
-        self.set_function(partial(self._walk_nary, "bvurem"), op.BV_UREM)
-        self.set_function(partial(self._walk_nary, "bvshl"), op.BV_LSHL)
-        self.set_function(partial(self._walk_nary, "bvlshr"), op.BV_LSHR)
-        self.set_function(partial(self._walk_nary, "bvult"), op.BV_ULT)
-        self.set_function(partial(self._walk_nary, "bvule"), op.BV_ULE)
-        self.set_function(partial(self._walk_nary, "bvslt"), op.BV_SLT)
-        self.set_function(partial(self._walk_nary, "bvsle"), op.BV_SLE)
-        self.set_function(partial(self._walk_nary, "concat"), op.BV_CONCAT)
-        self.set_function(partial(self._walk_nary, "bvcomp"), op.BV_COMP)
-        self.set_function(partial(self._walk_nary, "bvashr"), op.BV_ASHR)
-        self.set_function(partial(self._walk_nary, "bvsdiv"), op.BV_SDIV)
-        self.set_function(partial(self._walk_nary, "bvsrem"), op.BV_SREM)
-        self.set_function(self.walk_bv_extract, op.BV_EXTRACT)
-        self.set_function(self.walk_bv_rotate, op.BV_ROR)
-        self.set_function(self.walk_bv_rotate, op.BV_ROL)
-        self.set_function(self.walk_bv_extend, op.BV_SEXT)
-        self.set_function(self.walk_bv_extend, op.BV_ZEXT)
-
-        self.set_function(partial(self._walk_nary, "select"), op.ARRAY_SELECT)
-        self.set_function(partial(self._walk_nary, "store"), op.ARRAY_STORE)
-
     def _push_with_children_to_stack(self, formula, **kwargs):
         """Add children to the stack."""
 
@@ -283,7 +231,7 @@ class SmtDagPrinter(DagWalker):
         self.name_seed += 1
         return res
 
-    def _walk_nary(self, operator, formula, args):
+    def walk_nary(self, formula, args, operator):
         assert formula is not None
         sym = self._new_symbol()
         self.openings += 1
@@ -294,11 +242,125 @@ class SmtDagPrinter(DagWalker):
         self.write("))) ")
         return sym
 
+    def walk_and(self, formula, args):
+        return self.walk_nary(formula, args, "and")
+
+    def walk_or(self, formula, args):
+        return self.walk_nary(formula, args, "or")
+
+    def walk_not(self, formula, args):
+        return self.walk_nary(formula, args, "not")
+
+    def walk_implies(self, formula, args):
+        return self.walk_nary(formula, args, "=>")
+
+    def walk_iff(self, formula, args):
+        return self.walk_nary(formula, args, "=")
+
+    def walk_plus(self, formula, args):
+        return self.walk_nary(formula, args, "+")
+
+    def walk_minus(self, formula, args):
+        return self.walk_nary(formula, args, "-")
+
+    def walk_times(self, formula, args):
+        return self.walk_nary(formula, args, "*")
+
+    def walk_equals(self, formula, args):
+        return self.walk_nary(formula, args, "=")
+
+    def walk_le(self, formula, args):
+        return self.walk_nary(formula, args, "<=")
+
+    def walk_lt(self, formula, args):
+        return self.walk_nary(formula, args, "<")
+
+    def walk_ite(self, formula, args):
+        return self.walk_nary(formula, args, "ite")
+
+    def walk_toreal(self, formula, args):
+        return self.walk_nary(formula, args, "to_real")
+
+    def walk_div(self, formula, args):
+        return self.walk_nary(formula, args, "/")
+
+    def walk_pow(self, formula, args):
+        return self.walk_nary(formula, args, "pow")
+
+    def walk_bv_and(self, formula, args):
+        return self.walk_nary(formula, args, "bvand")
+
+    def walk_bv_or(self, formula, args):
+        return self.walk_nary(formula, args, "bvor")
+
+    def walk_bv_not(self, formula, args):
+        return self.walk_nary(formula, args, "bvnot")
+
+    def walk_bv_xor(self, formula, args):
+        return self.walk_nary(formula, args, "bvxor")
+
+    def walk_bv_add(self, formula, args):
+        return self.walk_nary(formula, args, "bvadd")
+
+    def walk_bv_sub(self, formula, args):
+        return self.walk_nary(formula, args, "bvsub")
+
+    def walk_bv_neg(self, formula, args):
+        return self.walk_nary(formula, args, "bvneg")
+
+    def walk_bv_mul(self, formula, args):
+        return self.walk_nary(formula, args, "bvmul")
+
+    def walk_bv_udiv(self, formula, args):
+        return self.walk_nary(formula, args, "bvudiv")
+
+    def walk_bv_urem(self, formula, args):
+
+        return self.walk_nary(formula, args, "bvurem")
+    def walk_bv_lshl(self, formula, args):
+        return self.walk_nary(formula, args, "bvshl")
+
+    def walk_bv_lshr(self, formula, args):
+        return self.walk_nary(formula, args, "bvlshr")
+
+    def walk_bv_ult(self, formula, args):
+        return self.walk_nary(formula, args, "bvult")
+
+    def walk_bv_ule(self, formula, args):
+        return self.walk_nary(formula, args, "bvule")
+
+    def walk_bv_slt(self, formula, args):
+        return self.walk_nary(formula, args, "bvslt")
+
+    def walk_bv_sle(self, formula, args):
+        return self.walk_nary(formula, args, "bvsle")
+
+    def walk_bv_concat(self, formula, args):
+        return self.walk_nary(formula, args, "concat")
+
+    def walk_bv_comp(self, formula, args):
+        return self.walk_nary(formula, args, "bvcomp")
+
+    def walk_bv_ashr(self, formula, args):
+        return self.walk_nary(formula, args, "bvashr")
+
+    def walk_bv_sdiv(self, formula, args):
+        return self.walk_nary(formula, args, "bvsdiv")
+
+    def walk_bv_srem(self, formula, args):
+        return self.walk_nary(formula, args, "bvsrem")
+
+    def walk_array_select(self, formula, args):
+        return self.walk_nary(formula, args, "select")
+
+    def walk_array_store(self, formula, args):
+        return self.walk_nary(formula, args, "store")
+
     def walk_symbol(self, formula, **kwargs):
         return quote(formula.symbol_name())
 
     def walk_function(self, formula, args, **kwargs):
-        return self._walk_nary(formula.function_name(), formula, args)
+        return self.walk_nary(formula, args, formula.function_name())
 
     def walk_int_constant(self, formula, **kwargs):
         if formula.constant_value() < 0:
@@ -374,6 +436,7 @@ class SmtDagPrinter(DagWalker):
         self.write("))) ")
         return sym
 
+    @handles(op.BV_SEXT, op.BV_ZEXT)
     def walk_bv_extend(self, formula, args, **kwargs):
         #pylint: disable=unused-argument
         if formula.is_bv_zext():
@@ -392,6 +455,7 @@ class SmtDagPrinter(DagWalker):
         self.write("))) ")
         return sym
 
+    @handles(op.BV_ROR, op.BV_ROL)
     def walk_bv_rotate(self, formula, args, **kwargs):
         #pylint: disable=unused-argument
         if formula.is_bv_ror():

--- a/pysmt/substituter.py
+++ b/pysmt/substituter.py
@@ -20,11 +20,12 @@ import warnings
 from six import iteritems
 
 import pysmt.walkers
+from pysmt.walkers.generic import handles
 import pysmt.operators as op
 from pysmt.exceptions import PysmtTypeError
 
 
-class Substituter(pysmt.walkers.DagWalker):
+class Substituter(pysmt.walkers.IdentityDagWalker):
     """Performs substitution of a set of terms within a formula.
 
     Let f be a formula ans subs be a map from formula to formula.
@@ -54,13 +55,8 @@ class Substituter(pysmt.walkers.DagWalker):
     separate calls to the substitution procedure.
     """
     def __init__(self, env):
-        pysmt.walkers.DagWalker.__init__(self, env=env, invalidate_memoization=True)
+        pysmt.walkers.IdentityDagWalker.__init__(self, env=env, invalidate_memoization=True)
         self.manager = self.env.formula_manager
-        self.orig_subs = None
-        # We keep an internal copy of an IdentityDagWalker. This is
-        # used to rebuild expressions that are not affected by the
-        # substitution.
-        self._inner_idw = pysmt.walkers.IdentityDagWalker(env=self.env)
 
     def _get_key(self, formula, **kwargs):
         return formula
@@ -96,9 +92,9 @@ class Substituter(pysmt.walkers.DagWalker):
             key = self._get_key(formula, **kwargs)
             self.memoization[key] = res
         else:
-            pysmt.walkers.DagWalker._push_with_children_to_stack(self,
-                                                                 formula,
-                                                                 **kwargs)
+            pysmt.walkers.IdentityDagWalker._push_with_children_to_stack(self,
+                                                                         formula,
+                                                                         **kwargs)
 
     def substitute(self, formula, subs):
         """Replaces any subformula in formula with the definition in subs."""
@@ -126,33 +122,28 @@ class Substituter(pysmt.walkers.DagWalker):
                 raise PysmtTypeError(
                     "Value %d does not belong to the Formula Manager." % i)
 
-        self.orig_subs = subs
         res = self.walk(formula, substitutions=subs)
-        self.orig_subs = None
         return res
 
 
 class MGSubstituter(Substituter):
-    """Performs Most Specific Substitution.
+    """Performs Most Generic Substitution.
 
     This is the default behavior since version 0.5
     """
     def __init__(self, env):
         Substituter.__init__(self, env=env)
-        self.set_function(self.walk_identity_or_replace, *op.all_types())
 
-    def walk_identity_or_replace(self, formula, args, **kwargs):
+    @handles(op.ALL_TYPES)
+    def walk_identity_or_replace(self, formula, args, substitutions, **kwargs):
         """
         If the formula appears in the substitution, return the substitution.
         Otherwise, rebuild the formula by calling the IdentityWalker.
         """
-        if formula in self.orig_subs:
-            return self.orig_subs[formula]
+        if formula in substitutions:
+            return substitutions[formula]
         else:
-            # Call the function associated to type of 'formula'
-            # E.g., if formula is an And() it will call walk_and
-            # and rebuild the And expression with the new children
-            return self._inner_idw.functions[formula.node_type()](formula, args=args, **kwargs)
+            return Substituter.super(self, formula, args=args, **kwargs)
 
 # EOC MGSubstituter
 
@@ -165,22 +156,22 @@ class MSSubstituter(Substituter):
 
     def __init__(self, env):
         Substituter.__init__(self, env=env)
-        self.set_function(self.walk_replace, *op.all_types())
 
     def substitute(self, formula, subs):
         return Substituter.substitute(self, formula, subs)
 
-    def _substitute(self, formula):
+    def _substitute(self, formula, substitutions):
         """Returns the substitution for formula, if one is defined, otherwise
         it defaults to the identify (formula).
 
         This is an helper function, to simplify the implementation of
         the walk_* functions.
         """
-        return self.orig_subs.get(formula, formula)
+        return substitutions.get(formula, formula)
 
-    def walk_replace(self, formula, args, **kwargs):
-        new_f = self._inner_idw.functions[formula.node_type()](formula, args=args, **kwargs)
-        return self._substitute(new_f)
+    @handles(op.ALL_TYPES)
+    def walk_replace(self, formula, args, substitutions, **kwargs):
+        new_f =  Substituter.super(self, formula, args=args, **kwargs)
+        return self._substitute(new_f, substitutions)
 
 # EOC MSSSubstituter

--- a/pysmt/substituter.py
+++ b/pysmt/substituter.py
@@ -57,6 +57,10 @@ class Substituter(pysmt.walkers.IdentityDagWalker):
     def __init__(self, env):
         pysmt.walkers.IdentityDagWalker.__init__(self, env=env, invalidate_memoization=True)
         self.manager = self.env.formula_manager
+        if self.__class__ == Substituter:
+            raise NotImplementedError(
+                "Cannot instantiate abstract Substituter class directly. "
+                "Use MSSubstituter or MGSubstituter instead.")
 
     def _get_key(self, formula, **kwargs):
         return formula

--- a/pysmt/test/test_dwf.py
+++ b/pysmt/test/test_dwf.py
@@ -27,8 +27,9 @@ class TestDwf(TestCase):
     # NOTE: We enforce order of execution of the tests, since in the
     # other test we define a custom type.
     def test_00_new_node_type(self):
-        self.assertEqual(len(CUSTOM_NODE_TYPES), 0, "Initially there should be no custom types")
-        idx = new_node_type()
+        self.assertNotIn(199, CUSTOM_NODE_TYPES,
+                        "Initially there should be no custom node with id 199")
+        idx = new_node_type(node_id=199)
         self.assertIsNotNone(idx)
         with self.assertRaises(AssertionError):
             new_node_type(idx)

--- a/pysmt/test/test_oracles.py
+++ b/pysmt/test/test_oracles.py
@@ -45,7 +45,6 @@ class TestOracles(TestCase):
         s = get_free_variables(f)
         self.assertEqual(set([x,y]), s)
 
-
     def test_atoms_oracle(self):
         oracle = get_env().ao
         stc = get_env().stc
@@ -57,7 +56,6 @@ class TestOracles(TestCase):
             for a in atoms:
                 ty = stc.get_type(a)
                 self.assertEqual(ty, BOOL)
-
                 self.assertFalse(a.is_and())
                 self.assertFalse(a.is_or())
                 self.assertFalse(a.is_not())

--- a/pysmt/test/test_walker_ext.py
+++ b/pysmt/test/test_walker_ext.py
@@ -1,0 +1,99 @@
+#
+# This file is part of pySMT.
+#
+#   Copyright 2015 Andrea Micheli and Marco Gario
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+from pysmt.test import TestCase
+from pysmt.type_checker import SimpleTypeChecker
+from pysmt.printers import HRPrinter, HRSerializer
+from pysmt.shortcuts import get_env, Symbol, reset_env
+from pysmt.exceptions import UnsupportedOperatorError
+from pysmt.environment import Environment
+from pysmt.operators import new_node_type, all_types
+
+
+class TestExtendSuper(TestCase):
+    def test_new_node_type(self):
+        old = list(all_types())
+        idx = new_node_type(node_str="xor")
+        self.assertIsNotNone(idx)
+        self.assertNotIn(idx, old)
+        with self.assertRaises(AssertionError):
+            new_node_type(idx)
+        XOR = idx
+
+        # Ad-hoc method to handle printing of the new node
+        def hrprinter_walk_xor(self, formula):
+            self.stream.write("(")
+            yield formula.arg(0)
+            self.stream.write(" *+* ")
+            yield formula.arg(1)
+            self.stream.write(")")
+
+        SimpleTypeChecker.walk_xor = SimpleTypeChecker.walk_bool_to_bool
+        HRPrinter.walk_xor = hrprinter_walk_xor
+
+        # Reset the env to recreate the TypeChecker and HRPrinter
+        reset_env()
+
+        # Shortcuts for function in env
+        create_node = get_env().formula_manager.create_node
+        # Create a test node (This implicitly calls the Type-checker)
+        x = Symbol("x")
+        f1 = create_node(node_type=XOR, args=(x,x))
+        self.assertIsNotNone(f1)
+
+        # String conversion should use the function defined above.
+        s_f1 = str(f1)
+        self.assertEqual(s_f1, "(x *+* x)")
+
+        # We did not define an implementation for the Simplifier
+        with self.assertRaises(UnsupportedOperatorError):
+            f1.simplify()
+
+        # Clean-up
+        del SimpleTypeChecker.walk_xor
+        del HRPrinter.walk_xor
+
+        class MySimpleTypeChecker(SimpleTypeChecker):
+            walk_xor = SimpleTypeChecker.walk_bool_to_bool
+
+        class MyHRPrinter(HRPrinter):
+            def walk_xor(self, formula):
+                return self.walk_nary(formula, " *+* ")
+
+        class MyHRSerializer(HRSerializer):
+            PrinterClass = MyHRPrinter
+
+        class MyEnv(Environment):
+            TypeCheckerClass = MySimpleTypeChecker
+            HRSerializerClass = MyHRSerializer
+
+        with MyEnv() as myenv:
+            create_node = myenv.formula_manager.create_node
+            # Create a test node (This implicitly calls the Type-checker)
+            x = Symbol("x")
+            f1 = create_node(node_type=XOR, args=(x,x))
+            self.assertIsNotNone(f1)
+
+            # String conversion should use the function defined above.
+            s_f1 = str(f1)
+            self.assertEqual(s_f1, "(x *+* x)")
+
+            # We did not define an implementation for the Simplifier
+            with self.assertRaises(UnsupportedOperatorError):
+                f1.simplify()
+
+        return

--- a/pysmt/test/test_walkers.py
+++ b/pysmt/test/test_walkers.py
@@ -256,6 +256,10 @@ class TestWalkers(TestCase):
         res = wc.walk(Symbol("x"))
         self.assertEqual(res, "CBAx")
 
+    def test_substituter_instance(self):
+        from pysmt.substituter import Substituter
+        with self.assertRaises(NotImplementedError):
+            Substituter(env=self.env)
 
 if __name__ == '__main__':
     main()

--- a/pysmt/walkers/__init__.py
+++ b/pysmt/walkers/__init__.py
@@ -33,7 +33,7 @@ it only once.
 
 """
 
-__all__ = ["DagWalker", "TreeWalker", "IdentityDagWalker"]
+__all__ = ["DagWalker", "TreeWalker", "IdentityDagWalker", "handles"]
 
 
 from pysmt.walkers.dag import DagWalker
@@ -44,3 +44,6 @@ assert TreeWalker
 
 from pysmt.walkers.identitydag import IdentityDagWalker
 assert IdentityDagWalker
+
+from pysmt.walkers.generic import handles
+assert handles

--- a/pysmt/walkers/__init__.py
+++ b/pysmt/walkers/__init__.py
@@ -33,9 +33,6 @@ it only once.
 
 """
 
-__all__ = ["DagWalker", "TreeWalker", "IdentityDagWalker", "handles"]
-
-
 from pysmt.walkers.dag import DagWalker
 assert DagWalker
 

--- a/pysmt/walkers/dag.py
+++ b/pysmt/walkers/dag.py
@@ -48,7 +48,6 @@ class DagWalker(Walker):
     def _get_children(self, formula):
         return formula.args()
 
-
     def _push_with_children_to_stack(self, formula, **kwargs):
         """Add children to the stack."""
         self.stack.append((True, formula))

--- a/pysmt/walkers/identitydag.py
+++ b/pysmt/walkers/identitydag.py
@@ -32,17 +32,17 @@ class IdentityDagWalker(DagWalker):
                            invalidate_memoization=invalidate_memoization)
         self.mgr = self.env.formula_manager
 
-    def walk_symbol(self, formula, **kwargs):
+    def walk_symbol(self, formula, args, **kwargs):
         return self.mgr.Symbol(formula.symbol_name(),
                                                formula.symbol_type())
 
-    def walk_real_constant(self, formula, **kwargs):
+    def walk_real_constant(self, formula, args, **kwargs):
         return self.mgr.Real(formula.constant_value())
 
-    def walk_int_constant(self, formula, **kwargs):
+    def walk_int_constant(self, formula, args, **kwargs):
         return self.mgr.Int(formula.constant_value())
 
-    def walk_bool_constant(self, formula, **kwargs):
+    def walk_bool_constant(self, formula, args, **kwargs):
         return self.mgr.Bool(formula.constant_value())
 
     def walk_and(self, formula, args, **kwargs):
@@ -73,11 +73,13 @@ class IdentityDagWalker(DagWalker):
         return self.mgr.LT(args[0], args[1])
 
     def walk_forall(self, formula, args, **kwargs):
-        qvars = [self.walk_symbol(v) for v in formula.quantifier_vars()]
+        qvars = [IdentityDagWalker.walk_symbol(self, v, None)
+                 for v in formula.quantifier_vars()]
         return self.mgr.ForAll(qvars, args[0])
 
     def walk_exists(self, formula, args, **kwargs):
-        qvars = [self.walk_symbol(v) for v in formula.quantifier_vars()]
+        qvars = [IdentityDagWalker.walk_symbol(self, v, None)
+                 for v in formula.quantifier_vars()]
         return self.mgr.Exists(qvars, args[0])
 
     def walk_plus(self, formula, args, **kwargs):

--- a/pysmt/walkers/identitydag.py
+++ b/pysmt/walkers/identitydag.py
@@ -73,12 +73,12 @@ class IdentityDagWalker(DagWalker):
         return self.mgr.LT(args[0], args[1])
 
     def walk_forall(self, formula, args, **kwargs):
-        qvars = [IdentityDagWalker.walk_symbol(self, v, None)
+        qvars = [self.walk_symbol(v, args, **kwargs)
                  for v in formula.quantifier_vars()]
         return self.mgr.ForAll(qvars, args[0])
 
     def walk_exists(self, formula, args, **kwargs):
-        qvars = [IdentityDagWalker.walk_symbol(self, v, None)
+        qvars = [self.walk_symbol(v, args, **kwargs)
                  for v in formula.quantifier_vars()]
         return self.mgr.Exists(qvars, args[0])
 
@@ -97,7 +97,7 @@ class IdentityDagWalker(DagWalker):
     def walk_function(self, formula, args, **kwargs):
         # We re-create the symbol name
         old_name = formula.function_name()
-        new_name = IdentityDagWalker.walk_symbol(self, old_name, None)
+        new_name = self.walk_symbol(old_name, args, **kwargs)
         return self.mgr.Function(new_name, args)
 
     def walk_toreal(self, formula, args, **kwargs):

--- a/pysmt/walkers/identitydag.py
+++ b/pysmt/walkers/identitydag.py
@@ -34,7 +34,7 @@ class IdentityDagWalker(DagWalker):
 
     def walk_symbol(self, formula, args, **kwargs):
         return self.mgr.Symbol(formula.symbol_name(),
-                                               formula.symbol_type())
+                               formula.symbol_type())
 
     def walk_real_constant(self, formula, args, **kwargs):
         return self.mgr.Real(formula.constant_value())
@@ -97,7 +97,7 @@ class IdentityDagWalker(DagWalker):
     def walk_function(self, formula, args, **kwargs):
         # We re-create the symbol name
         old_name = formula.function_name()
-        new_name = self.walk_symbol(old_name)
+        new_name = IdentityDagWalker.walk_symbol(self, old_name, None)
         return self.mgr.Function(new_name, args)
 
     def walk_toreal(self, formula, args, **kwargs):


### PR DESCRIPTION
*\* This is outdated: See discussion below **

Recover the behavior of the super Walker when inheriting, and easily
compose it.

  self.save_super_functions()

must be called during `__init__` **before** overriding the
functions (with set_function). Inside any walk, it is then possible to
call self._super() to execute the original walk, e.g.:

  self._super(formula, args, **kwargs)

in case of a DagWalker.

Examples usage using both a DagWalker (BddSimplifier) and
TreeWalker (SmartPrinter) are given.
