### PR TITLE
TypesOracle: Fix handling of constants

### DIFF
--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -444,7 +444,8 @@ class TypesOracle(walkers.DagWalker):
         return expanded
 
     @walkers.handles(set(op.ALL_TYPES) - \
-                     set([op.SYMBOL, op.FUNCTION, op.QUANTIFIERS]))
+                     set([op.SYMBOL, op.FUNCTION]) -\
+                     op.QUANTIFIERS - op.CONSTANTS)
     def walk_combine(self, formula, args, **kwargs):
         #pylint: disable=unused-argument
         res = set()
@@ -465,6 +466,10 @@ class TypesOracle(walkers.DagWalker):
     def walk_quantifier(self, formula, args, **kwargs):
         return frozenset([x.symbol_type()
                           for x in formula.quantifier_vars()]) | args[0]
+
+    @walkers.handles(op.CONSTANTS)
+    def walk_constant(self, formula, args, **kwargs):
+        return frozenset([formula.constant_type()])
 
 # EOC TypesOracle
 

--- a/pysmt/test/test_oracles.py
+++ b/pysmt/test/test_oracles.py
@@ -20,7 +20,7 @@ from pysmt.shortcuts import Symbol, Implies, And, Not
 from pysmt.test.examples import get_example_formulae
 from pysmt.test import TestCase, main
 from pysmt.oracles import get_logic
-from pysmt.typing import BOOL, Type
+from pysmt.typing import BOOL, Type, INT
 
 
 class TestOracles(TestCase):
@@ -121,6 +121,11 @@ class TestOracles(TestCase):
         self.assertTrue(idx_US < idx_BUSBBS)
         self.assertTrue(idx_BBS < idx_BUSBBS)
 
+    def test_type_oracles_constants(self):
+        mgr = self.env.formula_manager
+        f = mgr.Plus(mgr.Int(5), mgr.Int(6))
+        types_all = self.env.typeso.get_types(f)
+        self.assertEqual(types_all, [INT])
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
The TypesOracle was not able to correctly determined the types of expressions with constants, since constants were ignored.