### PR TITLE
Adding LIA support to MSat-Based Quantifier Elimination

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,7 +151,7 @@ customize its behavior.
 dependencies for building the solver (e.g., make or gcc) and has been
 tested mainly on Linux Debian/Ubuntu systems. We suggest that you
 refer to the documentation of each solver to understand how to install
-it with its python bindings. 
+it with its python bindings.
 
 For Yices, picosat, and CUDD, we use external wrappers:
 
@@ -198,7 +198,7 @@ each of the available quantifier eliminators
   Quantifier Eliminator   pySMT name   Supported Logics
   =====================   ==========   ================
   MathSAT FM              msat-fm      LRA
-  MathSAT LW              msat-lw      LRA
+  MathSAT LW              msat-lw      LRA, LIA
   Z3                      z3           LRA, LIA
   BDD (CUDD)              bdd          BOOL
   =====================   ==========   ================
@@ -221,5 +221,3 @@ pySMT is release under the APACHE 2.0 License.
 
 For further questions, feel free to open an issue, or write to
 pysmt@googlegroups.com (`Browse the Archive <https://groups.google.com/d/forum/pysmt>`_).
-
-

--- a/pysmt/factory.py
+++ b/pysmt/factory.py
@@ -40,7 +40,7 @@ from pysmt.solvers.portfolio import Portfolio
 
 DEFAULT_SOLVER_PREFERENCE_LIST = ['msat', 'z3', 'cvc4', 'yices', 'btor',
                                   'picosat', 'bdd']
-DEFAULT_QELIM_PREFERENCE_LIST = ['z3', 'msat_fm', 'msat_lw', 'bdd', 'shannon']
+DEFAULT_QELIM_PREFERENCE_LIST = ['z3', 'msat_lw', 'msat_fm', 'bdd', 'shannon']
 DEFAULT_INTERPOLATION_PREFERENCE_LIST = ['msat', 'z3']
 DEFAULT_LOGIC = QF_UFLIRA
 DEFAULT_QE_LOGIC = LRA

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -1095,8 +1095,8 @@ if hasattr(mathsat, "MSAT_EXIST_ELIM_ALLSMT_FM"):
                 raise PysmtValueError("Algorithm can be either 'fm' or 'lw'")
 
             if logic is not None and (not logic <= LRA and algorithm != "lw"):
-                raise NotImplementedError("MathSAT quantifier elimination for LIA"\
-                                          " only works with 'lw' algorithm")
+                raise PysmtValueError("MathSAT quantifier elimination for LIA"\
+                                      " only works with 'lw' algorithm")
 
             QuantifierEliminator.__init__(self)
             IdentityDagWalker.__init__(self, env=environment)
@@ -1119,13 +1119,13 @@ if hasattr(mathsat, "MSAT_EXIST_ELIM_ALLSMT_FM"):
         def exist_elim(self, variables, formula):
             logic = get_logic(formula, self.env)
             if not (logic <= LRA or logic <= LIA):
-                raise NotImplementedError("MathSAT quantifier elimination only"\
-                                          " supports LRA (detected logic " \
-                                          "is: %s)" % str(logic))
+                raise PysmtValueError("MathSAT quantifier elimination only"\
+                                      " supports LRA or LIA (detected logic " \
+                                      "is: %s)" % str(logic))
 
             if not logic <= LRA and self.algorithm != "lw":
-                raise NotImplementedError("MathSAT quantifier elimination for LIA"\
-                                          " only works with 'lw' algorithm")
+                raise PysmtValueError("MathSAT quantifier elimination for LIA"\
+                                      " only works with 'lw' algorithm")
 
 
             fterm = self.converter.convert(formula)
@@ -1198,9 +1198,9 @@ class MSatInterpolator(Interpolator):
             logic = get_logic(f, self.environment)
             ok = any(logic <= l for l in self.LOGICS)
             if not ok:
