### PR TITLE
Fix pysmt CLI for Python3 (closes #492)

### DIFF
--- a/pysmt/cmd/shell.py
+++ b/pysmt/cmd/shell.py
@@ -59,7 +59,7 @@ class PysmtShell(object):
 
     def __init__(self, argv):
         self.env = get_env()
-        self.solvers = self.env.factory.all_solvers().keys()
+        self.solvers = list(self.env.factory.all_solvers().keys())
         self.parser = self.get_parser()
         self.args = self.parser.parse_args(argv)
 


### PR DESCRIPTION
To append `dict_keys` to `list`, need to explicitly convert them.