### PR TITLE
Trivial improvements for bit vector simplification

### DIFF
--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -563,9 +563,23 @@ class Simplifier(pysmt.walkers.DagWalker):
         return self.manager.BVULT(args[0], args[1])
 
     def walk_bv_ule(self, formula, args, **kwargs):
-        if args[0].is_bv_constant() and args[1].is_bv_constant():
-            res = args[0].bv_unsigned_value() <= args[1].bv_unsigned_value()
-            return self.manager.Bool(res)
+        simplified = None
+
+        if args[0] == args[1]:
+            # x u<= x -> TRUE
+            simplified = self.manager.TRUE()
+        elif args[0].is_bv_constant():
+            lhs = args[0].bv_unsigned_value()
+            if lhs == 0:
+                # 0 u<= args[1] -> TRUE
+                simplified = self.manager.TRUE()
+            elif args[1].is_bv_constant():
+                res = lhs <= args[1].bv_unsigned_value()
+                simplified = self.manager.Bool(res)
+
+        if simplified is not None:
+            return simplified
+
         return self.manager.BVULE(args[0], args[1])
 
     def walk_bv_extract(self, formula, args, **kwargs):

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -774,6 +774,9 @@ class Simplifier(pysmt.walkers.DagWalker):
         if args[0].is_bv_constant() and args[1].is_bv_constant():
             res = args[0].bv_signed_value() < args[1].bv_signed_value()
             return self.manager.Bool(res)
+        if args[0] == args[1]:
+            # x < x -> False
+            return self.manager.Bool(False)
         return self.manager.BVSLT(args[0], args[1])
 
     def walk_bv_sle(self, formula, args, **kwargs):

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -543,9 +543,23 @@ class Simplifier(pysmt.walkers.DagWalker):
         return self.manager.BVURem(args[0], args[1])
 
     def walk_bv_ult(self, formula, args, **kwargs):
-        if args[0].is_bv_constant() and args[1].is_bv_constant():
-            res = args[0].bv_unsigned_value() < args[1].bv_unsigned_value()
-            return self.manager.Bool(res)
+        simplified = None
+
+        if args[0] == args[1]:
+            # x u< x -> FALSE
+            simplified = self.manager.FALSE()
+        elif args[1].is_bv_constant():
+            rhs = args[1].bv_unsigned_value()
+            if rhs == 0:
+                # args[0] u< 0 -> FALSE
+                simplified = self.manager.FALSE()
+            elif args[0].is_bv_constant():
+                res = args[0].bv_unsigned_value() < rhs
+                simplified = self.manager.Bool(res)
+
+        if simplified is not None:
+            return simplified
+
         return self.manager.BVULT(args[0], args[1])
 
     def walk_bv_ule(self, formula, args, **kwargs):

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -695,10 +695,30 @@ class Simplifier(pysmt.walkers.DagWalker):
         return self.manager.BVConcat(args[0], args[1])
 
     def walk_bv_lshl(self, formula, args, **kwargs):
-        if args[0].is_bv_constant() and args[1].is_bv_constant():
-            res = args[0].bv_unsigned_value() << args[1].bv_unsigned_value()
-            w = args[0].bv_width()
-            return self.manager.BV(res % (2 ** w), w)
+        simplified = None
+
+        if args[1].is_bv_constant():
+            rhs = args[1].bv_unsigned_value()
+
+            if rhs == 0:
+                # x << 0 -> x
+                simplified = args[0]
+            else:
+                width = args[0].bv_width()
+
+                if rhs >= width:
+                    # x_n << m -> 0, where m >= n
+                    simplified = self.manager.BVZero(width)
+                elif args[0].is_bv_constant():
+                    res = args[0].bv_unsigned_value() << rhs
+                    simplified = self.manager.BV(res % (2 ** width), width)
+        elif args[0].is_bv_constant() and args[0].bv_unsigned_value() == 0:
+            # 0 << x -> 0
+            simplified = args[0]
+
+        if simplified is not None:
+            return simplified
+
         return self.manager.BVLShl(args[0], args[1])
 
     def walk_bv_lshr(self, formula, args, **kwargs):

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -467,10 +467,33 @@ class Simplifier(pysmt.walkers.DagWalker):
         return self.manager.BVAdd(args[0], args[1])
 
     def walk_bv_mul(self, formula, args, **kwargs):
