### PR TITLE
SMTLIB: Supporting custom sorts in generic solvers

### DIFF
--- a/examples/generic_smtlib.py
+++ b/examples/generic_smtlib.py
@@ -21,7 +21,7 @@
 # See examples for Z3, Mathsat and Yices in pysmt/test/smtlib/bin/*.template
 #
 from pysmt.logics import QF_UFLRA, QF_UFIDL, QF_LRA, QF_IDL, QF_LIA
-from pysmt.shortcuts import get_env, GT, Solver, Symbol, Type, Equals
+from pysmt.shortcuts import get_env, GT, Solver, Symbol, Type, Equals, FunctionType
 from pysmt.typing import REAL, INT
 from pysmt.exceptions import NoSolverAvailableError
 
@@ -38,8 +38,9 @@ r, s = Symbol("r", REAL), Symbol("s", REAL)
 p, q = Symbol("p", INT), Symbol("q", INT)
 A = Type("A", 0)
 a, b = Symbol("a", A), Symbol("b", A)
+fun = Symbol("g", FunctionType(A, [INT, A]))
 
-f_a = Equals(a, b)
+f_a = Equals(a, fun(p, b))
 f_lra = GT(r, s)
 f_idl = GT(p, q)
 

--- a/examples/generic_smtlib.py
+++ b/examples/generic_smtlib.py
@@ -21,7 +21,7 @@
 # See examples for Z3, Mathsat and Yices in pysmt/test/smtlib/bin/*.template
 #
 from pysmt.logics import QF_UFLRA, QF_UFIDL, QF_LRA, QF_IDL, QF_LIA
-from pysmt.shortcuts import get_env, GT, Solver, Symbol, Type, Equals, FunctionType
+from pysmt.shortcuts import get_env, GT, Solver, Symbol
 from pysmt.typing import REAL, INT
 from pysmt.exceptions import NoSolverAvailableError
 
@@ -36,18 +36,9 @@ env.factory.add_generic_solver(name, path, logics)
 
 r, s = Symbol("r", REAL), Symbol("s", REAL)
 p, q = Symbol("p", INT), Symbol("q", INT)
-A = Type("A", 0)
-a, b = Symbol("a", A), Symbol("b", A)
-fun = Symbol("g", FunctionType(A, [INT, A]))
 
-f_a = Equals(a, fun(p, b))
 f_lra = GT(r, s)
 f_idl = GT(p, q)
-
-with Solver(name=name, logic=QF_UFLRA) as s:
-    s.add_assertion(f_a)
-    res = s.solve()
-    assert res, "Was expecting '%s' to be SAT" %f_a
 
 # PySMT takes care of recognizing that QF_LRA can be solved by a QF_UFLRA solver.
 with Solver(name=name, logic=QF_LRA) as s:

--- a/examples/generic_smtlib.py
+++ b/examples/generic_smtlib.py
@@ -21,7 +21,7 @@
 # See examples for Z3, Mathsat and Yices in pysmt/test/smtlib/bin/*.template
 #
 from pysmt.logics import QF_UFLRA, QF_UFIDL, QF_LRA, QF_IDL, QF_LIA
-from pysmt.shortcuts import get_env, GT, Solver, Symbol
+from pysmt.shortcuts import get_env, GT, Solver, Symbol, Type, Equals
 from pysmt.typing import REAL, INT
 from pysmt.exceptions import NoSolverAvailableError
 
@@ -36,9 +36,17 @@ env.factory.add_generic_solver(name, path, logics)
 
 r, s = Symbol("r", REAL), Symbol("s", REAL)
 p, q = Symbol("p", INT), Symbol("q", INT)
+A = Type("A", 0)
+a, b = Symbol("a", A), Symbol("b", A)
 
+f_a = Equals(a, b)
 f_lra = GT(r, s)
 f_idl = GT(p, q)
+
+with Solver(name=name, logic=QF_UFLRA) as s:
+    s.add_assertion(f_a)
+    res = s.solve()
+    assert res, "Was expecting '%s' to be SAT" %f_a
 
 # PySMT takes care of recognizing that QF_LRA can be solved by a QF_UFLRA solver.
 with Solver(name=name, logic=QF_LRA) as s:

--- a/pysmt/smtlib/solver.py
+++ b/pysmt/smtlib/solver.py
@@ -25,7 +25,7 @@ from pysmt.smtlib.script import SmtLibCommand
 from pysmt.solvers.solver import Solver, SolverOptions
 from pysmt.exceptions import (SolverReturnedUnknownResultError,
                               UnknownSolverAnswerError, PysmtValueError)
