### PR TITLE
Define main function for pysmt as module

### DIFF
--- a/pysmt/__main__.py
+++ b/pysmt/__main__.py
@@ -1,0 +1,35 @@
+#
+# This file is part of pySMT.
+#
+#   Copyright 2014 Andrea Micheli and Marco Gario
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+def error():
+    print("Invalid option try 'install' or 'shell'")
+    exit(-1)
+
+if __name__ == "__main__":
+    import sys
+
+    cmd = error
+    if len(sys.argv) >= 2:
+        sys.argv = sys.argv[1:]
+        if sys.argv[0] == 'install':
+            import pysmt.cmd.install
+            cmd = pysmt.cmd.install.main
+        elif sys.argv[0] == 'shell':
+            import pysmt.cmd.shell
+            cmd = pysmt.cmd.shell.main
+    cmd()

--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -259,7 +259,3 @@ def main():
                                          mirror_link=mirror_url,
                                          **i.extra_params)
             installer.install(force_redo=options.force_redo)
-
-
-if __name__ == "__main__":
-    main()

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,6 @@ setup(
     install_requires=["six"],
     entry_points={
         'console_scripts': [
-            'pysmt = pysmt.cmd.shell:main',
-            'pysmt-shell = pysmt.cmd.shell:main_interactive',
             'pysmt-install = pysmt.cmd.install:main',
         ],
     },


### PR DESCRIPTION
Two commands are defined as main function of pysmt

```python -m pysmt install``` 
and 
```python -m pysmt shell```

This removes the bin alias for pysmt-shell, but preserves pysmt-install.

