### PR TITLE
Fixed #620 by allowing n-ary BVConcat in the frontend 

### DIFF
--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -674,11 +674,17 @@ class FormulaManager(object):
                                 args=(left,right),
                                 payload=(left.bv_width(),))
 
-    def BVConcat(self, left, right):
-        """Returns the Concatenation of the two BVs"""
-        return self.create_node(node_type=op.BV_CONCAT,
-                                args=(left,right),
-                                payload=(left.bv_width()+right.bv_width(),))
+    def BVConcat(self, *args):
+        """Returns the Concatenation of the given BVs"""
+        ex = self._polymorph_args_to_tuple(args)
+        base = self.create_node(node_type=op.BV_CONCAT,
+                                args=(ex[0], ex[1]),
+                                payload=(ex[0].bv_width() + ex[1].bv_width(),))
+        for e in ex[2:]:
+            base = self.create_node(node_type=op.BV_CONCAT,
+                                    args=(base, e),
+                                    payload=(base.bv_width() + e.bv_width(),))
+        return base
 
     def BVExtract(self, formula, start=0, end=None):
         """Returns the slice of formula from start to end (inclusive)."""

--- a/pysmt/shortcuts.py
+++ b/pysmt/shortcuts.py
@@ -472,15 +472,14 @@ def BVXor(left, right):
     return get_env().formula_manager.BVXor(left, right)
 
 
-def BVConcat(left, right):
+def BVConcat(*args):
     """Returns the Concatenation of the two BVs
 
-    :param left: Specify the left bitvector
-    :param right: Specify the right bitvector
-    :returns: The concatenation of the two BVs
+    :param args: Specify the bitvectors to concatenate
+    :returns: The concatenation of the given BVs
     :rtype: FNode
     """
-    return get_env().formula_manager.BVConcat(left, right)
+    return get_env().formula_manager.BVConcat(*args)
 
 
 def BVExtract(formula, start=0, end=None):

--- a/pysmt/test/smtlib/test_parser_examples.py
+++ b/pysmt/test/smtlib/test_parser_examples.py
@@ -183,5 +183,19 @@ class TestSMTParseExamples(TestCase):
         self.assertEqual(len(get_env().formula_manager.get_all_symbols()),
                          len(script.get_declared_symbols()) + len(script.get_define_fun_parameter_symbols()))
 
+    @skipIfNoSolverForLogic(logics.QF_BV)
+    def test_nary_bvconcat(self):
+        txt = """
+        (set-logic QF_BV )
+        (declare-fun INPUT () (Array (_ BitVec 32) (_ BitVec 8) ) )
+        (declare-fun A () (_ BitVec 64))(assert (= A (bvor #x0000000000000000 (bvshl ((_ zero_extend 32) ((_ zero_extend 24) (select INPUT #x00000000))) #x0000000000000000))))
+        (declare-fun B () (_ BitVec 64))(assert (= B (concat ((_ extract 63 56) (bvor #x0000000000000000 (bvshl ((_ zero_extend 32) ((_ zero_extend 24) ((_ extract 7 0) (bvor #x0000000000000000 (bvshl ((_ zero_extend 32) ((_ zero_extend 24) (select INPUT #x00000000))) #x0000000000000000))))) #x0000000000000000))) ((_ extract 55 48) (bvor #x0000000000000000 (bvshl ((_ zero_extend 32) ((_ zero_extend 24) ((_ extract 7 0) (bvor #x0000000000000000 (bvshl ((_ zero_extend 32) ((_ zero_extend 24) (select INPUT #x00000000))) #x0000000000000000))))) #x0000000000000000))) ((_ extract 47 40) (bvor #x0000000000000000 (bvshl ((_ zero_extend 32) ((_ zero_extend 24) ((_ extract 7 0) (bvor #x0000000000000000 (bvshl ((_ zero_extend 32) ((_ zero_extend 24) (select INPUT #x00000000))) #x0000000000000000))))) #x0000000000000000))) ((_ extract 39 32) (bvor #x0000000000000000 (bvshl ((_ zero_extend 32) ((_ zero_extend 24) ((_ extract 7 0) (bvor #x0000000000000000 (bvshl ((_ zero_extend 32) ((_ zero_extend 24) (select INPUT #x00000000))) #x0000000000000000))))) #x0000000000000000))) ((_ extract 31 24) (bvor #x0000000000000000 (bvshl ((_ zero_extend 32) ((_ zero_extend 24) ((_ extract 7 0) (bvor #x0000000000000000 (bvshl ((_ zero_extend 32) ((_ zero_extend 24) (select INPUT #x00000000))) #x0000000000000000))))) #x0000000000000000))) ((_ extract 23 16) (bvor #x0000000000000000 (bvshl ((_ zero_extend 32) ((_ zero_extend 24) ((_ extract 7 0) (bvor #x0000000000000000 (bvshl ((_ zero_extend 32) ((_ zero_extend 24) (select INPUT #x00000000))) #x0000000000000000))))) #x0000000000000000))) ((_ extract 15 8) (bvor #x0000000000000000 (bvshl ((_ zero_extend 32) ((_ zero_extend 24) ((_ extract 7 0) (bvor #x0000000000000000 (bvshl ((_ zero_extend 32) ((_ zero_extend 24) (select INPUT #x00000000))) #x0000000000000000))))) #x0000000000000000))) ((_ extract 7 0) (bvor #x0000000000000000 (bvshl ((_ zero_extend 32) ((_ zero_extend 24) ((_ extract 7 0) (bvor #x0000000000000000 (bvshl ((_ zero_extend 32) ((_ zero_extend 24) (select INPUT #x00000000))) #x0000000000000000))))) #x0000000000000000))))))
+        (assert (=  A B))
+        (check-sat)"""
+        parser = SmtLibParser()
+        script = parser.get_script(cStringIO(txt))
+        f_in = script.get_last_formula()
+        self.assertSat(f_in)
+
 if __name__ == "__main__":
     main()

--- a/pysmt/test/smtlib/test_parser_examples.py
+++ b/pysmt/test/smtlib/test_parser_examples.py
@@ -183,7 +183,7 @@ class TestSMTParseExamples(TestCase):
         self.assertEqual(len(get_env().formula_manager.get_all_symbols()),
                          len(script.get_declared_symbols()) + len(script.get_define_fun_parameter_symbols()))
 
-    @skipIfNoSolverForLogic(logics.QF_BV)
+    @skipIfNoSolverForLogic(logics.QF_ABV)
     def test_nary_bvconcat(self):
         txt = """
         (set-logic QF_BV )


### PR DESCRIPTION
For the time-being I kept the binary internal representation of `BVConcat`, but we might consider to switch to a n-ary representation as for `Plus`. 