-                raise NotImplementedError(
-                    "Logic not supported by MathSAT interpolation."
-                    "(detected logic is: %s)" % str(logic))
+                raise PysmtValueError("Logic not supported by MathSAT "
+                                      "interpolation. (detected logic is: %s)" \
+                                      % str(logic))
 
     def binary_interpolant(self, a, b):
         res = self.sequence_interpolant([a, b])

--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -881,9 +881,9 @@ class Z3QuantifierEliminator(QuantifierEliminator):
     def eliminate_quantifiers(self, formula):
         logic = get_logic(formula, self.environment)
         if not logic <= LRA and not logic <= LIA:
-            raise NotImplementedError("Z3 quantifier elimination only "\
-                                      "supports LRA or LIA without combination."\
-                                      "(detected logic is: %s)" % str(logic))
+            raise PysmtValueError("Z3 quantifier elimination only "\
+                                  "supports LRA or LIA without combination."\
+                                  "(detected logic is: %s)" % str(logic))
 
         simplifier = z3.Tactic('simplify')
         eliminator = z3.Tactic('qe')
@@ -929,9 +929,8 @@ class Z3Interpolator(Interpolator):
             logic = get_logic(f, self.environment)
             ok = any(logic <= l for l in self.LOGICS)
             if not ok:
-                raise NotImplementedError(
-                    "Logic not supported by Z3 interpolation."
-                    "(detected logic is: %s)" % str(logic))
+                raise PysmtValueError("Logic not supported by Z3 interpolation."
+                                      "(detected logic is: %s)" % str(logic))
 
     def binary_interpolant(self, a, b):
         self._check_logic([a, b])

--- a/pysmt/test/test_qe.py
+++ b/pysmt/test/test_qe.py
@@ -61,9 +61,6 @@ class TestQE(TestCase):
         with self.assertRaises(NoSolverAvailableError):
             QuantifierEliminator(name="nonexistent")
 
-        # MathSAT QE does not support LIA
-        with self.assertRaises(NoSolverAvailableError):
-            QuantifierEliminator(name="msat", logic=LIA)
 
     @skipIfNoQEForLogic(LRA)
     def test_selection_lra(self):
@@ -122,12 +119,8 @@ class TestQE(TestCase):
         self._real_example(qe)
         self._alternation_bool_example(qe)
         self._alternation_real_example(qe)
-
-        with self.assertRaises(NotImplementedError):
-            self._int_example(qe)
-
-        with self.assertRaises(NotImplementedError):
-            self._alternation_int_example(qe)
+        self._int_example(qe)
+        self._alternation_int_example(qe)
 
         # Additional test for raising error on back conversion of
         # quantified formulae

--- a/pysmt/test/test_qe.py
+++ b/pysmt/test/test_qe.py
@@ -24,7 +24,7 @@ from pysmt.test import TestCase, main
 from pysmt.test import (skipIfNoSolverForLogic, skipIfNoQEForLogic,
                         skipIfQENotAvailable)
 from pysmt.test.examples import get_example_formulae
