### PR TITLE
Fix StopIteration use in SmtLib parser

### DIFF
--- a/pysmt/smtlib/parser/parser.py
+++ b/pysmt/smtlib/parser/parser.py
@@ -1055,8 +1055,7 @@ class SmtLibParser(object):
         try:
             p = tokens.consume()
         except StopIteration:
-            # No more data
-            return
+            raise #Re-raise execption for higher-level management, see get_command()
         if p != "(":
             raise PysmtSyntaxError("Unexpected token '%s' in %s command. " \
                                    "Expected '('" %

--- a/pysmt/test/smtlib/test_parser_examples.py
+++ b/pysmt/test/smtlib/test_parser_examples.py
@@ -27,7 +27,7 @@ from pysmt.smtlib.parser import SmtLibParser
 from pysmt.smtlib.script import smtlibscript_from_formula
 from pysmt.shortcuts import Iff
 from pysmt.shortcuts import read_smtlib, write_smtlib
-
+from pysmt.exceptions import PysmtSyntaxError
 
 class TestSMTParseExamples(TestCase):
 
@@ -146,6 +146,16 @@ class TestSMTParseExamples(TestCase):
             self.assertEqual(f_out.simplify(), f_in.simplify())
         # Clean-up
         os.remove(tmp_fname)
+
+    def test_incomplete_stream(self):
+        txt = """
+        (declare-fun A () Bool)
+        (declare-fun B () Bool)
+        (assert (and A
+        """
+        parser = SmtLibParser()
+        with self.assertRaises(PysmtSyntaxError):
+            parser.get_script(cStringIO(txt))
 
 if __name__ == "__main__":
     main()

--- a/pysmt/test/smtlib/test_smtlibscript.py
+++ b/pysmt/test/smtlib/test_smtlibscript.py
@@ -148,18 +148,24 @@ class TestSmtLibScript(TestCase):
             f = get_formula_strict(stream_in)
 
 
-    #n is defined once as an Int and once as a Real
     def test_define_funs_same_args(self):
+        # n is defined once as an Int and once as a Real
         smtlib_script = "\n".join(['(define-fun f ((n Int)) Int n)', '(define-fun f ((n Real)) Real n)'])
         stream = cStringIO(smtlib_script)
         parser = SmtLibParser()
-        script = parser.get_script(stream)
+        _ = parser.get_script(stream)
+        # No exceptions are thrown
+        self.assertTrue(True)
+
 
     def test_define_funs_arg_and_fun(self):
         smtlib_script = "\n".join(['(define-fun f ((n Int)) Int n)', '(declare-fun n () Real)'])
         stream = cStringIO(smtlib_script)
         parser = SmtLibParser()
-        script = parser.get_script(stream)
+        _ = parser.get_script(stream)
+        # No exceptions are thrown
+        self.assertTrue(True)
+
 
     def test_evaluate_command(self):
         class SmtLibIgnore(SmtLibIgnoreMixin):


### PR DESCRIPTION
This PR addresses #520 

Tests are passing, but we need to double-chekc the use of `consume()` vs `consume_enforce()` in all the cases.