### PR TITLE
CI: Tests clean-up and disable coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 omit = pysmt/cmd/*
+       pysmt/test/*
 
 [report]
 exclude_lines =

--- a/pysmt/test/examples.py
+++ b/pysmt/test/examples.py
@@ -117,6 +117,13 @@ def get_full_example_formulae(environment=None):
                     logic=pysmt.logics.QF_BOOL
                 ),
 
+            Example(hr="((x | y) & (! (x | y)))",
+                    expr=And(Or(x, y), Not(Or(x, y))),
+                    is_valid=False,
+                    is_sat=False,
+                    logic=pysmt.logics.QF_BOOL
+                ),
+
             #
             #  LIA
             #

--- a/pysmt/test/test_back.py
+++ b/pysmt/test/test_back.py
@@ -63,7 +63,7 @@ class TestBasic(TestCase):
                 try:
                     s = Solver(name=solver_name, logic=logic)
                     term = s.converter.convert(formula)
-                    if solver_name == "z3" and z3_string_buffer:
+                    if solver_name == "z3":
                         if z3_string_buffer:
                             res = s.converter.back_via_smtlib(term)
                         else:

--- a/pysmt/test/test_typechecker.py
+++ b/pysmt/test/test_typechecker.py
@@ -170,16 +170,16 @@ class TestSimpleTypeChecker(TestCase):
 
 
     def test_decorator_typecheck_result(self):
+        from pysmt.fnode import FNode, FNodeContent
+        from pysmt.operators import AND
         @typecheck_result
         def good_function():
             return self.x
 
         @typecheck_result
         def super_bad_function():
-            sb = And(self.x, self.y)
-            # !!! This hurts so badly  !!!
-            # !!! Do not try this at home !!!
-            sb._content.args[0] = self.p
+            sb = FNode(FNodeContent(node_type=AND, args=(self.p, self.p),
+                                    payload=None), -1)
             return sb
 
         good_function()

--- a/pysmt/type_checker.py
+++ b/pysmt/type_checker.py
@@ -67,7 +67,7 @@ class SimpleTypeChecker(walkers.DagWalker):
     def get_type(self, formula):
         """ Returns the pysmt.types type of the formula """
         res = self.walk(formula)
-        if not self.be_nice and  res is None:
+        if not self.be_nice and res is None:
             raise TypeError("The formula '%s' is not well-formed" % str(formula))
         return res
 


### PR DESCRIPTION
Correct some dead-code in the tests that were discovered by coverage.
Now that the tests have been checked, we omit test/ from the coverage analysis.