### PR TITLE
[msat-installer] Don't use $ORIGIN on darwin

### DIFF
--- a/pysmt/cmd/installers/msat.py
+++ b/pysmt/cmd/installers/msat.py
@@ -73,7 +73,7 @@ class MSatInstaller(SolverInstaller):
             SolverInstaller.do_download(setup_py_win_url, setup_py)
 
         # Run setup.py to compile the bindings
-        if self.os_name == "windows":
+        if self.os_name in {"windows", "darwin"}:
             SolverInstaller.run_python("./setup.py build_ext", self.python_bindings_dir)
         else:
             # NB: -R adds --rpath=$ORIGIN to link step, which makes shared library object


### PR DESCRIPTION
Before this commit, I get the following message:
```
$ pysmt-install --msat
...
ld: warning: directory not found for option '-L$ORIGIN'
```

From my brief perusing of the internet, it seems that `$ORIGIN` is a linux specific construct.