### PR TITLE
Bugfix: SMTLIB Parsing #x BV constants

### DIFF
--- a/pysmt/smtlib/parser/parser.py
+++ b/pysmt/smtlib/parser/parser.py
@@ -619,7 +619,7 @@ class SmtLibParser(object):
                     if token[1] != "x":
                         raise PysmtSyntaxError("Invalid bit-vector constant "
                                                "'%s'" % token)
-                    width = (len(token) - 2) * 16
+                    width = (len(token) - 2) * 4
                     value = int("0" + token[1:], 16)
                 res = mgr.BV(value, width)
             else:

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -462,6 +462,14 @@ class TestRegressions(TestCase):
             self.assertEqual(ex.pos_info[0], 0)
             self.assertEqual(ex.pos_info[1], 19)
 
+    def test_parse_bvconst_width(self):
+        smtlib_input = "(assert (> #x10 #x10))"
+        parser = SmtLibParser()
+        buffer_ = cStringIO(smtlib_input)
+        expr = parser.get_script(buffer_).get_last_formula()
+        const = expr.args()[0]
+        self.assertEqual(const.bv_width(), 8, const.bv_width())
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
SMT-LIB parsing of bv constants using the hexadecimal syntax
(e.g., #x10) would leads to the incorrect width of the bit-vector.

Fixes issue #442. Thanks to @cdmcdonell for reporting this.