### PR TITLE
Handle one-bit shifts in btor

### DIFF
--- a/pysmt/solvers/btor.py
+++ b/pysmt/solvers/btor.py
@@ -392,58 +392,10 @@ class BTORConverter(Converter, DagWalker):
         return self._btor.Urem(args[0], args[1])
 
     def walk_bv_lshl(self, formula, args, **kwargs):
-        # LHS width must be a power of 2
-        # Since this is a Logical Shift, we can Zero-Extend LHS
-        # if this is not the case
-        lhs, rhs = self._extend_bv_pow2(args[0]), args[1]
-        lhs_w, rhs_w = lhs.width, rhs.width
-
-        if lhs_w == 1:
-            assert rhs_w == 1, "expecting bit-widths to match"
-            # shifting a one-bit bit-vector
-            return self._btor.And(lhs, self._btor.Not(rhs))
-
-        # Boolector requires that witdh(rhs) = log2(width(lhs))
-        target_w = int(ceil(log(lhs_w, 2)))
-        if rhs_w == target_w:
-            return lhs << args[1]
-        else:
-            # If (rhs > max) Then 0 Else Rescale
-            max_value = 2**target_w-1
-            max_big = self._btor.Const(max_value, rhs_w)
-            cond = self._btor.Ugt(rhs, max_big)
-            zero = self._btor.Const(0, lhs_w)
-            rescaled = self._btor.Slice(rhs, target_w-1, 0)
-            return self._btor.Cond(cond,
-                                   zero,
-                                   self._btor.Sll(lhs, rescaled))
+        return self._btor.Sll(args[0], args[1])
 
     def walk_bv_lshr(self, formula, args, **kwargs):
