### PR TITLE
Remove Solver.declare_variable

### DIFF
--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -100,8 +100,7 @@ class CVC4Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
         self.cvc4.setLogic(self.logic_name)
 
     def declare_variable(self, var):
-        self.converter.declare_variable(var)
-        return
+        raise NotImplementedError
 
     def add_assertion(self, formula, named=None):
         self._assert_is_boolean(formula)

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -199,7 +199,7 @@ class MathSAT5Solver(IncrementalTrackingSolver, UnsatCoreSolver,
 
     @clear_pending_pop
     def declare_variable(self, var):
-        self.converter.declare_variable(var)
+        raise NotImplementedError
 
     @clear_pending_pop
     def _add_assertion(self, formula, named=None):

--- a/pysmt/solvers/pico.py
+++ b/pysmt/solvers/pico.py
@@ -202,7 +202,6 @@ class PicosatSolver(Solver):
             self._var_ids[symbol] = vid
             return vid
 
-
     @clear_pending_pop
     def reset_assertions(self):
         picosat.picosat_flushout(self._log_file_handler)
@@ -212,8 +211,7 @@ class PicosatSolver(Solver):
 
     @clear_pending_pop
     def declare_variable(self, var):
-        # no need to declare variables
-        pass
+        raise NotImplementedError
 
     def _get_pico_lit(self, lit):
         mult = 1
@@ -224,7 +222,6 @@ class PicosatSolver(Solver):
 
         vid = self._get_var_id(var)
         return vid * mult
-
 
     @clear_pending_pop
     @catch_conversion_error

--- a/pysmt/solvers/solver.py
+++ b/pysmt/solvers/solver.py
@@ -19,6 +19,7 @@ import abc
 
 from pysmt.typing import BOOL
 from pysmt.exceptions import SolverReturnedUnknownResultError
+from pysmt.decorators import deprecated
 from six.moves import xrange
 
 
@@ -210,13 +211,6 @@ class Solver(object):
 
     def reset_assertions(self):
         """Removes all defined assertions."""
-        raise NotImplementedError
-
-    def declare_variable(self, var):
-        """Declare a variable in the solver.
-
-        :type var: FNode
-        """
         raise NotImplementedError
 
     def add_assertion(self, formula, named=None):

--- a/pysmt/solvers/yices.py
+++ b/pysmt/solvers/yices.py
@@ -159,8 +159,7 @@ class YicesSolver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
 
     @clear_pending_pop
     def declare_variable(self, var):
-        self.declarations.add(var)
-        return
+        raise NotImplementedError
 
     @clear_pending_pop
     def add_assertion(self, formula, named=None):

--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -158,8 +158,7 @@ class Z3Solver(IncrementalTrackingSolver, UnsatCoreSolver,
 
     @clear_pending_pop
     def declare_variable(self, var):
-        self.declarations.add(var)
-        return
+        raise NotImplementedError
 
     @clear_pending_pop
     def _add_assertion(self, formula, named=None):


### PR DESCRIPTION
This removes declare_variable from the Solver Interface.
Only BDDs actually use this method to define the static ordering. All
other solvers implementations have been changed to raise a
NotImplementedError.