-
+from pysmt.oracles import TypesOracle
 
 class SmtLibOptions(SolverOptions):
     """Options for the SmtLib Solver.
@@ -78,7 +78,7 @@ class SmtLibSolver(Solver):
                         environment,
                         logic=logic,
                         **options)
-
+        self.to = self.environment.typeso
         if LOGICS is not None: self.LOGICS = LOGICS
         self.args = args
         self.declared_vars = set()
@@ -140,9 +140,6 @@ class SmtLibSolver(Solver):
         self.declared_sorts.add(sort)
 
     def _declare_variable(self, symbol):
-        sort = symbol.symbol_type()
-        if sort not in self.declared_sorts:
-            self._declare_sort(sort)
         cmd = SmtLibCommand(smtcmd.DECLARE_FUN, [symbol])
         self._send_silent_command(cmd)
         self.declared_vars.add(symbol)
@@ -173,6 +170,10 @@ class SmtLibSolver(Solver):
         # This is needed because Z3 (and possibly other solvers) incorrectly
         # recognize N * M * x as a non-linear term
         formula = formula.simplify()
+        sorts = self.to.get_types(formula, custom_only=True)
+        for s in sorts:
+            if s not in self.declared_sorts:
+                self._declare_sort(s)
         deps = formula.get_free_variables()
         for d in deps:
             if d not in self.declared_vars:

--- a/pysmt/smtlib/solver.py
+++ b/pysmt/smtlib/solver.py
@@ -82,6 +82,7 @@ class SmtLibSolver(Solver):
         if LOGICS is not None: self.LOGICS = LOGICS
         self.args = args
         self.declared_vars = set()
+        self.declared_sorts = set()
         self.solver = Popen(args, stdout=PIPE, stderr=PIPE, stdin=PIPE,
                             bufsize=-1)
         # Give time to the process to start-up
@@ -132,8 +133,16 @@ class SmtLibSolver(Solver):
         lst = self.parser.get_assignment_list(self.solver_stdout)
         self._debug("Read: %s", lst)
         return lst
+    
+    def _declare_sort(self, sort):
+        cmd = SmtLibCommand(smtcmd.DECLARE_SORT, [sort])
+        self._send_silent_command(cmd)
+        self.declared_sorts.add(sort)
 
     def _declare_variable(self, symbol):
+        sort = symbol.symbol_type()
+        if sort not in self.declared_sorts:
+            self._declare_sort(sort)
         cmd = SmtLibCommand(smtcmd.DECLARE_FUN, [symbol])
         self._send_silent_command(cmd)
         self.declared_vars.add(symbol)

--- a/pysmt/test/smtlib/test_generic_wrapper.py
+++ b/pysmt/test/smtlib/test_generic_wrapper.py
@@ -20,7 +20,7 @@ from unittest import skipIf
 
 from pysmt.test import TestCase, main
 from pysmt.shortcuts import get_env, Solver, is_valid, is_sat
-from pysmt.shortcuts import LE, LT, Real, GT, Int, Symbol, And, Not
+from pysmt.shortcuts import LE, LT, Real, GT, Int, Symbol, And, Not, Type, FunctionType, Equals, Function
 from pysmt.typing import BOOL, REAL, INT
 from pysmt.logics import QF_UFLIRA, QF_UFLRA, QF_UFLIA, QF_BOOL, QF_UFBV
 from pysmt.exceptions import (SolverRedefinitionError, NoSolverAvailableError,
@@ -109,6 +109,21 @@ class TestGenericWrapper(TestCase):
 
             self.assertFalse(model.get_value(b).is_true())
             self.assertTrue(model.get_value(a).is_true())
+
+    
+    @skipIf(len(ALL_WRAPPERS) == 0, "No wrapper available")
+    def test_custom_types(self):
+        A = Type("A", 0)
+        a, b = Symbol("a", A), Symbol("b", A)
+        p = Symbol("p", INT)
+        fun = Symbol("g", FunctionType(A, [INT, A]))
+        app = Function(fun, [p, b])
+        f_a = Equals(a, app)
+        for n in self.all_solvers:
+            with Solver(name=n, logic=QF_UFLIA) as s:
+                s.add_assertion(f_a)
+                res = s.solve()
+                self.assertTrue(res)
 
     @skipIf(len(ALL_WRAPPERS) == 0, "No wrapper available")
     def test_examples(self):


### PR DESCRIPTION
The current generic smtlib solver seems to not support variables with custom types (a.k.g. sorts).
This PR fixes the issue by sending a `(declare-sort)` command to the generic solver, whenever declaring a variable whose sort was not previously declared.
The `generic_smtlib.py` was edited in order to accommodate this change.