### PR TITLE
Print SmtLib term as string shortcut and default to dag SmtLib representation

### DIFF
--- a/pysmt/fnode.py
+++ b/pysmt/fnode.py
@@ -17,8 +17,8 @@
 #
 """FNode are the building blocks of formulae."""
 import collections
-
 import pysmt.environment
+import pysmt.smtlib
 from pysmt.operators import (FORALL, EXISTS, AND, OR, NOT, IMPLIES, IFF,
                              SYMBOL, FUNCTION,
                              REAL_CONSTANT, BOOL_CONSTANT, INT_CONSTANT,
@@ -48,7 +48,7 @@ from pysmt.utils import twos_complement
 from pysmt.constants import (Fraction, is_python_integer,
                              is_python_rational, is_python_boolean)
 from pysmt.exceptions import PysmtValueError, PysmtModeError
-import pysmt.smtlib
+
 
 FNodeContent = collections.namedtuple("FNodeContent",
                                       ["node_type", "args", "payload"])
@@ -508,17 +508,17 @@ class FNode(object):
         """
         return _env().serializer.serialize(self, threshold=threshold)
 
-    def smtlib_serialize(self, daggify=True):
+    def to_smtlib(self, daggify=True):
         """Returns a Smt-Lib string representation of the formula.
 
         The daggify parameter can be used to switch from a linear-size
-        representation that uses 'let' operators to represnt the
+        representation that uses 'let' operators to represent the
         formula as a dag or a simpler (but possibly exponential)
-        representation that expalnds the formula as a tree.
+        representation that expands the formula as a tree.
 
         See :py:class:`SmtPrinter`
         """
-        return pysmt.smtlib.printers.smtlib_serialize(self, daggify=daggify)
+        return pysmt.smtlib.printers.to_smtlib(self, daggify=daggify)
 
     def is_function_application(self):
         """Test whether the node is a Function application."""

--- a/pysmt/fnode.py
+++ b/pysmt/fnode.py
@@ -48,9 +48,7 @@ from pysmt.utils import twos_complement
 from pysmt.constants import (Fraction, is_python_integer,
                              is_python_rational, is_python_boolean)
 from pysmt.exceptions import PysmtValueError, PysmtModeError
-from pysmt.smtlib.printers import SmtPrinter, SmtDagPrinter
-from six.moves import cStringIO
-
+import pysmt.smtlib
 
 FNodeContent = collections.namedtuple("FNodeContent",
                                       ["node_type", "args", "payload"])
@@ -510,7 +508,6 @@ class FNode(object):
         """
         return _env().serializer.serialize(self, threshold=threshold)
 
-
     def smtlib_serialize(self, daggify=True):
         """Returns a Smt-Lib string representation of the formula.
 
@@ -521,16 +518,7 @@ class FNode(object):
 
         See :py:class:`SmtPrinter`
         """
-        buf = cStringIO()
-        p = None
-        if daggify:
-            p = SmtDagPrinter(buf)
-        else:
-            p = SmtPrinter(buf)
-        p.printer(f)
-        res = buf.getvalue()
-        buf.close()
-        return res
+        return pysmt.smtlib.printers.smtlib_serialize(self, daggify=daggify)
 
     def is_function_application(self):
         """Test whether the node is a Function application."""

--- a/pysmt/fnode.py
+++ b/pysmt/fnode.py
@@ -48,6 +48,8 @@ from pysmt.utils import twos_complement
 from pysmt.constants import (Fraction, is_python_integer,
                              is_python_rational, is_python_boolean)
 from pysmt.exceptions import PysmtValueError, PysmtModeError
+from pysmt.smtlib.printers import SmtPrinter, SmtDagPrinter
+from six.moves import cStringIO
 
 
 FNodeContent = collections.namedtuple("FNodeContent",
@@ -507,6 +509,28 @@ class FNode(object):
         See :py:class:`HRSerializer`
         """
         return _env().serializer.serialize(self, threshold=threshold)
+
+
+    def smtlib_serialize(self, daggify=True):
+        """Returns a Smt-Lib string representation of the formula.
+
+        The daggify parameter can be used to switch from a linear-size
+        representation that uses 'let' operators to represnt the
+        formula as a dag or a simpler (but possibly exponential)
+        representation that expalnds the formula as a tree.
+
+        See :py:class:`SmtPrinter`
+        """
+        buf = cStringIO()
+        p = None
+        if daggify:
+            p = SmtDagPrinter(buf)
+        else:
+            p = SmtPrinter(buf)
+        p.printer(f)
+        res = buf.getvalue()
+        buf.close()
+        return res
 
     def is_function_application(self):
         """Test whether the node is a Function application."""

--- a/pysmt/shortcuts.py
+++ b/pysmt/shortcuts.py
@@ -37,6 +37,7 @@ import pysmt.configuration as config
 import pysmt.environment
 import pysmt.smtlib.parser
 import pysmt.smtlib.script
+import pysmt.smtlib.printers
 
 
 def get_env():
@@ -1113,4 +1114,4 @@ def smtlib_serialize(formula, daggify=True):
 
     See :py:class:`SmtPrinter`
     """
-    return formula.smtlib_serialize(daggify=daggify)
+    return pysmt.smtlib.printers.smtlib_serialize(formula, daggify=daggify)

--- a/pysmt/shortcuts.py
+++ b/pysmt/shortcuts.py
@@ -1104,14 +1104,14 @@ def write_smtlib(formula, fname):
         script.serialize(fout)
 
 
-def smtlib_serialize(formula, daggify=True):
+def to_smtlib(formula, daggify=True):
     """Returns a Smt-Lib string representation of the formula.
 
     The daggify parameter can be used to switch from a linear-size
-    representation that uses 'let' operators to represnt the
+    representation that uses 'let' operators to represent the
     formula as a dag or a simpler (but possibly exponential)
-    representation that expalnds the formula as a tree.
+    representation that expands the formula as a tree.
 
     See :py:class:`SmtPrinter`
     """
-    return pysmt.smtlib.printers.smtlib_serialize(formula, daggify=daggify)
+    return pysmt.smtlib.printers.to_smtlib(formula, daggify=daggify)

--- a/pysmt/shortcuts.py
+++ b/pysmt/shortcuts.py
@@ -1101,3 +1101,16 @@ def write_smtlib(formula, fname):
     with open(fname, "w") as fout:
         script = pysmt.smtlib.script.smtlibscript_from_formula(formula)
         script.serialize(fout)
+
+
+def smtlib_serialize(formula, daggify=True):
+    """Returns a Smt-Lib string representation of the formula.
+
+    The daggify parameter can be used to switch from a linear-size
+    representation that uses 'let' operators to represnt the
+    formula as a dag or a simpler (but possibly exponential)
+    representation that expalnds the formula as a tree.
+
+    See :py:class:`SmtPrinter`
+    """
+    return formula.smtlib_serialize(daggify=daggify)

--- a/pysmt/smtlib/printers.py
+++ b/pysmt/smtlib/printers.py
@@ -17,7 +17,7 @@
 #
 from functools import partial
 
-from six.moves import xrange
+from six.moves import xrange, cStringIO
 
 import pysmt.operators as op
 from pysmt.environment import get_env
@@ -430,3 +430,25 @@ class SmtDagPrinter(DagWalker):
             self.write(")")
         self.write("))")
         return sym
+
+
+def smtlib_serialize(formula, daggify=True):
+    """Returns a Smt-Lib string representation of the formula.
+
+    The daggify parameter can be used to switch from a linear-size
+    representation that uses 'let' operators to represnt the
+    formula as a dag or a simpler (but possibly exponential)
+    representation that expalnds the formula as a tree.
+
+    See :py:class:`SmtPrinter`
+    """
+    buf = cStringIO()
+    p = None
+    if daggify:
+        p = SmtDagPrinter(buf)
+    else:
+        p = SmtPrinter(buf)
+    p.printer(formula)
+    res = buf.getvalue()
+    buf.close()
+    return res

--- a/pysmt/smtlib/printers.py
+++ b/pysmt/smtlib/printers.py
@@ -432,13 +432,13 @@ class SmtDagPrinter(DagWalker):
         return sym
 
 
-def smtlib_serialize(formula, daggify=True):
+def to_smtlib(formula, daggify=True):
     """Returns a Smt-Lib string representation of the formula.
 
     The daggify parameter can be used to switch from a linear-size
-    representation that uses 'let' operators to represnt the
+    representation that uses 'let' operators to represent the
     formula as a dag or a simpler (but possibly exponential)
-    representation that expalnds the formula as a tree.
+    representation that expands the formula as a tree.
 
     See :py:class:`SmtPrinter`
     """

--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -42,7 +42,7 @@ def check_sat_filter(log):
 
 
 class SmtLibCommand(namedtuple('SmtLibCommand', ['name', 'args'])):
-    def serialize(self, outstream=None, printer=None, daggify=False):
+    def serialize(self, outstream=None, printer=None, daggify=True):
         """Serializes the SmtLibCommand into outstream using the given printer.
 
         Exactly one of outstream or printer must be specified. When

--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -131,9 +131,9 @@ class SmtLibCommand(namedtuple('SmtLibCommand', ['name', 'args'])):
         else:
             raise UnknownSmtLibCommandError(self.name)
 
-    def serialize_to_string(self):
+    def serialize_to_string(self, daggify=True):
         buf = cStringIO()
-        self.serialize(buf)
+        self.serialize(buf, daggify=daggify)
         return buf.getvalue()
 
 

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -392,7 +392,7 @@ class TestRegressions(TestCase):
         buffer_ = cStringIO(smtlib_input)
         s = parser.get_script(buffer_)
         for c in s:
-            res = c.serialize_to_string()
+            res = c.serialize_to_string(daggify=False)
         self.assertEqual(res, smtlib_input)
 
     @skipIfSolverNotAvailable("z3")


### PR DESCRIPTION
This PR addresses issues #396 and #397.

I introduced a shortcut ```smtlib_serialize``` and a method of FNode with the same name that return a string representation of the given formula. The ```daggify``` parameter is used to enable or disable the use of ```let``` operators to represent the formulae linearly.