### PR TITLE
Fixed issue #596

### DIFF
--- a/pysmt/solvers/yices.py
+++ b/pysmt/solvers/yices.py
@@ -461,9 +461,11 @@ class YicesConverter(Converter, DagWalker):
     def walk_bv_constant(self, formula, **kwargs):
         width = formula.bv_width()
         res = None
-        if width <= 64:
-            # we can use the numberical representation
-            value = formula.constant_value()
+        value = formula.constant_value()
+        if value <= ((2**63) - 1):
+            # we can use the numerical representation
+            # Note: yicespy uses *signed* longs in the API, so the maximal
+            # representable number is 2^63 - 1
             res = yicespy.yices_bvconst_uint64(width, value)
         else:
             # we must resort to strings to communicate the result to yices

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -516,5 +516,34 @@ class TestRegressions(TestCase):
         s = to_smtlib(f0_of_false, False)
         self.assertEqual(s, '(|f 0| false)')
 
+    @skipIfSolverNotAvailable("yices")
+    def test_yices_bv_overflow(self):
+        smt_script = '''
+        (set-logic QF_BV)
+        (declare-fun s0 () (_ BitVec 64))
+        (define-fun s1 () (_ BitVec 64) #xFFFFFFFFFFFFFFFF)
+        (define-fun s2 () Bool (= s1 s0))
+        (assert s2)
+        (check-sat)
+        '''
+        from pysmt.smtlib.parser import get_formula_strict
+        f = get_formula_strict(cStringIO(smt_script))
+        self.assertSat(f, solver_name='yices')
+
+    @skipIfSolverNotAvailable("yices")
+    def test_yices_bv_no_overflow(self):
+        smt_script = '''
+        (set-logic QF_BV)
+        (declare-fun s0 () (_ BitVec 64))
+        (define-fun s1 () (_ BitVec 64) #x7FFFFFFFFFFFFFFF)
+        (define-fun s2 () Bool (= s1 s0))
+        (assert s2)
+        (check-sat)
+        '''
+        from pysmt.smtlib.parser import get_formula_strict
+        f = get_formula_strict(cStringIO(smt_script))
+        self.assertSat(f, solver_name='yices')
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The problem was a bad control in the conversion of BV constants: the yicespy swig API uses 64-bit signed longs, so the maximum number convertible via that API is 2^63-1. I fixed the control that falls back to string-based conversion.   