### PR TITLE
Fix/doublequote escaping

### DIFF
--- a/pysmt/printers.py
+++ b/pysmt/printers.py
@@ -176,7 +176,7 @@ class HRPrinter(TreeWalker):
     def walk_str_constant(self, formula):
         assert (type(formula.constant_value()) == str ), \
             "The type was " + str(type(formula.constant_value()))
-        self.write('"%s"' % formula.constant_value())
+        self.write('"%s"' % formula.constant_value().replace('"', '""'))
 
     def walk_str_length(self,formula):
         self.write("str.len(" )

--- a/pysmt/smtlib/parser/parser.py
+++ b/pysmt/smtlib/parser/parser.py
@@ -637,7 +637,10 @@ class SmtLibParser(object):
                 res = mgr.BV(value, width)
             elif token[0] == '"':
                 # String constant
-                res = mgr.String(token.replace('"',''))
+                val = token[1:-1]
+                val = val.replace('""', '"')
+                val = val.decode('string-escape')
+                res = mgr.String(val)
             else:
                 # it could be a number or a string
                 try:

--- a/pysmt/smtlib/parser/parser.py
+++ b/pysmt/smtlib/parser/parser.py
@@ -239,23 +239,22 @@ class Tokenizer(object):
 
                     elif c == "\"":
                         # String literals
-                        s = []
-                        c = next(reader)
-                        while c:
+                        s = c
+                        num_quotes = 0
+                        while True:
+                            c = next(reader)
+                            if not c:
+                                raise PysmtSyntaxError("Expected '\"'",
+                                                       reader.pos_info)
+
+                            if c != "\"" and num_quotes % 2 != 0:
+                                break
+
+                            s += c
                             if c == "\"":
-                                c = next(reader)
-                                if c == "\"":
-                                    s.append(c)
-                                    c = next(reader)
-                                else:
-                                    break
-                            else:
-                                s.append(c)
-                                c = next(reader)
-                        if not c:
-                            raise PysmtSyntaxError("Expected '|'",
-                                                   reader.pos_info)
-                        yield '"%s"' % ("".join(s)) # string literals maintain their quoting
+                                num_quotes += 1
+
+                        yield s
 
                     else:
                         yield c

--- a/pysmt/smtlib/parser/parser.py
+++ b/pysmt/smtlib/parser/parser.py
@@ -638,7 +638,6 @@ class SmtLibParser(object):
                 # String constant
                 val = token[1:-1]
                 val = val.replace('""', '"')
-                val = val.decode('string-escape')
                 res = mgr.String(val)
             else:
                 # it could be a number or a string

--- a/pysmt/smtlib/printers.py
+++ b/pysmt/smtlib/printers.py
@@ -124,7 +124,7 @@ class SmtPrinter(TreeWalker):
         self.write("#b" + formula.bv_bin_str())
 
     def walk_str_constant(self, formula):
-        self.write('"' + formula.constant_value() + '"')
+        self.write('"' + formula.constant_value().replace('"', '""') + '"')
 
     def walk_forall(self, formula):
         return self._walk_quantifier("forall", formula)
@@ -483,7 +483,7 @@ class SmtDagPrinter(DagWalker):
             return "false"
 
     def walk_str_constant(self, formula, **kwargs):
-        return '"' + formula.constant_value() + '"'
+        return '"' + formula.constant_value().replace('"', '""') + '"'
 
     def walk_forall(self, formula, args, **kwargs):
         return self._walk_quantifier("forall", formula, args)

--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -86,7 +86,7 @@ class SmtLibCommand(namedtuple('SmtLibCommand', ['name', 'args'])):
 
         elif self.name in [smtcmd.CHECK_SAT, smtcmd.EXIT,
                            smtcmd.RESET_ASSERTIONS, smtcmd.GET_UNSAT_CORE,
-                           smtcmd.GET_ASSIGNMENT]:
+                           smtcmd.GET_ASSIGNMENT, smtcmd.GET_MODEL]:
             outstream.write("(%s)" % self.name)
 
         elif self.name == smtcmd.SET_LOGIC:

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -23,7 +23,7 @@ import pysmt.smtlib.commands as smtcmd
 from pysmt.shortcuts import (Real, Plus, Symbol, Equals, And, Bool, Or, Not,
                              Div, LT, LE, Int, ToReal, Iff, Exists, Times, FALSE,
                              BVLShr, BVLShl, BVAShr, BV, BVAdd, BVULT, BVMul,
-                             Select, Array, Ite)
+                             Select, Array, Ite, String)
 from pysmt.shortcuts import Solver, get_env, qelim, get_model, TRUE, ExactlyOne
 from pysmt.typing import REAL, BOOL, INT, BVType, FunctionType, ArrayType
 from pysmt.test import (TestCase, skipIfSolverNotAvailable, skipIfNoSolverForLogic,
@@ -477,6 +477,38 @@ class TestRegressions(TestCase):
             Equals(x, y)
         with self.assertRaises(PysmtTypeError):
             LE(x, y)
+
+    def test_string_constant_quote_escaping_hr_printer(self):
+        x = String('a"b')
+        y = String('""')
+        z = String('"')
+        self.assertEqual('"a""b"', str(x))
+        self.assertEqual('""""""', str(y))
+        self.assertEqual('""""', str(z))
+
+    def test_string_constant_quote_escaping_smtlib_printer(self):
+        x = String('a"b')
+        y = String('""')
+        z = String('"')
+        self.assertEqual('"a""b"', x.to_smtlib())
+        self.assertEqual('""""""', y.to_smtlib())
+        self.assertEqual('""""', z.to_smtlib())
+
+    def test_string_constant_quote_escaping_parsing(self):
+        script = """
+        (declare-const x String)
+        (assert (= x "a""b"))
+        (assert (= x "\"\""))
+        (assert (= x "\"\"\"\""))
+        """
+
+        p = SmtLibParser()
+        buffer = cStringIO(script)
+        s = p.get_script(buffer)
+        self.assertEqual('a"b', s.commands[1].args[0].arg(1).constant_value())
+        self.assertEqual('"', s.commands[2].args[0].arg(1).constant_value())
+        self.assertEqual('""', s.commands[3].args[0].arg(1).constant_value())
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As discussed in PR #478 this is the fix for the double-quote parsing and printing of smt string constants.
Regression tests have been added that should currently fail on master but succeed using these changes.

While writing the testcases I noticed other places that had the issue, hopefully this should fix all of them!