### PR TITLE
Removed Solver.set_options

### DIFF
--- a/pysmt/solvers/solver.py
+++ b/pysmt/solvers/solver.py
@@ -299,14 +299,6 @@ class Solver(object):
             res[f] = v
         return res
 
-    def set_options(self, options):
-        """Sets multiple options at once.
-
-        :param options: Options to be set
-        :type options: Dictionary
-        """
-        raise NotImplementedError
-
     def __enter__(self):
         """Manages entering a Context (i.e., with statement)"""
         return self


### PR DESCRIPTION
This was not implemented by any solver. The proper way to set options is during initialization.