-        if args[0].is_bv_constant() and args[1].is_bv_constant():
-            res = args[0].constant_value() * args[1].constant_value()
-            res = res % 2**formula.bv_width()
-            return self.manager.BV(res, width=formula.bv_width())
+        simplified = None
+
+        if args[0].is_bv_constant():
+            lhs = args[0].bv_unsigned_value()
+            if lhs == 0:
+                # 0 * args[1] -> 0
+                simplified = self.manager.BVZero(formula.bv_width())
+            elif lhs == 1:
+                # 1 * args[1] -> args[1]
+                simplified = args[1]
+            elif args[1].is_bv_constant():
+                width = formula.bv_width()
+                res = lhs * args[1].bv_unsigned_value()
+                res = res % 2**width
+                simplified = self.manager.BV(res, width=width)
+        elif args[1].is_bv_constant():
+            rhs = args[1].bv_unsigned_value()
+            if rhs == 0:
+                # args[0] * 0 -> 0
+                simplified = self.manager.BVZero(formula.bv_width())
+            elif rhs == 1:
+                # args[0] * 1 -> args[0]
+                simplified = args[0]
+
+        if simplified is not None:
+            return simplified
+
         return self.manager.BVMul(args[0], args[1])
 
     def walk_bv_udiv(self, formula, args, **kwargs):

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -783,6 +783,9 @@ class Simplifier(pysmt.walkers.DagWalker):
         if args[0].is_bv_constant() and args[1].is_bv_constant():
             res = args[0].bv_signed_value() <= args[1].bv_signed_value()
             return self.manager.Bool(res)
+        if args[0] == args[1]:
+            # x <= x -> True
+            return self.manager.Bool(True)
         return self.manager.BVSLE(args[0], args[1])
 
     def walk_bv_comp(self, formula, args, **kwargs):

--- a/pysmt/test/test_bv_simplification.py
+++ b/pysmt/test/test_bv_simplification.py
@@ -20,7 +20,7 @@ from six.moves import xrange
 from pysmt.shortcuts import Solver, BVAnd, BVOr, BVXor, BVConcat, BVULT, BVUGT, \
     BVULE, BVUGE, BVAdd, BVSub, BVMul, BVUDiv, BVURem, BVLShl, BVLShr, BVNot, \
     BVNeg, BVZExt, BVSExt, BVRor, BVRol, BV, BVExtract, BVSLT, BVSLE, BVComp, \
-    BVSDiv, BVSRem, BVAShr, get_env, EqualsOrIff, BVZero, BVOne, Symbol
+    BVSDiv, BVSRem, BVAShr, get_env, EqualsOrIff, BVZero, BVOne, Symbol, Bool
 from pysmt.typing import BVType
 from pysmt.test import TestCase, skipIfSolverNotAvailable, main
 
@@ -234,6 +234,25 @@ class TestBvSimplification(TestCase):
         x, y = (Symbol(name, BVType(32)) for name in "xy")
         f = BVURem(x, y)
         self.check_equal_and_valid(f, BVURem(x, y))
+
+    def test_bv_ult_eq(self):
+        x, y = (Symbol(name, BVType(32)) for name in "xy")
+        f = BVULT(BVMul(x, y), BVMul(x, y))
+        self.check_equal_and_valid(f, Bool(False))
+
+    def test_bv_ult_zero(self):
+        x = Symbol("x", BVType(32))
+        f = BVULT(x, BVZero(32))
+        self.check_equal_and_valid(f, Bool(False))
+
+    def test_bv_ult_symbols(self):
+        x, y = (Symbol(name, BVType(32)) for name in "xy")
+        f = BVULT(x, y)
+        self.check_equal_and_valid(f, BVULT(x, y))
+
+    def test_bv_ult_constants(self):
+        f = BVULT(BVZero(32), BVOne(32))
+        self.check_equal_and_valid(f, Bool(True))
 
 if __name__ == '__main__':
     main()

--- a/pysmt/test/test_bv_simplification.py
+++ b/pysmt/test/test_bv_simplification.py
@@ -302,5 +302,34 @@ class TestBvSimplification(TestCase):
         f = BVAnd(BV(0xdededede, 32), BV(0xacacacac, 32))
         self.check_equal_and_valid(f, BV(0x8c8c8c8c, 32))
 
