### PR TITLE
Fix mathsat signature for BV_CONCAT

### DIFF
--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -464,7 +464,7 @@ class MSatConverter(Converter, DagWalker):
             mathsat.MSAT_TAG_BV_ADD: self._sig_binary,
             mathsat.MSAT_TAG_BV_UDIV:self._sig_binary,
             mathsat.MSAT_TAG_BV_UREM:self._sig_binary,
-            mathsat.MSAT_TAG_BV_CONCAT: self._sig_binary,
+            mathsat.MSAT_TAG_BV_CONCAT: self._sig_bv_concat,
             mathsat.MSAT_TAG_BV_OR:  self._sig_binary,
             mathsat.MSAT_TAG_BV_XOR: self._sig_binary,
             mathsat.MSAT_TAG_BV_AND: self._sig_binary,
@@ -564,6 +564,11 @@ class MSatConverter(Converter, DagWalker):
         _, msb, lsb = mathsat.msat_term_is_bv_extract(self.msat_env(), term)
         t = self.env.stc.get_type(args[0])
         return types.FunctionType(types.BVType(msb - lsb + 1), [t])
+
+    def _sig_bv_concat(self, term, args):
+        t1 = self.env.stc.get_type(args[0])
+        t2 = self.env.stc.get_type(args[1])
+        return types.FunctionType(types.BVType(t1.width + t2.width), [t1, t2])
 
     def _sig_array_read(self, term, args):
         t1 = self.env.stc.get_type(args[0])


### PR DESCRIPTION
Fixes an issue in the mathsat signature for concat. This was causing issues for `sequence_interpolant` when the interpolant contained `concat` because the signature wouldn't match.