### PR TITLE
MSat: Back conversion using TAGs

### DIFF
--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -531,10 +531,6 @@ class MSatConverter(Converter, DagWalker):
         t = self.env.stc.get_type(args[0])
         return types.FunctionType(t, [t, t])
 
-    def _sig_binary(self, term, args):
-        t = self.env.stc.get_type(args[0])
-        return types.FunctionType(t, [t, t])
-
     def _sig_bool_binary(self, term, args):
         t = self.env.stc.get_type(args[0])
         return types.FunctionType(types.BOOL, [t, t])

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -397,7 +397,53 @@ class MSatConverter(Converter, DagWalker):
         self.realType = mathsat.msat_get_rational_type(self.msat_env())
         self.intType = mathsat.msat_get_integer_type(self.msat_env())
 
+        # Back Conversion
         self.back_memoization = {}
+        self.back_fun = {
+            mathsat.MSAT_TAG_TRUE: lambda term, args: self.mgr.TRUE(),
+            mathsat.MSAT_TAG_FALSE:lambda term, args: self.mgr.FALSE(),
+            mathsat.MSAT_TAG_AND: self._back_adapter(self.mgr.And),
+            mathsat.MSAT_TAG_OR:  self._back_adapter(self.mgr.Or),
+            mathsat.MSAT_TAG_NOT: self._back_adapter(self.mgr.Not),
+            mathsat.MSAT_TAG_IFF: self._back_adapter(self.mgr.Iff),
+            mathsat.MSAT_TAG_ITE: self._back_adapter(self.mgr.Ite),
+            mathsat.MSAT_TAG_EQ:  self._back_adapter(self.mgr.Equals),
+            mathsat.MSAT_TAG_LEQ: self._back_adapter(self.mgr.LE),
+            mathsat.MSAT_TAG_PLUS: self._back_adapter(self.mgr.Plus),
+            mathsat.MSAT_TAG_TIMES: self._back_adapter(self.mgr.Times),
+            mathsat.MSAT_TAG_BV_MUL: self._back_adapter(self.mgr.BVMul),
+            mathsat.MSAT_TAG_BV_ADD: self._back_adapter(self.mgr.BVAdd),
+            mathsat.MSAT_TAG_BV_UDIV: self._back_adapter(self.mgr.BVUDiv),
+            mathsat.MSAT_TAG_BV_UREM: self._back_adapter(self.mgr.BVURem),
+            mathsat.MSAT_TAG_BV_CONCAT: self._back_adapter(self.mgr.BVConcat),
+            mathsat.MSAT_TAG_BV_OR: self._back_adapter(self.mgr.BVOr),
+            mathsat.MSAT_TAG_BV_XOR:self._back_adapter(self.mgr.BVXor),
+            mathsat.MSAT_TAG_BV_AND:self._back_adapter(self.mgr.BVAnd),
+            mathsat.MSAT_TAG_BV_NOT:self._back_adapter(self.mgr.BVNot),
+            mathsat.MSAT_TAG_BV_SUB:self._back_adapter(self.mgr.BVSub),
+            mathsat.MSAT_TAG_BV_NEG:self._back_adapter(self.mgr.BVNeg),
+            mathsat.MSAT_TAG_BV_SREM:self._back_adapter(self.mgr.BVSRem),
+            mathsat.MSAT_TAG_BV_SDIV:self._back_adapter(self.mgr.BVSDiv),
+            mathsat.MSAT_TAG_BV_ULT: self._back_adapter(self.mgr.BVULT),
+            mathsat.MSAT_TAG_BV_SLT: self._back_adapter(self.mgr.BVSLT),
+            mathsat.MSAT_TAG_BV_ULE: self._back_adapter(self.mgr.BVULE),
+            mathsat.MSAT_TAG_BV_SLE: self._back_adapter(self.mgr.BVSLE),
+            mathsat.MSAT_TAG_BV_LSHL: self._back_adapter(self.mgr.BVLShl),
+            mathsat.MSAT_TAG_BV_LSHR: self._back_adapter(self.mgr.BVLShr),
+            mathsat.MSAT_TAG_BV_ASHR: self._back_adapter(self.mgr.BVAShr),
+            mathsat.MSAT_TAG_BV_COMP: self._back_adapter(self.mgr.BVComp),
+            mathsat.MSAT_TAG_ARRAY_READ: self._back_adapter(self.mgr.Select),
+            mathsat.MSAT_TAG_ARRAY_WRITE: self._back_adapter(self.mgr.Store),
+            # Slightly more complext conversion
+            mathsat.MSAT_TAG_BV_EXTRACT: self._back_bv_extract,
+            mathsat.MSAT_TAG_BV_ZEXT: self._back_bv_zext,
+            mathsat.MSAT_TAG_BV_SEXT: self._back_bv_sext,
+            mathsat.MSAT_TAG_BV_ROL: self._back_bv_rol,
+            mathsat.MSAT_TAG_BV_ROR: self._back_bv_ror,
+            mathsat.MSAT_TAG_ARRAY_CONST: self._back_array_const,
+            # Symbols, Constants and UFs have TAG_UNKNOWN
+            mathsat.MSAT_TAG_UNKNOWN: self._back_tag_unknown,
+        }
 
         # Handling of UF bool args
         self._ufrewriter = MSatBoolUFRewriter(environment)
