### PR TITLE
Fix pysmt for z3 solver on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,18 +9,44 @@ environment:
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.8"
       PYTHON_ARCH: "32"
+      PYSMT_SOLVERS: "None"
 
-    # - PYTHON: "C:\\Python27-x64"
-    #   PYTHON_VERSION: "2.7.8"
-    #   PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.8"
+      PYTHON_ARCH: "64"
+      PYSMT_SOLVERS: "None"
 
-    # - PYTHON: "C:\\Python34"
-    #   PYTHON_VERSION: "3.4.1"
-    #   PYTHON_ARCH: "32"
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.1"
+      PYTHON_ARCH: "32"
+      PYSMT_SOLVERS: "None"
 
     - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.1"
       PYTHON_ARCH: "64"
+      PYSMT_SOLVERS: "None"
+
+
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.8"
+      PYTHON_ARCH: "32"
+      PYSMT_SOLVERS: "z3"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.8"
+      PYTHON_ARCH: "64"
+      PYSMT_SOLVERS: "z3"
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.1"
+      PYTHON_ARCH: "32"
+      PYSMT_SOLVERS: "z3"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.1"
+      PYTHON_ARCH: "64"
+      PYSMT_SOLVERS: "z3"
+
 
 install:
   - ECHO "Filesystem root:"
@@ -43,12 +69,14 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   - "%CMD_IN_ENV% pip install -r dev-requirements.txt"
+  - "%CMD_IN_ENV% python setup.py"
 
 # MG: Build is where we probably want to build the solvers
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
   # Build the compiled extension and run the project tests
+  - "%CMD_IN_ENV% python setup.py --check"
   - "%CMD_IN_ENV% nosetests -v "
 
 # after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,12 +17,12 @@ environment:
       PYSMT_SOLVER: "None"
 
     - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.1"
+      PYTHON_VERSION: "3.5.2"
       PYTHON_ARCH: "32"
       PYSMT_SOLVER: "None"
 
     - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.1"
+      PYTHON_VERSION: "3.5.2"
       PYTHON_ARCH: "64"
       PYSMT_SOLVER: "None"
 
@@ -38,12 +38,12 @@ environment:
       PYSMT_SOLVER: "z3"
 
     - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.1"
+      PYTHON_VERSION: "3.5.2"
       PYTHON_ARCH: "32"
       PYSMT_SOLVER: "z3"
 
     - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.1"
+      PYTHON_VERSION: "3.5.2"
       PYTHON_ARCH: "64"
       PYSMT_SOLVER: "z3"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,12 +16,12 @@ environment:
       PYTHON_ARCH: "64"
       PYSMT_SOLVER: "None"
 
-    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.2"
       PYTHON_ARCH: "32"
       PYSMT_SOLVER: "None"
 
-    - PYTHON: "C:\\Python34-x64"
+    - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.2"
       PYTHON_ARCH: "64"
       PYSMT_SOLVER: "None"
@@ -37,12 +37,12 @@ environment:
       PYTHON_ARCH: "64"
       PYSMT_SOLVER: "z3"
 
-    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.2"
       PYTHON_ARCH: "32"
       PYSMT_SOLVER: "z3"
 
-    - PYTHON: "C:\\Python34-x64"
+    - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.2"
       PYTHON_ARCH: "64"
       PYSMT_SOLVER: "z3"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,43 +9,44 @@ environment:
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.8"
       PYTHON_ARCH: "32"
-      PYSMT_SOLVERS: "None"
+      PYSMT_SOLVER: "None"
 
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.8"
       PYTHON_ARCH: "64"
-      PYSMT_SOLVERS: "None"
+      PYSMT_SOLVER: "None"
 
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4.1"
       PYTHON_ARCH: "32"
-      PYSMT_SOLVERS: "None"
+      PYSMT_SOLVER: "None"
 
     - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.1"
       PYTHON_ARCH: "64"
-      PYSMT_SOLVERS: "None"
+      PYSMT_SOLVER: "None"
 
 
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.8"
       PYTHON_ARCH: "32"
