### PR TITLE
Fixes for OSX installation of CVC4

### DIFF
--- a/pysmt/cmd/installers/cvc4.py
+++ b/pysmt/cmd/installers/cvc4.py
@@ -75,7 +75,7 @@ class CVC4Installer(SolverInstaller):
 
 
         # Fix the paths of the bindings
-        SolverInstaller.mv(os.path.join(self.bin_path, "lib/pyshared/CVC4.so.4.0.0"),
+        SolverInstaller.mv(os.path.join(self.bin_path, "lib/pyshared/CVC4.4.so"),
                            os.path.join(self.bin_path, "lib/pyshared/_CVC4.so"))
 
     def get_installed_version(self):

--- a/pysmt/cmd/installers/cvc4.py
+++ b/pysmt/cmd/installers/cvc4.py
@@ -47,7 +47,7 @@ class CVC4Installer(SolverInstaller):
         SolverInstaller.run("bash autogen.sh", directory=self.extract_path)
 
         # Fix url of ANTLR
-        SolverInstaller.run("sed -i s/http/https/g ./contrib/get-antlr-3.4", directory=self.extract_path)
+        SolverInstaller.run("sed -i .bak s/http/https/g ./contrib/get-antlr-3.4", directory=self.extract_path)
 
         # Build ANTLR
         SolverInstaller.run("bash get-antlr-3.4",

--- a/pysmt/cmd/installers/cvc4.py
+++ b/pysmt/cmd/installers/cvc4.py
@@ -56,7 +56,8 @@ class CVC4Installer(SolverInstaller):
         # Configure and build CVC4
         config_cmd = "./configure --prefix={bin_path} \
                                   --enable-language-bindings=python \
-                                  --with-antlr-dir={dir_path}/antlr-3.4 ANTLR={dir_path}/antlr-3.4/bin/antlr3"
+                                  --with-antlr-dir={dir_path}/antlr-3.4 ANTLR={dir_path}/antlr-3.4/bin/antlr3 \
+                                  --disable-dependency-tracking"
         config_cmd = config_cmd.format(bin_path=self.bin_path,
                                        dir_path=self.extract_path)
 

--- a/pysmt/walkers/generic.py
+++ b/pysmt/walkers/generic.py
@@ -17,7 +17,7 @@
 #
 from functools import partial
 from six import with_metaclass
-import collections
+import collections.abc
 
 import pysmt.operators as op
 import pysmt.exceptions
@@ -40,7 +40,7 @@ class handles(object):
 
     """
     def __init__(self, *nodetypes):
-        if len(nodetypes) == 1 and isinstance(nodetypes[0], collections.Iterable):
+        if len(nodetypes) == 1 and isinstance(nodetypes[0], collections.abc.Iterable):
             nodetypes = nodetypes[0]
         self.nodetypes = list(nodetypes)
 


### PR DESCRIPTION
I ran into four problems while installing the CVC4 support in OSX.
1) A deprecation warning about a feature that will disappear in python 3.8
2) A problem due to the script assuming GNU version of sed (OSX uses BSD version by default).  (Change should work on Linux but untested)
3) A problem in running CVC4 configure script that makes it crash.  Applied the recommended change from the error message.
4) The name of the generated .so file was incorrect causing installation to fail at the last moment.  I would guess that this will break Linux builds so maybe it needs to try one filename and, if that fails, try the other filename?  I'm not in a position to test this at the moment though.