@@ -569,216 +615,95 @@ class MSatConverter(Converter, DagWalker):
         :returns The pysmt formula representing the given term
         :rtype Pysmt formula
         """
-        res = None
-        arity = len(args)
+        decl = mathsat.msat_term_get_decl(term)
+        tag = mathsat.msat_decl_get_tag(self.msat_env(), decl)
 
-        if mathsat.msat_term_is_true(self.msat_env(), term):
-            res = mgr.TRUE()
+        try:
+            return self.back_fun[tag](term, args)
+        except KeyError:
+            raise PysmtTypeError("Unsupported expression:",
+                                 mathsat.msat_term_repr(term))
 
-        elif mathsat.msat_term_is_false(self.msat_env(), term):
-            res = mgr.FALSE()
+    def _back_adapter(self, op):
+        """Create a function that for the given op.
 
-        elif mathsat.msat_term_is_number(self.msat_env(), term):
+        This is used in the construction of back_fun, to simplify the code.
+        """
+        def back_apply(term, args):
+            return op(*args)
+        return back_apply
+
+    def _back_bv_extract(self, term, args):
+        res, msb, lsb = mathsat.msat_term_is_bv_extract(self.msat_env(), term)
+        assert res
+        return self.mgr.BVExtract(args[0], lsb, msb)
+
+    def _back_bv_zext(self, term, args):
+        is_zext, amount = mathsat.msat_term_is_bv_zext(self.msat_env(), term)
+        assert is_zext
+        return self.mgr.BVZExt(args[0], amount)
+
+    def _back_bv_sext(self, term, args):
+        is_sext, amount = mathsat.msat_term_is_bv_sext(self.msat_env(), term)
+        assert is_sext
+        return self.mgr.BVSExt(args[0], amount)
+
+    def _back_bv_rol(self, term, args):
+        is_rol, amount = mathsat.msat_term_is_bv_rol(self.msat_env(), term)
+        assert is_rol
+        return self.mgr.BVRol(args[0], amount)
+
+    def _back_bv_ror(self, term, args):
+        is_ror, amount = mathsat.msat_term_is_bv_ror(self.msat_env(), term)
+        assert is_ror
+        return self.mgr.BVRor(args[0], amount)
+
+    def _back_array_const(self, term, args):
+        msat_type = mathsat.msat_term_get_type(term)
+        pysmt_type = self._msat_type_to_type(msat_type)
+        return self.mgr.Array(pysmt_type.index_type, args[0])
+
+    def _back_tag_unknown(self, term, args):
+        """The TAG UNKNOWN is used to represent msat functions.
+
+        This includes, Constants, Symbols and UFs.
+        """
+        if mathsat.msat_term_is_number(self.msat_env(), term):
             ty = mathsat.msat_term_get_type(term)
             if mathsat.msat_is_integer_type(self.msat_env(), ty):
-                res = mgr.Int(int(mathsat.msat_term_repr(term)))
+                res = self.mgr.Int(int(mathsat.msat_term_repr(term)))
             elif mathsat.msat_is_rational_type(self.msat_env(), ty):
-                res = mgr.Real(Fraction(mathsat.msat_term_repr(term)))
+                res = self.mgr.Real(Fraction(mathsat.msat_term_repr(term)))
             else:
                 assert "_" in str(term), "Unsupported type for '%s'" % str(term)
                 val, width = str(term).split("_")
                 val = int(val)
                 width = int(width)
-                res = mgr.BV(val, width)
-
-        elif mathsat.msat_term_is_and(self.msat_env(), term):
-            res = mgr.And(args)
-
-        elif mathsat.msat_term_is_or(self.msat_env(), term):
-            res = mgr.Or(args)
-
-        elif mathsat.msat_term_is_not(self.msat_env(), term):
-            assert arity == 1
-            res = mgr.Not(args[0])
-
-        elif mathsat.msat_term_is_iff(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.Iff(args[0], args[1])
-
-        elif mathsat.msat_term_is_term_ite(self.msat_env(), term):
-            assert arity == 3
-            res = mgr.Ite(args[0], args[1], args[2])
-
-        elif mathsat.msat_term_is_equal(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.Equals(args[0], args[1])
-
-        elif mathsat.msat_term_is_leq(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.LE(args[0], args[1])
-
-        elif mathsat.msat_term_is_plus(self.msat_env(), term):
-            res = mgr.Plus(args)
-
-        elif mathsat.msat_term_is_times(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.Times(args[0], args[1])
-
-        elif mathsat.msat_term_is_boolean_constant(self.msat_env(), term):
-            rep = mathsat.msat_term_repr(term)
-            res = mgr.Symbol(rep, types.BOOL)
-
+                res = self.mgr.BV(val, width)
         elif mathsat.msat_term_is_constant(self.msat_env(), term):
             rep = mathsat.msat_term_repr(term)
-
             ty = mathsat.msat_term_get_type(term)
-            if mathsat.msat_is_rational_type(self.msat_env(), ty):
-                res = mgr.Symbol(rep, types.REAL)
+            if mathsat.msat_term_is_boolean_constant(self.msat_env(), term):
+                res = self.mgr.Symbol(rep, types.BOOL)
+            elif mathsat.msat_is_rational_type(self.msat_env(), ty):
+                res = self.mgr.Symbol(rep, types.REAL)
             elif mathsat.msat_is_integer_type(self.msat_env(), ty):
-                res = mgr.Symbol(rep, types.INT)
+                res = self.mgr.Symbol(rep, types.INT)
             else:
                 check_arr, idx_type, val_type = mathsat.msat_is_array_type(self.msat_env(), ty)
                 if check_arr:
                     i = self._msat_type_to_type(idx_type)
                     e = self._msat_type_to_type(val_type)
-                    res = mgr.Symbol(rep, types.ArrayType(i, e))
+                    res = self.mgr.Symbol(rep, types.ArrayType(i, e))
                 else:
                     _, width = mathsat.msat_is_bv_type(self.msat_env(), ty)
                     assert width is not None, "Unsupported variable type for '%s'"%str(term)
-                    res = mgr.Symbol(rep, types.BVType(width))
+                    res = self.mgr.Symbol(rep, types.BVType(width))
 
         elif mathsat.msat_term_is_uf(self.msat_env(), term):
             d = mathsat.msat_term_get_decl(term)
             fun = self.get_symbol_from_declaration(d)
-            res = mgr.Function(fun, args)
-
-        elif mathsat.msat_term_is_bv_times(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVMul(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_plus(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVAdd(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_udiv(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVUDiv(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_urem(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVURem(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_extract(self.msat_env(), term)[0]:
-            assert arity == 1
-            res, msb, lsb = mathsat.msat_term_is_bv_extract(self.msat_env(), term)
-            assert res
-            res = mgr.BVExtract(args[0], lsb, msb)
-
-        elif mathsat.msat_term_is_bv_concat(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVConcat(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_or(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVOr(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_xor(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVXor(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_and(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVAnd(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_not(self.msat_env(), term):
-            assert arity == 1
-            res = mgr.BVNot(args[0])
-
-        elif mathsat.msat_term_is_bv_minus(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVSub(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_neg(self.msat_env(), term):
-            assert arity == 1
-            res = mgr.BVNeg(args[0])
-
-        elif mathsat.msat_term_is_bv_srem(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVSRem(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_sdiv(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVSDiv(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_ult(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVULT(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_slt(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVSLT(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_uleq(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVULE(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_sleq(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVSLE(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_lshl(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVLShl(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_lshr(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVLShr(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_ashr(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVAShr(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_comp(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.BVComp(args[0], args[1])
-
-        elif mathsat.msat_term_is_bv_zext(self.msat_env(), term)[0]:
-            assert arity == 1
-            res, amount = mathsat.msat_term_is_bv_zext(self.msat_env(), term)
-            assert res
-            res = mgr.BVZExt(args[0], amount)
-
-        elif mathsat.msat_term_is_bv_sext(self.msat_env(), term)[0]:
-            assert arity == 1
-            res, amount = mathsat.msat_term_is_bv_sext(self.msat_env(), term)
-            assert res
-            res = mgr.BVSExt(args[0], amount)
-
-        elif mathsat.msat_term_is_bv_rol(self.msat_env(), term)[0]:
-            assert arity == 1
-            res, amount = mathsat.msat_term_is_bv_rol(self.msat_env(), term)
-            assert res
-            res = mgr.BVRol(args[0], amount)
-
-        elif mathsat.msat_term_is_bv_ror(self.msat_env(), term)[0]:
-            assert arity == 1
-            res, amount = mathsat.msat_term_is_bv_ror(self.msat_env(), term)
-            assert res
-            res = mgr.BVRor(args[0], amount)
-
-        elif mathsat.msat_term_is_array_read(self.msat_env(), term):
-            assert arity == 2
-            res = mgr.Select(args[0], args[1])
-
-        elif mathsat.msat_term_is_array_write(self.msat_env(), term):
-            assert arity == 3
-            res = mgr.Store(args[0], args[1], args[2])
-
-        elif mathsat.msat_term_is_array_const(self.msat_env(), term):
-            ty = mathsat.msat_term_get_type(term)
-            pyty = self._msat_type_to_type(ty)
-            res = mgr.Array(pyty.index_type, args[0])
-
+            res = self.mgr.Function(fun, args)
         else:
             raise PysmtTypeError("Unsupported expression:",
                                  mathsat.msat_term_repr(term))


### PR DESCRIPTION
Refactor the walk_back in order to replace big `if...elif` with a map. This relies on the possibility of using the TAG for a msat_decl, and use that directly to select the function to perform back conversion. This is now similar to what we do for Z3. 

At the same time, we use the TAGs to perform the same sort of refactoring for the function _get_signature.
