### PR TITLE
CVC4: Force absolute import of CVC4

### DIFF
--- a/pysmt/cmd/installers/cvc4.py
+++ b/pysmt/cmd/installers/cvc4.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
+
 import os
 import sys
 

--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -15,6 +15,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from __future__ import absolute_import
+
 from six.moves import xrange
 
 from pysmt.exceptions import SolverAPINotFound


### PR DESCRIPTION
The python bindings name clashes with the modules names both in
solvers and installers. This can create problems in python 2 on some
systems.

We address this by requiring the use of absolute import. Note that we
already do the same for z3.

Thanks to Alexey Ignatiev (@2sev) for bringing this issue to our attention.
