### PR TITLE
Default SMT-LIB Script to daggified serialization

### DIFF
--- a/ci/travis_install.sh
+++ b/ci/travis_install.sh
@@ -22,13 +22,13 @@ fi
 
 
 # This is for btor that fails to find the python 3 library to link
-export LIBRARY_PATH=${LIBRARY_PATH}:/opt/python/3.5.2/lib
+export LIBRARY_PATH=${LIBRARY_PATH}:/opt/python/3.5.3/lib
 
 # For some reason, Travis CI cannot find the command python3.5-config.
 # Therefore, we force the path here
 if [ "${TRAVIS_PYTHON_VERSION}" == "3.5" ];
 then
-    export PATH=${PATH}:/opt/python/3.5.2/bin/ ;
+    export PATH=${PATH}:/opt/python/3.5.3/bin/ ;
 fi
 
 pip install six

--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -205,11 +205,11 @@ class SmtLibScript(object):
 
         return _And(stack)
 
-    def to_file(self, fname, daggify=False):
+    def to_file(self, fname, daggify=True):
         with open(fname, "w") as outstream:
             self.serialize(outstream, daggify=daggify)
 
-    def serialize(self, outstream, daggify=False):
+    def serialize(self, outstream, daggify=True):
         """Serializes the SmtLibScript expanding commands"""
         if daggify:
             printer = SmtDagPrinter(outstream)


### PR DESCRIPTION
In #397 we made the serialization of an SmtCommand daggified by default. This did not include the methods that operate directly on the SmtLibScript. This commit fixes this left-over.

Fixes #416 . 