+    def test_bv_or_zero(self):
+        x = Symbol("x", BVType(32))
+        f = BVOr(x, BVZero(32))
+        self.check_equal_and_valid(f, x)
+
+    def test_bv_zero_or(self):
+        x = Symbol("x", BVType(32))
+        f = BVOr(BVZero(32), x)
+        self.check_equal_and_valid(f, x)
+
+    def test_bv_or_all_ones(self):
+        x = Symbol("x", BVType(32))
+        f = BVOr(x, BV(2**32 - 1, 32))
+        self.check_equal_and_valid(f, BV(2**32 - 1, 32))
+
+    def test_bv_all_ones_or(self):
+        x = Symbol("x", BVType(32))
+        f = BVOr(BV(2**32 - 1, 32), x)
+        self.check_equal_and_valid(f, BV(2**32 - 1, 32))
+
+    def test_bv_or_symbols(self):
+        x, y = (Symbol(name, BVType(32)) for name in "xy")
+        f = BVOr(x, y)
+        self.check_equal_and_valid(f, BVOr(x, y))
+
+    def test_bv_or_constants(self):
+        f = BVOr(BV(0xdededede, 32), BV(0xacacacac, 32))
+        self.check_equal_and_valid(f, BV(0xfefefefe, 32))
+
 if __name__ == '__main__':
     main()

--- a/pysmt/test/test_bv_simplification.py
+++ b/pysmt/test/test_bv_simplification.py
@@ -354,5 +354,29 @@ class TestBvSimplification(TestCase):
         f = BVSub(BV(1, 32), BV(2, 32))
         self.check_equal_and_valid(f, BV(0xffffffff, 32))
 
+    def test_bv_lshl_zero(self):
+        x = Symbol("x", BVType(32))
+        f = BVLShl(x, BVZero(32))
+        self.check_equal_and_valid(f, x)
+
+    def test_bv_zero_lshl(self):
+        x = Symbol("x", BVType(32))
+        f = BVLShl(BVZero(32), x)
+        self.check_equal_and_valid(f, BVZero(32))
+
+    def test_bv_lshl_overflow(self):
+        x = Symbol("x", BVType(32))
+        f = BVLShl(x, BV(33, 32))
+        self.check_equal_and_valid(f, BVZero(32))
+
+    def test_bv_lshl_symbols(self):
+        x, y = (Symbol(name, BVType(32)) for name in "xy")
+        f = BVLShl(x, y)
+        self.check_equal_and_valid(f, BVLShl(x, y))
+
+    def test_bv_lshl_constants(self):
+        f = BVLShl(BV(0xff, 32), BVOne(32))
+        self.check_equal_and_valid(f, BV(0x1fe, 32))
+
 if __name__ == '__main__':
     main()

--- a/pysmt/test/test_bv_simplification.py
+++ b/pysmt/test/test_bv_simplification.py
@@ -163,5 +163,41 @@ class TestBvSimplification(TestCase):
         f = BVMul(BV(2**31, 32), BV(3, 32))
         self.check_equal_and_valid(f, BV(0x80000000, 32))
 
+    def test_bv_udiv_1(self):
+        x = Symbol("x", BVType(32))
+        f = BVUDiv(x, BVOne(32))
+        self.check_equal_and_valid(f, x)
+
+    def test_bv_symbol_udiv_0(self):
+        x = Symbol("x", BVType(32))
+        f = BVUDiv(x, BVZero(32))
+        self.check_equal_and_valid(f, BV(2**32 - 1, 32))
+
+    def test_bv_0_udiv_0(self):
+        f = BVUDiv(BVZero(32), BVZero(32))
+        self.check_equal_and_valid(f, BV(2**32 - 1, 32))
+
+    def test_bv_nonzero_udiv_0(self):
+        f = BVUDiv(BV(10, 32), BVZero(32))
+        self.check_equal_and_valid(f, BV(2**32 - 1, 32))
+
+    def test_bv_0_udiv_nonzero(self):
+        f = BVUDiv(BVZero(32), BV(10, 32))
+        self.check_equal_and_valid(f, BVZero(32))
+
+    def test_bv_0_udiv_symbol(self):
+        x = Symbol("x", BVType(32))
+        f = BVUDiv(BVZero(32), x)
+        self.check_equal_and_valid(f, BVUDiv(BVZero(32), x))
+
+    def test_bv_udiv_constants(self):
+        f = BVUDiv(BV(20, 32), BV(10, 32))
+        self.check_equal_and_valid(f, BV(2, 32))
+
+    def test_bv_udiv_symbols(self):
+        x, y = (Symbol(name, BVType(32)) for name in "xy")
+        f = BVUDiv(x, y)
+        self.check_equal_and_valid(f, BVUDiv(x, y))
+
 if __name__ == '__main__':
     main()

