### PR TITLE
Z3: Fixed deallocation sequence in Solver

### DIFF
--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -291,6 +291,24 @@ BOOLREF_SET = op.BOOL_OPERATORS | op.RELATIONS
 ARITHREF_SET = op.IRA_OPERATORS
 BITVECREF_SET = op.BV_OPERATORS
 
+z3_inc_ref = z3.Z3_inc_ref
+z3_dec_ref = z3.Z3_dec_ref
+_refs = {}
+def _my_inc_ref(ctx, term):
+    print("Incref ", term)
+    sterm=str(term)
+    if not sterm in _refs: _refs[sterm]=1
+    else: _refs[sterm]+=1
+    z3_inc_ref(ctx, term)
+def _my_dec_ref(ctx, term):
+    sterm=str(term)
+    _refs[sterm]-=1
+    print("Decref ", term, _refs[sterm])
+    z3_dec_ref(ctx, term)
+
+z3.Z3_inc_ref = _my_inc_ref
+z3.Z3_dec_ref = _my_dec_ref
+import random
 
 class Z3Converter(Converter, DagWalker):
 
@@ -910,8 +928,11 @@ class Z3Converter(Converter, DagWalker):
 
     def __del__(self):
         # Cleaning-up Z3Converter requires dec-ref'ing the terms in the cache
-        for t in self.memoization.values():
+        for k in self.memoization:
+            print(k)
+            t = self.memoization[k]
             z3.Z3_dec_ref(self.ctx.ref(), t)
+        print("DEL")
 
 # EOC Z3Converter
 


### PR DESCRIPTION
The Z3Solver was deleting the reference to the z3.Solver without deleting the reference to the Converter. Since the converter internally used the ctx from the solver, this might cause the issues from #522 and #465. 