### PR TITLE
Suspend Type-Checking Context

### DIFF
--- a/pysmt/environment.py
+++ b/pysmt/environment.py
@@ -155,6 +155,27 @@ class Environment(object):
 
 # EOC Environment
 
+class SuspendTypeChecking(object):
+    '''Context class that suspends the type-checking during formula
+    creation. This could be useful to avoid costly type-checking when
+    creating huge formulae that are guaranteed to be correct.
+    '''
+
+    def __init__(self, env=None):
+        if env is None:
+            env = get_env()
+        self.env = env
+        self.fm = env.formula_manager
+
+    def __enter__(self):
+        """Entering a Context """
+        self.fm._do_type_check = lambda x : x
+        return self.env
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Remove environment from global stack."""
+        self.fm._do_type_check = self.fm._do_type_check_real
+
 #### GLOBAL ENVIRONMENTS STACKS ####
 ENVIRONMENTS_STACK = []
 

--- a/pysmt/shortcuts.py
+++ b/pysmt/shortcuts.py
@@ -38,7 +38,6 @@ import pysmt.environment
 import pysmt.smtlib.parser
 import pysmt.smtlib.script
 
-
 def get_env():
     """Returns the global environment.
 

--- a/pysmt/test/test_typechecker.py
+++ b/pysmt/test/test_typechecker.py
@@ -23,7 +23,7 @@ from pysmt.type_checker import (assert_no_boolean_in_args,
 from pysmt.shortcuts import (Symbol, And, Plus, Minus, Times, Equals, Or, Iff,
                              LE, LT, Not, GE, GT, Ite, Bool, Int, Real, Div,
                              Function)
-from pysmt.environment import get_env
+from pysmt.environment import get_env, SuspendTypeChecking
 from pysmt.exceptions import PysmtTypeError
 from pysmt.test import TestCase, main
 from pysmt.test.examples import get_example_formulae
@@ -191,6 +191,17 @@ class TestSimpleTypeChecker(TestCase):
     def test_examples(self):
         for (f, _, _, _) in get_example_formulae():
             self.assertIs(f.get_type(), BOOL)
+
+    def test_suspend(self):
+        with self.assertRaises(PysmtTypeError):
+            And(self.x, self.r)
+
+        r = None
+        with SuspendTypeChecking():
+            r = And(self.x, self.r)
+
+        self.assertTrue(r.is_and())
+        self.assertEquals(list(r.args()), [self.x, self.r])
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR introduces a context class to suspend the type checking of formulae during construction.

This could be useful to avoid costly type-checking when creating huge formulae that are guaranteed to be correct.