--- a/pysmt/test/test_bv_simplification.py
+++ b/pysmt/test/test_bv_simplification.py
@@ -254,5 +254,24 @@ class TestBvSimplification(TestCase):
         f = BVULT(BVZero(32), BVOne(32))
         self.check_equal_and_valid(f, Bool(True))
 
+    def test_bv_ule_eq(self):
+        x, y = (Symbol(name, BVType(32)) for name in "xy")
+        f = BVULE(BVMul(x, y), BVMul(x, y))
+        self.check_equal_and_valid(f, Bool(True))
+
+    def test_bv_zero_ule(self):
+        x = Symbol("x", BVType(32))
+        f = BVULE(BVZero(32), x)
+        self.check_equal_and_valid(f, Bool(True))
+
+    def test_bv_ule_symbols(self):
+        x, y = (Symbol(name, BVType(32)) for name in "xy")
+        f = BVULE(x, y)
+        self.check_equal_and_valid(f, BVULE(x, y))
+
+    def test_bv_ule_constants(self):
+        f = BVULE(BVZero(32), BVOne(32))
+        self.check_equal_and_valid(f, Bool(True))
+
 if __name__ == '__main__':
     main()

--- a/pysmt/test/test_bv_simplification.py
+++ b/pysmt/test/test_bv_simplification.py
@@ -331,5 +331,28 @@ class TestBvSimplification(TestCase):
         f = BVOr(BV(0xdededede, 32), BV(0xacacacac, 32))
         self.check_equal_and_valid(f, BV(0xfefefefe, 32))
 
+    def test_bv_sub_zero(self):
+        x = Symbol("x", BVType(32))
+        f = BVSub(x, BVZero(32))
+        self.check_equal_and_valid(f, x)
+
+    def test_bv_sub_eq(self):
+        x, y = (Symbol(name, BVType(32)) for name in "xy")
+        f = BVSub(BVMul(x, y), BVMul(x, y))
+        self.check_equal_and_valid(f, BVZero(32))
+
+    def test_bv_sub_symbols(self):
+        x, y = (Symbol(name, BVType(32)) for name in "xy")
+        f = BVSub(x, y)
+        self.check_equal_and_valid(f, BVSub(x, y))
+
+    def test_bv_sub_constants(self):
+        f = BVSub(BV(30, 32), BV(20, 32))
+        self.check_equal_and_valid(f, BV(10, 32))
+
+    def test_bv_sub_underflow(self):
+        f = BVSub(BV(1, 32), BV(2, 32))
+        self.check_equal_and_valid(f, BV(0xffffffff, 32))
+
 if __name__ == '__main__':
     main()

--- a/pysmt/test/test_bv_simplification.py
+++ b/pysmt/test/test_bv_simplification.py
@@ -416,5 +416,19 @@ class TestBvSimplification(TestCase):
         f = BVSLT(BV(10, 32), BV(2**32 - 1, 32))
         self.check_equal_and_valid(f, Bool(False))
 
+    def test_bv_sle_eq(self):
+        x, y = (Symbol(name, BVType(32)) for name in "xy")
+        f = BVSLE(BVMul(x, y), BVMul(x, y))
+        self.check_equal_and_valid(f, Bool(True))
+
+    def test_bv_sle_symbols(self):
+        x, y = (Symbol(name, BVType(32)) for name in "xy")
+        f = BVSLE(x, y)
+        self.check_equal_and_valid(f, BVSLE(x, y))
+
+    def test_bv_sle_constants(self):
+        f = BVSLE(BV(10, 32), BV(2**32 - 1, 32))
+        self.check_equal_and_valid(f, Bool(False))
+
 if __name__ == '__main__':
     main()

