### PR TITLE
CVC4: Free C++ SmtEngine when Solver is destroyed

### DIFF
--- a/ci/travis_install.sh
+++ b/ci/travis_install.sh
@@ -22,13 +22,13 @@ fi
 
 
 # This is for btor that fails to find the python 3 library to link
-export LIBRARY_PATH=${LIBRARY_PATH}:/opt/python/3.5.2/lib
+export LIBRARY_PATH=${LIBRARY_PATH}:/opt/python/3.5.3/lib
 
 # For some reason, Travis CI cannot find the command python3.5-config.
 # Therefore, we force the path here
 if [ "${TRAVIS_PYTHON_VERSION}" == "3.5" ];
 then
-    export PATH=${PATH}:/opt/python/3.5.2/bin/ ;
+    export PATH=${PATH}:/opt/python/3.5.3/bin/ ;
 fi
 
 pip install six

--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -97,7 +97,9 @@ class CVC4Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
 
     def reset_assertions(self):
         del self.cvc4
-        self.cvc4 = CVC4.SmtEngine(self.em)
+        # CVC4's SWIG interface is not acquiring ownership of the
+        # SmtEngine object. Forcing it here.
+        self.cvc4 = CVC4.SmtEngine(self.em); self.cvc4.thisown=1
         self.options(self)
         self.declarations = set()
         self.cvc4.setLogic(self.logic_name)


### PR DESCRIPTION
The SWIG wrapper is not handling properly the ownership of either SmtEngine or ExprManager, resulting in a memory leak: When the python objects are release the underlying C++ are not destroyed.

This commit works-around the issue by forcing the ownership of the SmtEngine to the python wrapper. When the wrapper is destroyed, the C++ is also destroyed.

A proper patch for CVC4 should be designed in order to properly account also for the release of the ExprManager, and the fact that ExprManager is ref'd within SmtEngine (but SWIG has no way of knowing this).

See http://www.swig.org/Doc1.3/Python.html#Python_nn30 for an explanation of the memory management features in SWIG.