### PR TITLE
Static Version number in package

### DIFF
--- a/make_distrib.sh
+++ b/make_distrib.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# Replace version information
+# See: https://git-scm.com/docs/git-describe
+# E.g. v0.5.1-4-g49a49f2-wip
+#      * 4 commits after tag v0.5.1
+#      * Latest commit "49a49f2"
+# we get v0.5.1.dev4
+#
+VERSION=`git describe | sed  's/v\(.*\)-\(.*\)-\(.*\)/\1.dev\2/'`
+echo "__version__ = \"$VERSION\"" > pysmt/__init__.py
+
+# Create package files
 python setup.py bdist --format=gztar
 python setup.py sdist --format=gztar
 

--- a/pysmt/__init__.py
+++ b/pysmt/__init__.py
@@ -18,34 +18,25 @@
 
 VERSION = (0, 8, 1, "dev", 1)
 
-# PEP440 Format
-__version__ = "%d.%d.%d%s%d" % VERSION if len(VERSION) == 5 else \
-              "%d.%d.%d" % VERSION
-
-def git_version():
-    """Human-readable version of latest commit.
-
-    E.g. v0.5.1-4-g49a49f2-wip
-         * 4 commits after tag v0.5.1
-         * Latest commit "49a49f2"
-         * -wip: Working tree is dirty (non committed stuff)
-    See: https://git-scm.com/docs/git-describe
-
-    If the command fails we return __version__
-    """
-    try:
-        import subprocess
-        git_version = subprocess.check_output(["git", "describe", "--dirty=-wip"],
-                                              stderr=subprocess.STDOUT)
-        return git_version.strip().decode('ascii')
-    except subprocess.CalledProcessError:
-        return __version__ # pragma: no cover
-    except OSError:
-        return __version__ # pragma: no cover
-
-# Override version number in dev branch to include the number of
-# commits since the release
+# Try to provide human-readable version of latest commit for dev versions
+# E.g. v0.5.1-4-g49a49f2-wip
+#      * 4 commits after tag v0.5.1
+#      * Latest commit "49a49f2"
+#      * -wip: Working tree is dirty (non committed stuff)
+# See: https://git-scm.com/docs/git-describe
 if len(VERSION) == 5:
-    commits_from_tag = git_version().split("-")[1]
-    VERSION = VERSION[:4] + (commits_from_tag,)
-    __version__ = "%d.%d.%d%s%s" % VERSION
+    import subprocess
+    try:
+        git_version = subprocess.check_output(["git", "describe",
+                                               "--dirty=-wip"],
+                                              stderr=subprocess.STDOUT)
+        commits_from_tag = git_version.strip().decode('ascii')
+        commits_from_tag = commits_from_tag.split("-")[1]
+        commits_from_tag = int(commits_from_tag)
+        VERSION = VERSION[:4] + (commits_from_tag,)
+    except Exception as ex:
+        pass
+
+# PEP440 Format
+__version__ = "%d.%d.%d.%s%d" % VERSION if len(VERSION) == 5 else \
+              "%d.%d.%d" % VERSION

--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -28,7 +28,7 @@ from pysmt.cmd.installers.base import solver_install_site
 
 from pysmt.environment import get_env
 from pysmt.exceptions import PysmtException
-from pysmt import git_version
+from pysmt import __version__ as pysmt_version
 
 # Build a list of installers, one for each solver
 Installer = namedtuple("Installer",
@@ -119,7 +119,7 @@ def parse_options():
                                      ' variable PYSMT_SOLVER if not already '
                                      'instaled on the system.')
     parser.add_argument('--version', action='version',
-                        version='%(prog)s {version}'.format(version=git_version()))
+                        version='%(prog)s {version}'.format(version=pysmt_version))
 
     for i in INSTALLERS:
         name = i.InstallerClass.SOLVER

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -412,13 +412,6 @@ class TestRegressions(TestCase):
     def test_array_initialization_printing(self):
         self.assertEqual(str(Array(INT, Int(0), {Int(1):Int(2)})), "Array{Int, Int}(0)[1 := 2]")
 
-    def test_git_version(self):
-        from pysmt import git_version
-        v = git_version()
-        self.assertIsNotNone(v)
-        parts = v.split("-")
-        self.assertTrue(len(parts) , 4)
-
     @skipIfSolverNotAvailable("btor")
     def test_boolector_assumptions(self):
         with Solver(name='btor') as solver:


### PR DESCRIPTION
When running a dev version, we use git to compute the version number. This works ok if we are running pysmt from the git checkout.

However, if we do pip install of a dev version, this can fail. This PR provides a default value for this.
This is more of a temporary fix and a principled solution would be appreciated.