--- a/pysmt/test/test_bv_simplification.py
+++ b/pysmt/test/test_bv_simplification.py
@@ -378,5 +378,29 @@ class TestBvSimplification(TestCase):
         f = BVLShl(BV(0xff, 32), BVOne(32))
         self.check_equal_and_valid(f, BV(0x1fe, 32))
 
+    def test_bv_lshr_zero(self):
+        x = Symbol("x", BVType(32))
+        f = BVLShr(x, BVZero(32))
+        self.check_equal_and_valid(f, x)
+
+    def test_bv_zero_lshr(self):
+        x = Symbol("x", BVType(32))
+        f = BVLShr(BVZero(32), x)
+        self.check_equal_and_valid(f, BVZero(32))
+
+    def test_bv_lshr_underflow(self):
+        x = Symbol("x", BVType(32))
+        f = BVLShr(x, BV(33, 32))
+        self.check_equal_and_valid(f, BVZero(32))
+
+    def test_bv_lshr_symbols(self):
+        x, y = (Symbol(name, BVType(32)) for name in "xy")
+        f = BVLShr(x, y)
+        self.check_equal_and_valid(f, BVLShr(x, y))
+
+    def test_bv_lshr_constants(self):
+        f = BVLShr(BV(0xff, 32), BVOne(32))
+        self.check_equal_and_valid(f, BV(0x7f, 32))
+
 if __name__ == '__main__':
     main()

--- a/pysmt/test/test_bv_simplification.py
+++ b/pysmt/test/test_bv_simplification.py
@@ -402,5 +402,19 @@ class TestBvSimplification(TestCase):
         f = BVLShr(BV(0xff, 32), BVOne(32))
         self.check_equal_and_valid(f, BV(0x7f, 32))
 
+    def test_bv_slt_eq(self):
+        x, y = (Symbol(name, BVType(32)) for name in "xy")
+        f = BVSLT(BVMul(x, y), BVMul(x, y))
+        self.check_equal_and_valid(f, Bool(False))
+
+    def test_bv_slt_symbols(self):
+        x, y = (Symbol(name, BVType(32)) for name in "xy")
+        f = BVSLT(x, y)
+        self.check_equal_and_valid(f, BVSLT(x, y))
+
+    def test_bv_slt_constants(self):
+        f = BVSLT(BV(10, 32), BV(2**32 - 1, 32))
+        self.check_equal_and_valid(f, Bool(False))
+
 if __name__ == '__main__':
     main()

--- a/pysmt/test/test_bv_simplification.py
+++ b/pysmt/test/test_bv_simplification.py
@@ -273,5 +273,34 @@ class TestBvSimplification(TestCase):
         f = BVULE(BVZero(32), BVOne(32))
         self.check_equal_and_valid(f, Bool(True))
 
+    def test_bv_and_zero(self):
+        x = Symbol("x", BVType(32))
+        f = BVAnd(x, BVZero(32))
+        self.check_equal_and_valid(f, BVZero(32))
+
+    def test_bv_zero_and(self):
+        x = Symbol("x", BVType(32))
+        f = BVAnd(BVZero(32), x)
+        self.check_equal_and_valid(f, BVZero(32))
+
+    def test_bv_and_all_ones(self):
+        x = Symbol("x", BVType(32))
+        f = BVAnd(x, BV(2**32 - 1, 32))
+        self.check_equal_and_valid(f, x)
+
+    def test_bv_all_ones_and(self):
+        x = Symbol("x", BVType(32))
+        f = BVAnd(BV(2**32 - 1, 32), x)
+        self.check_equal_and_valid(f, x)
+
+    def test_bv_and_symbols(self):
+        x, y = (Symbol(name, BVType(32)) for name in "xy")
+        f = BVAnd(x, y)
+        self.check_equal_and_valid(f, BVAnd(x, y))
+
+    def test_bv_and_constants(self):
+        f = BVAnd(BV(0xdededede, 32), BV(0xacacacac, 32))
+        self.check_equal_and_valid(f, BV(0x8c8c8c8c, 32))
+
 if __name__ == '__main__':
     main()

--- a/pysmt/test/test_bv_simplification.py
+++ b/pysmt/test/test_bv_simplification.py
@@ -199,5 +199,41 @@ class TestBvSimplification(TestCase):
         f = BVUDiv(x, y)
         self.check_equal_and_valid(f, BVUDiv(x, y))
 