-from pysmt.exceptions import (SolverReturnedUnknownResultError,
+from pysmt.exceptions import (SolverReturnedUnknownResultError, PysmtValueError,
                               NoSolverAvailableError, ConvertExpressionError)
 from pysmt.logics import LRA, LIA, UFLIRA
 
@@ -77,7 +77,6 @@ class TestQE(TestCase):
         self._alternation_int_example(qe)
         self._std_examples(qe, LRA)
         self._std_examples(qe, LIA)
-
         self._modular_congruence(qe)
 
         # Additional test for raising error on back conversion of
@@ -86,7 +85,7 @@ class TestQE(TestCase):
 
         f = ForAll([p], Exists([q], Equals(ToReal(p),
                                            Plus(ToReal(q), ToReal(Int(1))))))
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(PysmtValueError):
             qe.eliminate_quantifiers(f).simplify()
 
 
@@ -99,10 +98,10 @@ class TestQE(TestCase):
         self._alternation_real_example(qe)
         self._std_examples(qe, LRA)
 
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(PysmtValueError):
             self._int_example(qe)
 
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(PysmtValueError):
             self._alternation_int_example(qe)
 
         # Additional test for raising error on back conversion of
@@ -111,7 +110,7 @@ class TestQE(TestCase):
 
         f = ForAll([p], Exists([q], Equals(ToReal(p),
                                            Plus(ToReal(q), ToReal(Int(1))))))
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(PysmtValueError):
             qe.eliminate_quantifiers(f).simplify()
 
 
@@ -134,7 +133,7 @@ class TestQE(TestCase):
 
         f = ForAll([p], Exists([q], Equals(ToReal(p),
                                            Plus(ToReal(q), ToReal(Int(1))))))
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(PysmtValueError):
             qe.eliminate_quantifiers(f).simplify()
 
     def _modular_congruence(self, qe):

--- a/pysmt/test/test_qe.py
+++ b/pysmt/test/test_qe.py
@@ -17,7 +17,7 @@
 #
 from pysmt.shortcuts import Symbol, ForAll, Exists, And, Iff, GE, LT, Real, Int
 from pysmt.shortcuts import Minus, Equals, Plus, ToReal, Implies, LE, TRUE, Not
-from pysmt.shortcuts import QuantifierEliminator
+from pysmt.shortcuts import Times, QuantifierEliminator
 from pysmt.shortcuts import is_sat, is_valid
 from pysmt.typing import REAL, BOOL, INT
 from pysmt.test import TestCase, main
@@ -25,7 +25,7 @@ from pysmt.test import (skipIfNoSolverForLogic, skipIfNoQEForLogic,
                         skipIfQENotAvailable)
 from pysmt.test.examples import get_example_formulae
 from pysmt.exceptions import (SolverReturnedUnknownResultError,
-                              NoSolverAvailableError)
+                              NoSolverAvailableError, ConvertExpressionError)
 from pysmt.logics import LRA, LIA, UFLIRA
 
 
@@ -77,6 +77,9 @@ class TestQE(TestCase):
         self._alternation_int_example(qe)
         self._std_examples(qe, LRA)
         self._std_examples(qe, LIA)
+
+        self._modular_congruence(qe)
+
         # Additional test for raising error on back conversion of
         # quantified formulae
         p, q = Symbol("p", INT), Symbol("q", INT)
@@ -121,6 +124,9 @@ class TestQE(TestCase):
         self._alternation_real_example(qe)
         self._int_example(qe)
         self._alternation_int_example(qe)
+        self._std_examples(qe, LIA)
+
+        self._modular_congruence(qe)
 
         # Additional test for raising error on back conversion of
         # quantified formulae
@@ -130,6 +136,12 @@ class TestQE(TestCase):
                                            Plus(ToReal(q), ToReal(Int(1))))))
         with self.assertRaises(NotImplementedError):
             qe.eliminate_quantifiers(f).simplify()
+
+    def _modular_congruence(self, qe):
+        p, q = (Symbol(n, INT) for n in "pq")
+        f = Exists([q], Equals(Times(q, Int(2)), p))
+        with self.assertRaises(ConvertExpressionError):
+            qe.eliminate_quantifiers(f)
 
 
     def _bool_example(self, qe):

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -190,7 +190,8 @@ class TestRegressions(TestCase):
             qelim(f)
         except ConvertExpressionError as ex:
             # The modulus operator must be there
-            self.assertIn("%2", str(ex.expression))
+            self.assertTrue("%2" in str(ex.expression) or \
+                            "int_mod_congr" in str(ex.expression))
 
     @skipIfSolverNotAvailable("msat")
     def test_msat_partial_model(self):


### PR DESCRIPTION
* Added LIA support in MathSAT Quantifier Eliminator using "LW" algorithm (see issue #387)
* Updated tests for QE
* Changed preference list for QE to prefer LW over FM when using MathSAT