-      PYSMT_SOLVERS: "z3"
+      PYSMT_SOLVER: "z3"
 
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.8"
       PYTHON_ARCH: "64"
-      PYSMT_SOLVERS: "z3"
+      PYSMT_SOLVER: "z3"
 
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4.1"
       PYTHON_ARCH: "32"
-      PYSMT_SOLVERS: "z3"
+      PYSMT_SOLVER: "z3"
 
     - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.1"
       PYTHON_ARCH: "64"
-      PYSMT_SOLVERS: "z3"
+      PYSMT_SOLVER: "z3"
+
 
 
 install:
@@ -69,14 +70,20 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   - "%CMD_IN_ENV% pip install -r dev-requirements.txt"
-  - "%CMD_IN_ENV% python setup.py"
 
-# MG: Build is where we probably want to build the solvers
-build: false  # Not a C# project, build stuff at the test step instead.
+  # Install the solvers
+  - "%CMD_IN_ENV% python install.py --confirm-agreement"
+
+  # Set the pythonpath
+  - "python install.py --env > bindings_path.txt"
+  - "SET /p BINDINGS_CMD=<bindings_path.txt"
+  - "%BINDINGS_CMD%"
+  - ECHO "PythonPath=%PYTHONPATH%"
+
+build: false
 
 test_script:
-  # Build the compiled extension and run the project tests
-  - "%CMD_IN_ENV% python setup.py --check"
+  - "%CMD_IN_ENV% python install.py --check"
   - "%CMD_IN_ENV% nosetests -v "
 
 # after_test:

--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -17,6 +17,7 @@ from six.moves import input
 import os
 import argparse
 import sys
+import platform
 
 from collections import namedtuple
 
@@ -133,12 +134,14 @@ def parse_options():
                         action='store_true', default=False,
                         help='Confirm that you agree with the licenses of the\
                         solvers and skip the interactive question')
-
+    
+    install_path_default = os.path.join("~", ".smt_solvers")
     parser.add_argument('--install-path', dest='install_path',
-                        type=str, default="~/.smt_solvers",
+                        type=str, default=install_path_default,
                         help='The folder to use for the installation')
 
-    py_bindings = "~/.smt_solvers/python-bindings-%d.%d" % sys.version_info[0:2]
+    py_bindings = os.path.join(install_path_default, 
+                               "python-bindings-%d.%d" % sys.version_info[0:2])
     parser.add_argument('--bindings-path', dest='bindings_path',
                         type=str, default=py_bindings,
                         help='The folder to use for the bindings')
@@ -214,7 +217,10 @@ def main():
 
     elif options.env:
         bindings_dir= os.path.expanduser(options.bindings_path)
-        print("export PYTHONPATH=\""+ bindings_dir + ":${PYTHONPATH}\"")
+        if platform.system().lower() == "windows":
+            print("set PYTHONPATH=" + bindings_dir + ":%{PYTHONPATH}%")
+        else:
+            print("export PYTHONPATH=\"" + bindings_dir + ":${PYTHONPATH}\"")
 
     else:
         if len(solvers_to_install) == 0:

--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -218,7 +218,7 @@ def main():
     elif options.env:
         bindings_dir= os.path.expanduser(options.bindings_path)
         if platform.system().lower() == "windows":
-            print("set PYTHONPATH=" + bindings_dir + ":%{PYTHONPATH}%")
+            print("set PYTHONPATH=" + bindings_dir + ";%PYTHONPATH%")
         else:
             print("export PYTHONPATH=\"" + bindings_dir + ":${PYTHONPATH}\"")
 

--- a/pysmt/cmd/installers/base.py
+++ b/pysmt/cmd/installers/base.py
@@ -18,6 +18,7 @@ import shutil
 import zipfile
 import tarfile
 import six
+import struct
 
 from contextlib import contextmanager
 
@@ -75,7 +76,11 @@ class SolverInstaller(object):
 
     @property
     def architecture(self):
