### PR TITLE
Enforce a single call to is_sat if not incremental

### DIFF
--- a/pysmt/test/test_shannon_expansion.py
+++ b/pysmt/test/test_shannon_expansion.py
@@ -27,6 +27,7 @@ from pysmt.test.examples import get_example_formulae
 class TestShannon(TestCase):
 
     def setUp(self):
+        TestCase.setUp(self)
         self.x, self.y = Symbol("x"), Symbol("y")
 
 

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -563,6 +563,14 @@ class TestBasic(TestCase):
                 s.add_assertion(And(x,y))
                 s.solve()
 
+    @skipIfNoSolverForLogic(QF_BOOL)
+    def test_incremental_is_sat(self):
+        from pysmt.exceptions import SolverStatusError
+        with Solver(incremental=False, logic=QF_BOOL) as s:
+            self.assertTrue(s.is_sat(Symbol("x")))
+            with self.assertRaises(SolverStatusError):
+                s.is_sat(Not(Symbol("x")))
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Non incremental is_sat modifies the stack of assertions. For this
reason, it should be possible to call it only once.

This achieves this by raising an error in solve() if called after a call
to is_sat.

This also clarifies the documentation of Solver.get_model.

Thanks to @colinmorris for the feedback on Solver interface.