### PR TITLE
Install swig for yices and picosat in Travis build

### DIFF
--- a/ci/travis_before_install.sh
+++ b/ci/travis_before_install.sh
@@ -63,7 +63,7 @@ fi
 python ${DIR}/check_python_version.py "${TRAVIS_PYTHON_VERSION}"
 
 # Install latest version of SWIG
-if [ "${PYSMT_SOLVER}" == "bdd" ] || [ "${PYSMT_SOLVER}" == "cvc4" ] || [ "${PYSMT_SOLVER}" == "btor" ] || [ "${PYSMT_SOLVER}" == "all" ]
+if [ "${PYSMT_SOLVER}" == "bdd" ] || [ "${PYSMT_SOLVER}" == "cvc4" ] || [ "${PYSMT_SOLVER}" == "btor" ] || [ "${PYSMT_SOLVER}" == "yices" ] || [ "${PYSMT_SOLVER}" == "picosat" ] || [ "${PYSMT_SOLVER}" == "all" ]
 then
     git clone https://github.com/swig/swig.git
     cd swig


### PR DESCRIPTION
It appears that yices and picosat need swig, because the master branch was failing travis on my fork: https://travis-ci.org/makaimann/pysmt/builds/507901966

This just installs swig for those two solvers as well.