### PR TITLE
Simplify shared lib usage

### DIFF
--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -185,12 +185,12 @@ def main():
         mirror_url += "/{archive_name}"
 
     # This should work on any platform
-    install_dir= os.path.expanduser(options.install_path)
+    install_dir = os.path.expanduser(options.install_path)
     if not os.path.exists(install_dir):
         os.mkdir(install_dir)
 
     # This should work on any platform
-    bindings_dir= os.path.expanduser(options.bindings_path)
+    bindings_dir = os.path.expanduser(options.bindings_path)
     if not os.path.exists(bindings_dir):
         os.mkdir(bindings_dir)
 
@@ -225,13 +225,10 @@ def main():
         if platform.system().lower() == "windows":
             if options.powershell:
                 print('$env:PythonPath += ";%s"' % bindings_dir)
-                print('$env:Path += ";%s"' % bindings_dir)
             else:
                 print("set PYTHONPATH=" + bindings_dir + ";%PYTHONPATH%")
-                print("set PATH=" + bindings_dir + ";%PATH%")
         else:
             print("export PYTHONPATH=\"" + bindings_dir + ":${PYTHONPATH}\"")
-            print("export LD_LIBRARY_PATH=\"" + bindings_dir + ":${LD_LIBRARY_PATH}\"")
 
     else:
         if len(solvers_to_install) == 0:

--- a/pysmt/cmd/installers/msat.py
+++ b/pysmt/cmd/installers/msat.py
@@ -73,7 +73,10 @@ class MSatInstaller(SolverInstaller):
             SolverInstaller.do_download(setup_py_win_url, setup_py)
 
         # Run setup.py to compile the bindings
-        SolverInstaller.run_python("./setup.py build", self.python_bindings_dir)
+        # NB: -R adds --rpath=$ORIGIN to link step, which makes shared library object
+        # searched for in the extension's directory (no need for LD_LIBRARY_PATH)
+        # (note: this is default behavior for DLL discovery on Windows)
+        SolverInstaller.run_python("./setup.py build_ext -R $ORIGIN", self.python_bindings_dir)
 
 
     def move(self):

--- a/pysmt/cmd/installers/msat.py
+++ b/pysmt/cmd/installers/msat.py
@@ -73,10 +73,13 @@ class MSatInstaller(SolverInstaller):
             SolverInstaller.do_download(setup_py_win_url, setup_py)
 
         # Run setup.py to compile the bindings
-        # NB: -R adds --rpath=$ORIGIN to link step, which makes shared library object
-        # searched for in the extension's directory (no need for LD_LIBRARY_PATH)
-        # (note: this is default behavior for DLL discovery on Windows)
-        SolverInstaller.run_python("./setup.py build_ext -R $ORIGIN", self.python_bindings_dir)
+        if self.os_name == "windows":
+            SolverInstaller.run_python("./setup.py build_ext", self.python_bindings_dir)
+        else:
+            # NB: -R adds --rpath=$ORIGIN to link step, which makes shared library object
+            # searched for in the extension's directory (no need for LD_LIBRARY_PATH)
+            # (note: this is the default behavior for DLL discovery on Windows)
+            SolverInstaller.run_python("./setup.py build_ext -R $ORIGIN", self.python_bindings_dir)
 
 
     def move(self):

--- a/pysmt/cmd/installers/z3.py
+++ b/pysmt/cmd/installers/z3.py
@@ -56,18 +56,27 @@ class Z3Installer(SolverInstaller):
 
     def move(self):
         bpath = os.path.join(self.extract_path, "bin")
-        files = [os.path.join(bpath, "python/z3")]
+        libfiles = []
         if self.os_name == "linux":
-            files += glob.glob(bpath + '/*.so')
+            libfiles += glob.glob(bpath + '/*.so')
         elif self.os_name == "darwin":
-            files += glob.glob(bpath + '/*.a')
-            files += glob.glob(bpath + '/*.dylib')
+            libfiles += glob.glob(bpath + '/*.a')
+            libfiles += glob.glob(bpath + '/*.dylib')
         elif self.os_name == "windows":
-            files += glob.glob(bpath + '/*.dll')
-            files += glob.glob(bpath + '/*.lib')
+            libfiles += glob.glob(bpath + '/*.dll')
+            libfiles += glob.glob(bpath + '/*.lib')
 
-        for f in files:
-            SolverInstaller.mv(f, self.bindings_dir)
+        SolverInstaller.mv(os.path.join(bpath, "python/z3"), self.bindings_dir)
+
+        # z3 will check for shared libraries in z3/lib, before builtins.Z3_LIB_DIRS,
+        # and Z3_LIBRARY_PATH env var lookup (or OS-level LD_LIBRARY_PATH)
+        # (see z3/z3core.py)
+        libpath = os.path.join(self.bindings_dir, "z3/lib/")
+        if not os.path.exists(libpath):
+            os.mkdir(libpath)
+
+        for f in libfiles:
+            SolverInstaller.mv(f, libpath)
 
     def get_installed_version(self):
         return self.get_installed_version_script(self.bindings_dir, "z3")


### PR DESCRIPTION
Modify `z3` and `msat` installers in order to make their shared binary objects (libraries/dlls) auto-discoverable, without the need for setting `LD_LIBRARY_PATH`/`PATH`.

Tested on Linux, but not on Windows.