### PR TITLE
CI: Python 3.7 on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,45 +6,71 @@ env:
 
 matrix:
   include:
-  # Linux - Python 3.6
+  # Linux - Python 3.7
   - os: linux
-    python: 3.6
+    sudo: required
+    dist: xenial
+    python: 3.7
     env: PYSMT_SOLVER="all"       PYSMT_GMPY="TRUE"
   - os: linux
-    python: 3.6
+    python: 3.7
+    sudo: required
+    dist: xenial
     env: PYSMT_SOLVER="all"       PYSMT_GMPY="FALSE"
   - os: linux
-    python: 3.6
+    python: 3.7
+    sudo: required
+    dist: xenial
     env: PYSMT_SOLVER="None"      PYSMT_GMPY="FALSE"   PYSMT_CYTHON="TRUE"
   - os: linux
-    python: 3.6
+    sudo: required
+    dist: xenial
+    python: 3.7
     env: PYSMT_SOLVER="None"      PYSMT_GMPY="FALSE"   PYSMT_CYTHON="FALSE"
   - os: linux
-    python: 3.6
+    sudo: required
+    dist: xenial
+    python: 3.7
     env: PYSMT_SOLVER="msat"      PYSMT_GMPY="FALSE"
   - os: linux
-    python: 3.6
+    sudo: required
+    dist: xenial
+    python: 3.7
     env: PYSMT_SOLVER="z3"        PYSMT_GMPY="FALSE"
   - os: linux
-    python: 3.6
+    sudo: required
+    dist: xenial
+    python: 3.7
     env: PYSMT_SOLVER="cvc4"      PYSMT_GMPY="FALSE"
   - os: linux
-    python: 3.6
+    sudo: required
+    dist: xenial
+    python: 3.7
     env: PYSMT_SOLVER="yices"     PYSMT_GMPY="FALSE"
   - os: linux
-    python: 3.6
+    sudo: required
+    dist: xenial
+    python: 3.7
     env: PYSMT_SOLVER="bdd"       PYSMT_GMPY="FALSE"
   - os: linux
-    python: 3.6
+    sudo: required
+    dist: xenial
+    python: 3.7
     env: PYSMT_SOLVER="picosat"   PYSMT_GMPY="FALSE"
   - os: linux
-    python: 3.6
+    sudo: required
+    dist: xenial
+    python: 3.7
     env: PYSMT_SOLVER="btor"      PYSMT_GMPY="FALSE"
   - os: linux
-    python: 3.6
+    sudo: required
+    dist: xenial
+    python: 3.7
     env: PYSMT_SOLVER="msat_wrap" PYSMT_GMPY="FALSE"
   - os: linux
-    python: 3.6
+    sudo: required
+    dist: xenial
+    python: 3.7
     env: PYSMT_SOLVER="z3_wrap"   PYSMT_GMPY="FALSE"
 
   # Linux - Python 2.7

--- a/ci/travis_before_install.sh
+++ b/ci/travis_before_install.sh
@@ -61,3 +61,10 @@ fi
 
 # Check that the correct version of Python is running.
 python ${DIR}/check_python_version.py "${TRAVIS_PYTHON_VERSION}"
+
+# Install latest version of SWIG
+git clone https://github.com/swig/swig.git
+cd swig
+git checkout rel-3.0.10
+./autogen.sh && ./configure && make
+sudo make install

--- a/ci/travis_install.sh
+++ b/ci/travis_install.sh
@@ -52,8 +52,8 @@ fi
 
 # Adding Python 3.7 library path to GCC search
 if [ "${TRAVIS_PYTHON_VERSION}" == "3.7" ]; then
-    export LIBRARY_PATH="/opt/python/3.7.0/lib:${LIBRARY_PATH}"
-    export CPATH="/opt/python/3.7.0/include/python3.7m:${CPATH}"
+    export LIBRARY_PATH="/opt/python/3.7.1/lib:${LIBRARY_PATH}"
+    export CPATH="/opt/python/3.7.1/include/python3.7m:${CPATH}"
 fi
 
 

--- a/ci/travis_install.sh
+++ b/ci/travis_install.sh
@@ -50,10 +50,10 @@ then
     $PIP_INSTALL gmpy2;
 fi
 
-# Adding Python 3.6 library path to GCC search
-if [ "${TRAVIS_PYTHON_VERSION}" == "3.6" ]; then
-    export LIBRARY_PATH="/opt/python/3.6.3/lib:${LIBRARY_PATH}"
-    export CPATH="/opt/python/3.6.3/include/python3.6m:${CPATH}"
+# Adding Python 3.7 library path to GCC search
+if [ "${TRAVIS_PYTHON_VERSION}" == "3.7" ]; then
+    export LIBRARY_PATH="/opt/python/3.7.0/lib:${LIBRARY_PATH}"
+    export CPATH="/opt/python/3.7.0/include/python3.7m:${CPATH}"
 fi
 
 


### PR DESCRIPTION
Upgrade CI to use python 3.7 . 
The CI environment uses an older version of SWIG (2.X), but CVC4 requires SWIG 3. We install SWIG 3.0.10 from source.

See https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905