### PR TITLE
Z3: Check context presence on del

### DIFF
--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -911,8 +911,12 @@ class Z3Converter(Converter, DagWalker):
 
     def __del__(self):
         # Cleaning-up Z3Converter requires dec-ref'ing the terms in the cache
-        for t in self.memoization.values():
-            z3.Z3_dec_ref(self.ctx.ref(), t)
+        if self.ctx.ref():
+            # Check that there is still a context object
+            # This might not be the case if we are using the global context
+            # and the interpreter is shutting down
+            for t in self.memoization.values():
+                z3.Z3_dec_ref(self.ctx.ref(), t)
 
 # EOC Z3Converter
 


### PR DESCRIPTION
Address #522 by explicitly checking if the context is still available on ``Z3Converter.__del__``