### PR TITLE
Fixed type-checking of Equals, LT and LE.

### DIFF
--- a/pysmt/test/test_formula.py
+++ b/pysmt/test/test_formula.py
@@ -727,7 +727,7 @@ class TestFormulaManager(TestCase):
             x[1]
 
     def test_infix_extended(self):
-        p, r, x, y = self.p, self.r, self.x, self.y
+        p, r, s, x, y = self.p, self.r, self.s, self.x, self.y
         get_env().enable_infix_notation = True
 
         self.assertEqual(Plus(p, Int(1)), p + 1)
@@ -772,7 +772,7 @@ class TestFormulaManager(TestCase):
             x.Ite(1,2)
 
         self.assertEqual(6 - r, Plus(Times(r, Real(-1)), Real(6)))
-        self.assertEqual(Not(Equals(x,y)), x.NotEquals(y))
+        self.assertEqual(Not(Equals(r,s)), r.NotEquals(s))
         # BVs
 
         # BV_CONSTANT: We use directly python numbers

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -29,7 +29,7 @@ from pysmt.typing import REAL, BOOL, INT, BVType, FunctionType, ArrayType
 from pysmt.test import (TestCase, skipIfSolverNotAvailable, skipIfNoSolverForLogic,
                         skipIfNoQEForLogic)
 from pysmt.test import main
-from pysmt.exceptions import ConvertExpressionError, PysmtValueError
+from pysmt.exceptions import ConvertExpressionError, PysmtValueError, PysmtTypeError
 from pysmt.test.examples import get_example_formulae
 from pysmt.environment import Environment
 from pysmt.rewritings import cnf_as_set
@@ -469,6 +469,14 @@ class TestRegressions(TestCase):
         expr = parser.get_script(buffer_).get_last_formula()
         const = expr.args()[0]
         self.assertEqual(const.bv_width(), 8, const.bv_width())
+
+    def test_equality_typing(self):
+        x = Symbol('x', BOOL)
+        y = Symbol('y', BOOL)
+        with self.assertRaises(PysmtTypeError):
+            Equals(x, y)
+        with self.assertRaises(PysmtTypeError):
+            LE(x, y)
 
 
 if __name__ == "__main__":

--- a/pysmt/test/test_typechecker.py
+++ b/pysmt/test/test_typechecker.py
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from pysmt.typing import REAL, BOOL, INT, FunctionType
+from pysmt.typing import REAL, BOOL, INT, FunctionType, BV8
 from pysmt.type_checker import (assert_no_boolean_in_args,
                                 assert_boolean_args,
                                 assert_same_type_args,
@@ -58,6 +58,30 @@ class TestSimpleTypeChecker(TestCase):
         tc = get_env().stc
         res = tc.walk(h)
         self.assertEqual(res, BOOL)
+
+
+    def test_arith_relations(self):
+        self.assertEqual(self.tc.walk(LE(self.p, self.q)), BOOL)
+        self.assertEqual(self.tc.walk(LT(self.p, self.q)), BOOL)
+        self.assertEqual(self.tc.walk(LE(self.r, self.s)), BOOL)
+        self.assertEqual(self.tc.walk(LT(self.r, self.s)), BOOL)
+
+        with self.assertRaises(PysmtTypeError):
+            LE(self.p, self.r)
+        with self.assertRaises(PysmtTypeError):
+            LT(self.p, self.r)
+        with self.assertRaises(PysmtTypeError):
+            LE(self.x, self.y)
+        with self.assertRaises(PysmtTypeError):
+            LT(self.x, self.y)
+
+        bv_a = Symbol("BV_A", BV8)
+        bv_b = Symbol("BV_B", BV8)
+
+        with self.assertRaises(PysmtTypeError):
+            LE(bv_a, bv_b)
+        with self.assertRaises(PysmtTypeError):
+            LT(bv_a, bv_b)
 
 
     def test_functions(self):

--- a/pysmt/type_checker.py
+++ b/pysmt/type_checker.py
@@ -155,12 +155,23 @@ class SimpleTypeChecker(walkers.DagWalker):
             return None
         return BVType(target_width)
 
-    @walkers.handles(op.EQUALS, op.LE, op.LT)
-    def walk_math_relation(self, formula, args, **kwargs):
+    def walk_equals(self, formula, args, **kwargs):
         #pylint: disable=unused-argument
-        if args[0].is_bv_type():
+        if args[0].is_bool_type():
+            raise PysmtTypeError("The formula '%s' is not well-formed."
+                                 "Equality operator is not supported for Boolean"
+                                 " terms. Use Iff instead." \
+                                 % str(formula))
+        elif args[0].is_bv_type():
             return self.walk_bv_to_bool(formula, args)
         return self.walk_type_to_type(formula, args, args[0], BOOL)
+
+    @walkers.handles(op.LE, op.LT)
+    def walk_math_relation(self, formula, args, **kwargs):
+        #pylint: disable=unused-argument
+        if args[0].is_real_type():
+            return self.walk_type_to_type(formula, args, REAL, BOOL)
+        return self.walk_type_to_type(formula, args, INT, BOOL)
 
     def walk_ite(self, formula, args, **kwargs):
         assert formula is not None


### PR DESCRIPTION
`LT` and `LE` are only allowed over (INT, INT) and (REAL, REAL), while equals is allowed for ('a, 'a) except if `a is BOOL.

The previous behavior allowed `Equals(BOOL, BOOL)` and also `LT(BV[8], BV[8])`