### PR TITLE
sort the times args while simplifying

### DIFF
--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -23,6 +23,7 @@ import pysmt.operators as op
 import pysmt.typing as types
 from pysmt.utils import set_bit
 from pysmt.exceptions import PysmtValueError
+from pysmt.fnode import FNode
 
 
 class Simplifier(pysmt.walkers.DagWalker):
@@ -360,7 +361,7 @@ class Simplifier(pysmt.walkers.DagWalker):
             elif not const.is_one():
                 new_args.append(const)
 
-        new_args = sorted(new_args, key=hash)
+        new_args = sorted(new_args, key=FNode.node_id)
         return self.manager.Times(new_args)
 
 

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -360,6 +360,7 @@ class Simplifier(pysmt.walkers.DagWalker):
             elif not const.is_one():
                 new_args.append(const)
 
+        new_args = sorted(new_args, key=hash)
         return self.manager.Times(new_args)
 
 

--- a/pysmt/test/test_simplify.py
+++ b/pysmt/test/test_simplify.py
@@ -134,5 +134,10 @@ class TestSimplify(TestCase):
         f = Or(x, y, z, Not(x))
         self.assertEqual(f.simplify(), TRUE())
 
+    def test_trivial_true_times(self):
+        x,y,z = (Symbol(name, REAL) for name in "xyz")
+        f = Equals(Times(x, z, y), Times(z, y, x))
+        self.assertEqual(f.simplify(), TRUE())
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
the args of the times args are processed using a stack. Each call
to simplify reverts the order of nonlinear multiplication. And because of that
the simplify function could not reach a fix-point if called repeatedly.
As a solution, we perform sorting of the arguments while doing simplication.