### PR TITLE
Handle ARRAY_VALUE for CVC4

### DIFF
--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -339,6 +339,13 @@ class CVC4Converter(Converter, DagWalker):
     def walk_array_select(self, formula, args, **kwargs):
         return self.mkExpr(CVC4.SELECT, args[0], args[1])
 
+    def walk_array_value(self, formula, args, **kwargs):
+        arr_type = self.env.stc.get_type(formula)
+        rval = self.mkConst(CVC4.ArrayStoreAll(self._type_to_cvc4(arr_type), args[0]))
+        for i, c in enumerate(args[1::2]):
+            rval = self.mkExpr(CVC4.STORE, rval, c, args[(i*2)+2])
+        return rval
+
     def walk_minus(self, formula, args, **kwargs):
         return self.mkExpr(CVC4.MINUS, args[0], args[1])
 

--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -27,7 +27,7 @@ except ImportError:
     raise SolverAPINotFound
 
 import pysmt.typing as types
-from pysmt.logics import PYSMT_LOGICS, ARRAYS_CONST_LOGICS
+from pysmt.logics import PYSMT_LOGICS
 
 from pysmt.solvers.solver import Solver, Converter, SolverOptions
 from pysmt.exceptions import (SolverReturnedUnknownResultError,
@@ -79,7 +79,6 @@ class CVC4Options(SolverOptions):
 class CVC4Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
 
     LOGICS = PYSMT_LOGICS -\
-             ARRAYS_CONST_LOGICS -\
              set(l for l in PYSMT_LOGICS if not l.theory.linear)
 
     OptionsClass = CVC4Options

--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -112,7 +112,9 @@ class CVC4Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
         self.cvc4 = CVC4.SmtEngine(self.em); self.cvc4.thisown=1
         self.options(self)
         self.declarations = set()
-        self.cvc4.setLogic(self.logic_name)
+        # remove extra characters from logic_name
+        logic = self.logic_name.replace("*", "")
+        self.cvc4.setLogic(logic)
 
     def declare_variable(self, var):
         raise NotImplementedError

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -199,7 +199,6 @@ class TestBasic(TestCase):
     def test_examples_cvc4(self):
         for (f, validity, satisfiability, logic) in get_example_formulae():
             if not logic.theory.linear: continue
-            if logic.theory.arrays_const: continue
             try:
                 v = is_valid(f, solver_name='cvc4', logic=logic)
                 s = is_sat(f, solver_name='cvc4', logic=logic)


### PR DESCRIPTION
This would just add a walker function for array_value  (stores on an array with a default constant) to cvc4.

Note: I tried to match the coding style from msat.py.
Note 2: There is one limitation in CVC4 which does not allow equalities between two ArrayStoreAll's (arrays with default constants). Of course this also holds if there are additional Stores on top of the ArrayStoreAlls. It will throw an error if a user tries to do this.