### PR TITLE
BV: Convert GMPY object in BV constructor

### DIFF
--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -569,21 +569,24 @@ class FormulaManager(object):
         if width is None:
             raise PysmtValueError("Need to specify a width for the constant")
 
-        if is_python_integer(value):
-            if value < 0:
-                raise PysmtValueError("Cannot specify a negative value: %d" \
-                                      % value)
-            if value >= 2**width:
-                raise PysmtValueError("Cannot express %d in %d bits" \
-                                      % (value, width))
-
-            return self.create_node(node_type=op.BV_CONSTANT,
-                                    args=tuple(),
-                                    payload=(value, width))
-
+        if is_pysmt_integer(value):
+            _value = value
+        elif is_python_integer(value):
+            _value = pysmt_integer_from_integer(value)
         else:
-            raise PysmtTypeError("Invalid type in constant. The type was:" + \
-                                 str(type(value)))
+            raise PysmtTypeError("Invalid type in constant. The type was: %s" \
+                                 % str(type(value)))
+        if _value < 0:
+            raise PysmtValueError("Cannot specify a negative value: %d" \
+                                  % _value)
+        if _value >= 2**width:
+            raise PysmtValueError("Cannot express %d in %d bits" \
+                                  % (_value, width))
+
+        return self.create_node(node_type=op.BV_CONSTANT,
+                                args=tuple(),
+                                payload=(_value, width))
+
 
     def SBV(self, value, width=None):
         """Returns a constant of type BitVector interpreting the sign.

--- a/pysmt/solvers/btor.py
+++ b/pysmt/solvers/btor.py
@@ -34,6 +34,7 @@ from pysmt.exceptions import (SolverReturnedUnknownResultError,
                               ConvertExpressionError, PysmtValueError)
 from pysmt.decorators import clear_pending_pop, catch_conversion_error
 from pysmt.logics import QF_BV, QF_UFBV, QF_ABV, QF_AUFBV, QF_AX
+from pysmt.constants import to_python_integer
 
 
 class BoolectorOptions(SolverOptions):
@@ -343,7 +344,7 @@ class BTORConverter(Converter, DagWalker):
         return _uf(*args)
 
     def walk_bv_constant(self, formula, **kwargs):
-        value = formula.constant_value()
+        value = to_python_integer(formula.constant_value())
         width = formula.bv_width()
         return self._btor.Const(value, width)
 

--- a/pysmt/test/__init__.py
+++ b/pysmt/test/__init__.py
@@ -24,6 +24,7 @@ except ImportError:
     import unittest
 
 from pysmt.environment import get_env, reset_env
+skipIf = unittest.skipIf
 
 
 class TestCase(unittest.TestCase):

--- a/pysmt/test/test_bv.py
+++ b/pysmt/test/test_bv.py
@@ -15,12 +15,14 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+
 from pysmt.test import TestCase, skipIfNoSolverForLogic, main
 from pysmt.shortcuts import Symbol, And, Symbol, Equals, TRUE
 from pysmt.shortcuts import is_sat, is_valid, get_model, is_unsat
 from pysmt.typing import BVType, BV32, BV128, FunctionType, ArrayType
 from pysmt.logics import QF_BV
 from pysmt.exceptions import PysmtValueError, PysmtTypeError
+
 
 class TestBV(TestCase):
 


### PR DESCRIPTION
Automatically convert GMPY object in the BV constructor.

Previously, BV(mpz(5), 8) would create a node with a mpz object in the
payload *independently* of whether GMPY was enabled or not.

The behavior of the BV constructor is now consistent with the behavior of
Int and Real.

Tests for this have been added in test_constants.py. See Issue #435 .