### PR TITLE
Fix assertion tracking for boolector

### DIFF
--- a/pysmt/solvers/btor.py
+++ b/pysmt/solvers/btor.py
@@ -189,6 +189,7 @@ class BoolectorSolver(IncrementalTrackingSolver,
         self._assert_is_boolean(formula)
         term = self.converter.convert(formula)
         self.btor.Assert(term)
+        return formula
 
     def get_model(self):
         assignment = {}


### PR DESCRIPTION
This is a very simple fix for btor to correctly support the `IncrementalTrackingSolver` interface. Currently, getting the assertions from a `BoolectorSolver` always gives a list of `None`, because `_add_assertion` doesn't return anything.

This change just returns `formula` from _add_assertion for tracking in self._assertion_stack.