-        return platform.machine()
+        bits = 8 * struct.calcsize("P")
+        if bits == 64:
+            return "x86_64"
+        else:
+            return "x86"
 
     @property
     def python_version(self):

--- a/pysmt/cmd/installers/z3.py
+++ b/pysmt/cmd/installers/z3.py
@@ -83,4 +83,3 @@ class Z3Installer(SolverInstaller):
                 # Return None, without raising an exception
                 # pylint: disable=lost-exception
                 return version
-

--- a/pysmt/cmd/installers/z3.py
+++ b/pysmt/cmd/installers/z3.py
@@ -74,7 +74,7 @@ class Z3Installer(SolverInstaller):
         with TemporaryPath([self.bindings_dir]):
             version = None
             try:
-                import z3        
+                import z3  
                 (major, minor, ver, _) = z3.get_version()
                 version = "%d.%d.%d" % (major, minor, ver)
             finally:

--- a/pysmt/cmd/installers/z3.py
+++ b/pysmt/cmd/installers/z3.py
@@ -27,7 +27,7 @@ class Z3Installer(SolverInstaller):
     def __init__(self, install_dir, bindings_dir, solver_version,
                  mirror_link=None, osx=None):
         arch = self.architecture
-        if arch == "x86_64":
+        if arch == "x86_64" or arch == "AMD64":
             arch = "x64"
 
         system = self.os_name
@@ -35,6 +35,8 @@ class Z3Installer(SolverInstaller):
             system = "ubuntu-14.04"
         elif system == "darwin":
             system = "osx-%s" % osx
+        elif system == "windows":
+            system = "win"
 
         archive_name = "z3-%s-%s-%s.zip" % (solver_version, arch, system)
         native_link = "https://github.com/Z3Prover/z3/releases/download/z3-4.4.1/{archive_name}"
@@ -62,6 +64,9 @@ class Z3Installer(SolverInstaller):
             files += [ "libz3.so" ]
         elif self.os_name == "darwin":
             files += [ "libz3.a", "libz3.dylib" ]
+        elif self.os_name == "windows":
+            files += [ "libz3.dll", "libz3.lib" ]
+
         for f in files:
             SolverInstaller.mv(os.path.join(bpath, f), self.bindings_dir)
 
@@ -69,7 +74,7 @@ class Z3Installer(SolverInstaller):
         with TemporaryPath([self.bindings_dir]):
             version = None
             try:
-                import z3
+                import z3        
                 (major, minor, ver, _) = z3.get_version()
                 version = "%d.%d.%d" % (major, minor, ver)
             finally:
@@ -78,3 +83,4 @@ class Z3Installer(SolverInstaller):
                 # Return None, without raising an exception
                 # pylint: disable=lost-exception
                 return version
+

--- a/pysmt/cmd/installers/z3.py
+++ b/pysmt/cmd/installers/z3.py
@@ -27,7 +27,7 @@ class Z3Installer(SolverInstaller):
     def __init__(self, install_dir, bindings_dir, solver_version,
                  mirror_link=None, osx=None):
         arch = self.architecture
-        if arch == "x86_64" or arch == "AMD64":
+        if arch == "x86_64":
             arch = "x64"
 
         system = self.os_name

--- a/pysmt/cmd/installers/z3.py
+++ b/pysmt/cmd/installers/z3.py
@@ -74,7 +74,7 @@ class Z3Installer(SolverInstaller):
         with TemporaryPath([self.bindings_dir]):
             version = None
             try:
-                import z3  
+                import z3
                 (major, minor, ver, _) = z3.get_version()
                 version = "%d.%d.%d" % (major, minor, ver)
             finally:


### PR DESCRIPTION
This PR does:  
- fix default `smt_solvers` directory in order to be properly handled also on Win  
- fix the message for the option `--env` for Win
- fix `installers\z3.py` in order to install z3 python bindings on Win.

Check done on my win 10 - 64 bit machine:
- calling `install.py  --check`, z3 solver is 'True'
- run `nose .` and the result is 'OK'

 
