### PR TITLE
Fix bug in deque pop in smtlib/parser

### DIFF
--- a/pysmt/smtlib/parser/parser.py
+++ b/pysmt/smtlib/parser/parser.py
@@ -189,7 +189,7 @@ class Tokenizer(object):
         """Consumes and returns a single token from the stream.
            If the stream is empty, a PysmtSyntaxError is thrown"""
         if self.extra_queue:
-            return self.extra_queue.pop(0)
+            return self.extra_queue.popleft()
         else:
             try:
                 t = self.consume_maybe()

--- a/pysmt/test/smtlib/test_parser_examples.py
+++ b/pysmt/test/smtlib/test_parser_examples.py
@@ -23,7 +23,7 @@ from six.moves import cStringIO
 import pysmt.logics as logics
 from pysmt.test import TestCase, skipIfNoSolverForLogic, main
 from pysmt.test.examples import get_example_formulae
-from pysmt.smtlib.parser import SmtLibParser
+from pysmt.smtlib.parser import SmtLibParser, Tokenizer
 from pysmt.smtlib.script import smtlibscript_from_formula
 from pysmt.shortcuts import Iff
 from pysmt.shortcuts import read_smtlib, write_smtlib
@@ -156,6 +156,20 @@ class TestSMTParseExamples(TestCase):
         parser = SmtLibParser()
         with self.assertRaises(PysmtSyntaxError):
             parser.get_script(cStringIO(txt))
+
+    def test_parse_consume(self):
+        smt_script = """
+        (model
+        (define-fun STRING_cmd_line_arg_1_1000 () String "AAAAAAAAAAAA")
+        )
+        """
+        tokens = Tokenizer(cStringIO(smt_script), interactive=True)
+        parser = SmtLibParser()
+        tokens.consume()
+        tokens.consume()
+        next_token = tokens.consume()
+        tokens.add_extra_token(next_token)
+        tokens.consume()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Collection.deque does not have a method pop that takes arguments (i.e. `pop(0)` does not exist). I replaced the method with `popleft()` which achieve the same result as the intended one.