-        # LHS width must be a power of 2
-        # Since this is a Logical Shift, we can Zero-Extend LHS
-        # if this is not the case
-        lhs, rhs = self._extend_bv_pow2(args[0]), args[1]
-        lhs_w, rhs_w = lhs.width, rhs.width
-        target_w = int(ceil(log(lhs_w, 2)))
-
-        if lhs_w == 1:
-            assert rhs_w == 1, "expecting bit-widths to match"
-            # shifting a one-bit bit-vector
-            return self._btor.And(lhs, self._btor.Not(rhs))
-
-        # Boolector requires that width(rhs) = log2(width(lhs))
-        if rhs_w == target_w:
-            return lhs >> rhs
-        else:
-            # If (rhs > max) Then 0 Else Rescale
-            max_value = 2**target_w-1
-            max_big = self._btor.Const(max_value, rhs_w)
-            cond = self._btor.Ugt(rhs, max_big)
-            zero = self._btor.Const(0, lhs_w)
-            rescaled = self._btor.Slice(rhs, target_w-1, 0)
-            return self._btor.Cond(cond,
-                                   zero,
-                                   self._btor.Srl(lhs, rescaled))
+        return self._btor.Srl(args[0], args[1])
 
     def walk_bv_rol(self, formula, args, **kwargs):
         return self._btor.Rol(args[0],
@@ -475,32 +427,7 @@ class BTORConverter(Converter, DagWalker):
         return self._btor.Srem(args[0], args[1])
 
     def walk_bv_ashr (self, formula, args, **kwargs):
-        # LHS width must be a power of 2
-        # Since this is an Arithmetic Shift, we need to Sign-Extend LHS
-        # if this is not the case
-        lhs, rhs = self._extend_bv_pow2(args[0], signed=True), args[1]
-        lhs_w, rhs_w = lhs.width, rhs.width
-
-        if lhs_w == 1:
-            assert rhs_w == 1, "expecting bit-widths to match"
-            # shifting a one-bit bit-vector
-            # for ashr this just gives the original result back
-            return lhs
-
-        # Boolector requires that witdh(rhs) = log2(width(lhs))
-        target_w = int(ceil(log(lhs_w, 2)))
-        if rhs_w == target_w:
-            return self._btor.Sra(lhs, rhs)
-        else:
-            # IF (rhs <= max) Then Rescale Else Max
-            max_value = 2**target_w-1
-            max_big = self._btor.Const(max_value, rhs_w)
-            cond = self._btor.Ulte(rhs, max_big)
-            max_small = self._btor.Const(max_value, target_w)
-            rescaled = self._btor.Slice(rhs, target_w-1, 0)
-            return self._btor.Sra(lhs, self._btor.Cond(cond,
-                                                       rescaled,
-                                                       max_small))
+        return self._btor.Sra(args[0], args[1])
 
     def walk_array_store(self, formula, args, **kwargs):
         return self._btor.Write(args[0], args[1], args[2])

--- a/pysmt/solvers/btor.py
+++ b/pysmt/solvers/btor.py
@@ -398,6 +398,11 @@ class BTORConverter(Converter, DagWalker):
         lhs, rhs = self._extend_bv_pow2(args[0]), args[1]
         lhs_w, rhs_w = lhs.width, rhs.width
 
+        if lhs_w == 1:
+            assert rhs_w == 1, "expecting bit-widths to match"
+            # shifting a one-bit bit-vector
+            return self._btor.And(lhs, self._btor.Not(rhs))
+
         # Boolector requires that witdh(rhs) = log2(width(lhs))
         target_w = int(ceil(log(lhs_w, 2)))
         if rhs_w == target_w:
@@ -420,6 +425,11 @@ class BTORConverter(Converter, DagWalker):
         lhs, rhs = self._extend_bv_pow2(args[0]), args[1]
         lhs_w, rhs_w = lhs.width, rhs.width
         target_w = int(ceil(log(lhs_w, 2)))
+
+        if lhs_w == 1:
+            assert rhs_w == 1, "expecting bit-widths to match"
+            # shifting a one-bit bit-vector
+            return self._btor.And(lhs, self._btor.Not(rhs))
 
         # Boolector requires that width(rhs) = log2(width(lhs))
         if rhs_w == target_w:
@@ -470,6 +480,12 @@ class BTORConverter(Converter, DagWalker):
         # if this is not the case
         lhs, rhs = self._extend_bv_pow2(args[0], signed=True), args[1]
         lhs_w, rhs_w = lhs.width, rhs.width
+
+        if lhs_w == 1:
+            assert rhs_w == 1, "expecting bit-widths to match"
+            # shifting a one-bit bit-vector
+            # for ashr this just gives the original result back
+            return lhs
 
         # Boolector requires that witdh(rhs) = log2(width(lhs))
         target_w = int(ceil(log(lhs_w, 2)))


### PR DESCRIPTION
EDIT: Actually, it turns out that the latest version of boolector does not have this restriction any more. Thus, the best solution is to simply call the relevant boolector shift method without any rewriting (implemented here: https://github.com/pysmt/pysmt/pull/592/commits/39b2c8e3c8d062ed3cd991dd22cffbf4a4eb5a6f). Thanks to @mpreiner for pointing this out.

Through the API, boolector requires that the second argument to a shift has a width that is `log2` of the first argument's width. This is handled in PySMT by extracting the lower bits of the second argument. However, there can be a problem here for bit-vectors of width 1.

Example:
Running the following:
```
    x = Symbol('x', BVType(1))
    y = Symbol('y', BVType(1))
    res = Symbol('res', BVType(1))

    s = Solver(name='btor')
    s.add_assertion(EqualsOrIff(res, BVLShl(x, y)))
    s.check_sat()
```
Gives this error:
```
Traceback (most recent call last):
  File "./shifttest.py", line 11, in <module>
    s.add_assertion(EqualsOrIff(res, BVLShl(x, y)))
  File "/home/makai/repos/pysmt/pysmt/solvers/solver.py", line 364, in add_assertion
    tracked = self._add_assertion(formula, named=named)
  File "/home/makai/repos/pysmt/pysmt/decorators.py", line 64, in clear_pending_pop_wrap
    return f(self, *args, **kwargs)
  File "/home/makai/repos/pysmt/pysmt/solvers/btor.py", line 190, in _add_assertion
    term = self.converter.convert(formula)
  File "/home/makai/repos/pysmt/pysmt/decorators.py", line 84, in catch_conversion_error_wrap
    res = f(*args, **kwargs)
  File "/home/makai/repos/pysmt/pysmt/solvers/btor.py", line 268, in convert
    return self.walk(formula)
  File "/home/makai/repos/pysmt/pysmt/walkers/dag.py", line 106, in walk
    res = self.iter_walk(formula, **kwargs)
  File "/home/makai/repos/pysmt/pysmt/walkers/dag.py", line 98, in iter_walk
    self._process_stack(**kwargs)
  File "/home/makai/repos/pysmt/pysmt/walkers/dag.py", line 91, in _process_stack
    self._compute_node_result(formula, **kwargs)
  File "/home/makai/repos/pysmt/pysmt/walkers/dag.py", line 75, in _compute_node_result
    self.memoization[key] = f(formula, args=args, **kwargs)
  File "/home/makai/repos/pysmt/pysmt/solvers/btor.py", line 411, in walk_bv_lshl
    rescaled = self._btor.Slice(rhs, target_w-1, 0)
  File "pyboolector.pyx", line 1482, in pyboolector.Boolector.Slice
OverflowError: can't convert negative value to uint32_t
```

This pull request handles this issue by using a different rewrite in the 1 bit case. To ensure that this is correct, I also verified each of the rewrites, please see the attached smt-lib files.
[btor-shift-rewrite-proofs.tar.gz](https://github.com/pysmt/pysmt/files/3287710/btor-shift-rewrite-proofs.tar.gz)