+    def test_bv_urem_1(self):
+        x = Symbol("x", BVType(32))
+        f = BVURem(x, BVOne(32))
+        self.check_equal_and_valid(f, BVZero(32))
+
+    def test_bv_symbol_urem_0(self):
+        x = Symbol("x", BVType(32))
+        f = BVURem(x, BVZero(32))
+        self.check_equal_and_valid(f, x)
+
+    def test_bv_0_urem_0(self):
+        f = BVURem(BVZero(32), BVZero(32))
+        self.check_equal_and_valid(f, BVZero(32))
+
+    def test_bv_nonzero_urem_0(self):
+        f = BVURem(BV(10, 32), BVZero(32))
+        self.check_equal_and_valid(f, BV(10, 32))
+
+    def test_bv_0_urem_nonzero(self):
+        f = BVURem(BVZero(32), BV(10, 32))
+        self.check_equal_and_valid(f, BVZero(32))
+
+    def test_bv_0_urem_symbol(self):
+        x = Symbol("x", BVType(32))
+        f = BVURem(BVZero(32), x)
+        self.check_equal_and_valid(f, BVZero(32))
+
+    def test_bv_urem_constants(self):
+        f = BVURem(BV(20, 32), BV(11, 32))
+        self.check_equal_and_valid(f, BV(9, 32))
+
+    def test_bv_urem_symbols(self):
+        x, y = (Symbol(name, BVType(32)) for name in "xy")
+        f = BVURem(x, y)
+        self.check_equal_and_valid(f, BVURem(x, y))
+
 if __name__ == '__main__':
     main()

--- a/pysmt/test/test_bv_simplification.py
+++ b/pysmt/test/test_bv_simplification.py
@@ -20,7 +20,7 @@ from six.moves import xrange
 from pysmt.shortcuts import Solver, BVAnd, BVOr, BVXor, BVConcat, BVULT, BVUGT, \
     BVULE, BVUGE, BVAdd, BVSub, BVMul, BVUDiv, BVURem, BVLShl, BVLShr, BVNot, \
     BVNeg, BVZExt, BVSExt, BVRor, BVRol, BV, BVExtract, BVSLT, BVSLE, BVComp, \
-    BVSDiv, BVSRem, BVAShr, get_env, EqualsOrIff, BVZero, Symbol
+    BVSDiv, BVSRem, BVAShr, get_env, EqualsOrIff, BVZero, BVOne, Symbol
 from pysmt.typing import BVType
 from pysmt.test import TestCase, skipIfSolverNotAvailable, main
 
@@ -129,6 +129,39 @@ class TestBvSimplification(TestCase):
     def test_bv_add_overflow(self):
         f = BVAdd(BV(2**32 - 1, 32), BV(10, 32))
         self.check_equal_and_valid(f, BV(9, 32))
+
+    def test_bv_0_mul(self):
+        x = Symbol("x", BVType(32))
+        f = BVMul(BVZero(32), x)
+        self.check_equal_and_valid(f, BVZero(32))
+
+    def test_bv_1_mul(self):
+        x = Symbol("x", BVType(32))
+        f = BVMul(BVOne(32), x)
+        self.check_equal_and_valid(f, x)
+
+    def test_bv_mul_0(self):
+        x = Symbol("x", BVType(32))
+        f = BVMul(x, BVZero(32))
+        self.check_equal_and_valid(f, BVZero(32))
+
+    def test_bv_mul_1(self):
+        x = Symbol("x", BVType(32))
+        f = BVMul(x, BVOne(32))
+        self.check_equal_and_valid(f, x)
+
+    def test_bv_mul_constants(self):
+        f = BVMul(BV(10, 32), BV(12, 32))
+        self.check_equal_and_valid(f, BV(120, 32))
+
+    def test_bv_mul_symbols(self):
+        x, y = (Symbol(name, BVType(32)) for name in "xy")
+        f = BVMul(x, y)
+        self.check_equal_and_valid(f, BVMul(x, y))
+
+    def test_bv_mul_overflow(self):
+        f = BVMul(BV(2**31, 32), BV(3, 32))
+        self.check_equal_and_valid(f, BV(0x80000000, 32))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This pull request implements the simplification of bit vector items in some trivial cases, such as simplifying BVAdd(x, BVZero(n)) to BVZero(n). Therefore, users may not need to call the expensive BDD simplifier for those trivial cases.