### PR TITLE
Infix: Add NotEquals

### DIFF
--- a/pysmt/fnode.py
+++ b/pysmt/fnode.py
@@ -681,6 +681,9 @@ class FNode(object):
     def Equals(self, right):
         return self._apply_infix(right, _mgr().Equals)
 
+    def NotEquals(self, right):
+        return self._apply_infix(right, _mgr().NotEquals)
+
     def Ite(self, then_, else_):
         if _env().enable_infix_notation:
             if isinstance(then_, FNode) and isinstance(else_, FNode):

--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -266,10 +266,14 @@ class FormulaManager(object):
     def Equals(self, left, right):
         """ Creates an expression of the form: left = right
 
-        Restriction: Left and Right must be both REAL or INT type
+        For the boolean case use Iff
         """
         return self.create_node(node_type=op.EQUALS,
                                 args=(left, right))
+
+    def NotEquals(self, left, right):
+        """ Creates an expression of the form: left != right"""
+        return self.Not(self.Equals(left, right))
 
     def GE(self, left, right):
         """ Creates an expression of the form:

--- a/pysmt/shortcuts.py
+++ b/pysmt/shortcuts.py
@@ -209,6 +209,10 @@ def Equals(left, right):
     return get_env().formula_manager.Equals(left, right)
 
 
+def NotEquals(left, right):
+    r""".. math:: l != r"""
+    return get_env().formula_manager.NotEquals(left, right)
+
 def GT(left, right):
     r""".. math:: l > r"""
     return get_env().formula_manager.GT(left, right)

--- a/pysmt/test/test_formula.py
+++ b/pysmt/test/test_formula.py
@@ -22,6 +22,7 @@ import pysmt
 from pysmt.typing import BOOL, REAL, INT, FunctionType, BV8, BVType
 from pysmt.shortcuts import Symbol, is_sat, Not, Implies, GT, Plus, Int, Real
 from pysmt.shortcuts import Minus, Times, Xor, And, Or, TRUE, Iff, FALSE, Ite
+from pysmt.shortcuts import Equals
 from pysmt.shortcuts import get_env
 from pysmt.environment import Environment
 from pysmt.test import TestCase, skipIfNoSolverForLogic, main
@@ -771,7 +772,7 @@ class TestFormulaManager(TestCase):
             x.Ite(1,2)
 
         self.assertEqual(6 - r, Plus(Times(r, Real(-1)), Real(6)))
-
+        self.assertEqual(Not(Equals(x,y)), x.NotEquals(y))
         # BVs
 
         # BV_CONSTANT: We use directly python numbers


### PR DESCRIPTION
When using infix notation, it would be nice to write ```x != y```. However, this is not possible for the same reasons that we do not allow ``` x == y```. The current way to write this in infix notation would be: ```~ x.Equals(y)```, that is not particularly readable in my opinion. 

This introduces a new function in fnode so that we can write ```x.NotEquals(y)```.