### PR TITLE
Fixed cyclic import errors

### DIFF
--- a/pysmt/fnode.py
+++ b/pysmt/fnode.py
@@ -17,7 +17,6 @@
 #
 """FNode are the building blocks of formulae."""
 import collections
-import pysmt.environment
 import pysmt.smtlib
 from pysmt.operators import (FORALL, EXISTS, AND, OR, NOT, IMPLIES, IFF,
                              SYMBOL, FUNCTION,
@@ -852,10 +851,12 @@ class FNode(object):
 
 def _env():
     """Aux function to obtain the environment."""
+    import pysmt.environment
     return pysmt.environment.get_env()
 
 def _mgr():
     """Aux function to obtain the formula manager."""
+    import pysmt.environment
     return pysmt.environment.get_env().formula_manager
 
 def _is_bv(node):

--- a/pysmt/fnode.py
+++ b/pysmt/fnode.py
@@ -17,6 +17,7 @@
 #
 """FNode are the building blocks of formulae."""
 import collections
+import pysmt
 import pysmt.smtlib
 from pysmt.operators import (FORALL, EXISTS, AND, OR, NOT, IMPLIES, IFF,
                              SYMBOL, FUNCTION,
@@ -851,12 +852,10 @@ class FNode(object):
 
 def _env():
     """Aux function to obtain the environment."""
-    import pysmt.environment
     return pysmt.environment.get_env()
 
 def _mgr():
     """Aux function to obtain the formula manager."""
-    import pysmt.environment
     return pysmt.environment.get_env().formula_manager
 
 def _is_bv(node):

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -23,7 +23,7 @@ properties of formulae.
  * FreeVarsOracle says which variables are free in the formula
 """
 
-import pysmt.walkers
+import pysmt
 import pysmt.operators as op
 
 from pysmt import typing as types
@@ -423,7 +423,6 @@ class AtomsOracle(pysmt.walkers.DagWalker):
 
 def get_logic(formula, env=None):
     if env is None:
-        import pysmt.environment
         env = pysmt.environment.get_env()
     # Get Quantifier Information
     qf = env.qfo.is_qf(formula)

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -24,6 +24,7 @@ properties of formulae.
 """
 
 import pysmt
+import pysmt.walkers
 import pysmt.operators as op
 
 from pysmt import typing as types

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -25,7 +25,6 @@ properties of formulae.
 
 import pysmt.walkers
 import pysmt.operators as op
-import pysmt.environment
 
 from pysmt import typing as types
 
@@ -424,6 +423,7 @@ class AtomsOracle(pysmt.walkers.DagWalker):
 
 def get_logic(formula, env=None):
     if env is None:
+        import pysmt.environment
         env = pysmt.environment.get_env()
     # Get Quantifier Information
     qf = env.qfo.is_qf(formula)

--- a/pysmt/test/test_imports.py
+++ b/pysmt/test/test_imports.py
@@ -35,10 +35,9 @@ class TestImports(TestCase):
             module_name, module_path = stack.pop()
             for _, name, ispkg in pkgutil.iter_modules(module_path):
                 fullname = "%s.%s" % (module_name, name)
-                command = "%s -c 'import %s'" % (sys.executable, fullname)
-                process = subprocess.Popen(command, shell=True)
-                process.communicate()
-                self.assertEqual(process.returncode, 0)
+                command = [sys.executable, '-c', 'import %s' % fullname]
+                returncode = subprocess.call(command)
+                self.assertEqual(returncode, 0, msg="Failed to import %s module" % fullname)
                 if ispkg and fullname not in TestImports.EXCLUSION_LIST:
                     stack.append((fullname, [os.path.join(p, name) for p in module_path]))
 

--- a/pysmt/test/test_imports.py
+++ b/pysmt/test/test_imports.py
@@ -1,0 +1,46 @@
+#
+# This file is part of pySMT.
+#
+#   Copyright 2014 Andrea Micheli and Marco Gario
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import sys
+import subprocess
+import pkgutil
+import os.path
+
+from pysmt.test import TestCase, main
+import pysmt
+
+
+class TestImports(TestCase):
+
+    EXCLUSION_LIST = ["pysmt.test", "pysmt.solvers", "pysmt.cmd"]
+
+    def test_imports(self):
+        stack = [(pysmt.__name__, pysmt.__path__)]
+        while stack:
+            module_name, module_path = stack.pop()
+            for _, name, ispkg in pkgutil.iter_modules(module_path):
+                fullname = "%s.%s" % (module_name, name)
+                command = "%s -c 'import %s'" % (sys.executable, fullname)
+                process = subprocess.Popen(command, shell=True)
+                process.communicate()
+                self.assertEqual(process.returncode, 0)
+                if ispkg and fullname not in TestImports.EXCLUSION_LIST:
+                    stack.append((fullname, [os.path.join(p, name) for p in module_path]))
+
+if __name__ == '__main__':
+    main()

--- a/pysmt/typing.py
+++ b/pysmt/typing.py
@@ -31,6 +31,8 @@ on a factory service. Each BitVector width is represented by a
 different instance of BVType.
 
 """
+import pysmt
+import pysmt.walkers
 from pysmt.exceptions import PysmtValueError
 
 
@@ -500,24 +502,20 @@ class TypeManager(object):
 
 def BVType(width=32):
     """Returns the BV type for the given width."""
-    import pysmt.environment
     mgr = pysmt.environment.get_env().type_manager
     return mgr.BVType(width=width)
 
 def FunctionType(return_type, param_types):
     """Returns Function Type with the given arguments."""
-    import pysmt.environment
     mgr = pysmt.environment.get_env().type_manager
     return mgr.FunctionType(return_type=return_type, param_types=param_types)
 
 def ArrayType(index_type, elem_type):
     """Returns the Array type with the given arguments."""
-    import pysmt.environment
     mgr = pysmt.environment.get_env().type_manager
     return mgr.ArrayType(index_type=index_type, elem_type=elem_type)
 
 def Type(name, arity=0):
     """Returns the Type Declaration with the given name (sort declaration)."""
-    import pysmt.environment
     mgr = pysmt.environment.get_env().type_manager
     return mgr.Type(name=name, arity=arity)

--- a/pysmt/typing.py
+++ b/pysmt/typing.py
@@ -497,25 +497,27 @@ class TypeManager(object):
 
 # EOC TypeManager
 
-import pysmt.environment
-
 
 def BVType(width=32):
     """Returns the BV type for the given width."""
+    import pysmt.environment
     mgr = pysmt.environment.get_env().type_manager
     return mgr.BVType(width=width)
 
 def FunctionType(return_type, param_types):
     """Returns Function Type with the given arguments."""
+    import pysmt.environment
     mgr = pysmt.environment.get_env().type_manager
     return mgr.FunctionType(return_type=return_type, param_types=param_types)
 
 def ArrayType(index_type, elem_type):
     """Returns the Array type with the given arguments."""
+    import pysmt.environment
     mgr = pysmt.environment.get_env().type_manager
     return mgr.ArrayType(index_type=index_type, elem_type=elem_type)
 
 def Type(name, arity=0):
     """Returns the Type Declaration with the given name (sort declaration)."""
+    import pysmt.environment
     mgr = pysmt.environment.get_env().type_manager
     return mgr.Type(name=name, arity=arity)

--- a/pysmt/typing.py
+++ b/pysmt/typing.py
@@ -32,7 +32,6 @@ different instance of BVType.
 
 """
 import pysmt
-import pysmt.walkers
 from pysmt.exceptions import PysmtValueError
 
 


### PR DESCRIPTION
This PR addresses issue #405 .

I created a test that invokes the python interpreter and checks that each pysmt module (except the testing ones and the solvers) can be imported as a standalone (i.e. without previously importing something else).

In order for this test to work I had to move some imports of the environment module inside some functions, but I think this trade-off is acceptable.