### PR TITLE
Support for division by Zero

### DIFF
--- a/pysmt/environment.py
+++ b/pysmt/environment.py
@@ -74,6 +74,7 @@ class Environment(object):
         self._factory = None
         # Configurations
         self.enable_infix_notation = False
+        self.enable_div_by_0 = True
 
         # Dynamic Walker Configuration Map
         # See: add_dynamic_walker_function

--- a/pysmt/fnode.py
+++ b/pysmt/fnode.py
@@ -22,7 +22,7 @@ import pysmt.smtlib
 from pysmt.operators import (FORALL, EXISTS, AND, OR, NOT, IMPLIES, IFF,
                              SYMBOL, FUNCTION,
                              REAL_CONSTANT, BOOL_CONSTANT, INT_CONSTANT,
-                             PLUS, MINUS, TIMES,
+                             PLUS, MINUS, TIMES, DIV,
                              LE, LT, EQUALS,
                              ITE,
                              TOREAL,
@@ -298,6 +298,10 @@ class FNode(object):
     def is_times(self):
         """Test whether the node is the Times operator."""
         return self.node_type() == TIMES
+
+    def is_div(self):
+        """Test whether the node is the Division operator."""
+        return self.node_type() == DIV
 
     def is_implies(self):
         """Test whether the node is the Implies operator."""

--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -33,6 +33,7 @@ if sys.version_info >= (3, 3):
 else:
     from collections import Iterable
 
+import warnings
 from six.moves import xrange
 
 import pysmt.typing as types
@@ -261,7 +262,11 @@ class FormulaManager(object):
 
     def Div(self, left, right):
         """ Creates an expression of the form: left / right """
-        if right.is_constant(types.REAL):
+        if right.is_constant(types.REAL, 0) and self.env.enable_div_by_0:
+            # Allow division by 0 byt warn the user
+            # This can only happen in non-linear logics
+            warnings.warn("Warning: Division by 0")
+        elif right.is_constant(types.REAL):
             # If right is a constant we rewrite as left * 1/right
             inverse = Fraction(1) / right.constant_value()
             return self.Times(left, self.Real(inverse))

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -315,6 +315,13 @@ class TheoryOracle(walkers.DagWalker):
         if len(left.get_free_variables()) != 0 and \
            len(right.get_free_variables()) != 0:
             theory_out = theory_out.set_linear(False)
+        elif formula.arg(1).is_zero():
+            # DivBy0 is non-linear
+            theory_out = theory_out.set_linear(False)
+        else:
+            theory_out = theory_out.combine(args[1])
+        return theory_out
+
         # This is  not in DL anymore
         theory_out = theory_out.set_difference_logic(False)
         return theory_out

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -975,7 +975,7 @@ class Simplifier(pysmt.walkers.DagWalker):
         sl = args[0]
         sr = args[1]
 
-        if sl.is_constant() and sr.is_constant():
+        if sl.is_constant() and sr.is_constant() and not sr.is_zero():
             l = sl.constant_value()
             r = sr.constant_value()
             if sl.is_real_constant():

--- a/pysmt/test/test_nlira.py
+++ b/pysmt/test/test_nlira.py
@@ -17,11 +17,11 @@
 #
 
 from pysmt.test import TestCase, main
-from pysmt.test import skipIfSolverNotAvailable
+from pysmt.test import skipIfSolverNotAvailable, skipIfNoSolverForLogic
 
 from pysmt.oracles import get_logic
 from pysmt.shortcuts import FreshSymbol, Times, Equals, Div, Real, Int, Pow
-from pysmt.shortcuts import Solver, is_sat
+from pysmt.shortcuts import Solver, Symbol, And, Not, is_sat
 from pysmt.typing import REAL, INT
 from pysmt.exceptions import (ConvertExpressionError,
                               NonLinearError,
@@ -116,6 +116,17 @@ class TestNonLinear(TestCase):
             self.assertTrue(is_sat(f))
         except SolverReturnedUnknownResultError:
             pass
+
+    @skipIfNoSolverForLogic(QF_NRA)
+    def test_div_by_0(self):
+        varA = Symbol('A', REAL)
+        varB = Symbol('B', REAL)
+
+        f = And(Equals(varA, varB),
+                Not(Equals(Div(varA, Real(0)), Div(varB, Real(0)))))
+
+        self.assertUnsat(f)
+
 
 if __name__ == "__main__":
     main()

--- a/pysmt/test/test_oracles.py
+++ b/pysmt/test/test_oracles.py
@@ -20,7 +20,7 @@ from pysmt.shortcuts import Symbol, Implies, And, Not
 from pysmt.test.examples import get_example_formulae
 from pysmt.test import TestCase, main
 from pysmt.oracles import get_logic
-from pysmt.typing import BOOL, Type, INT, FunctionType
+from pysmt.typing import BOOL, Type, INT, REAL, FunctionType
 
 
 class TestOracles(TestCase):
@@ -137,6 +137,15 @@ class TestOracles(TestCase):
         theory = self.env.theoryo.get_theory(f_1)
         self.assertEqual(theory, QF_UFIDL.theory)
 
+    def test_types_oracle_divby0(self):
+        from pysmt.logics import QF_NRA
+
+        mgr = self.env.formula_manager
+        r = mgr.Symbol("r", REAL)
+        f = mgr.Equals(mgr.Real(4),
+                       mgr.Div(r, mgr.Real(0)))
+        theory = self.env.theoryo.get_theory(f)
+        self.assertFalse(theory.linear)
 
 
 if __name__ == '__main__':

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -240,33 +240,6 @@ class TestBasic(TestCase):
             self.assertEqual(satisfiability, s, f)
 
     def do_model(self, solver_name):
-        def assert_model(f, subs, solver):
-            simp = f.substitute(subs).simplify()
-            if not simp.is_true() and get_env().enable_div_by_0:
-                free_vars = simp.get_free_variables()
-                self.assertTrue(len(free_vars) == 0)
-
-                # Models might not be simplified to a constant value
-                # if there is a division by zero. We find the
-                # division(s) and ask the solver for a replacement
-                # expression.
-                stack = [simp]
-                div_0 = []
-                while stack:
-                    x = stack.pop()
-                    if x.is_constant():
-                        pass
-                    elif x.is_div() and x.arg(1).is_zero():
-                        div_0.append(x)
-                    stack += x.args()
-
-                subs = {}
-                for d in div_0:
-                    subs[d] = solver.get_value(d)
-                    simp = simp.substitute(subs).simplify()
-
-            self.assertEqual(simp, TRUE(), "%s -- %s :> %s" % (f, subs, simp))
-            return
 
         for (f, _, satisfiability, logic) in get_example_formulae():
             if satisfiability and not logic.theory.uninterpreted and logic.quantifier_free:
@@ -277,20 +250,8 @@ class TestBasic(TestCase):
                         check = s.solve()
                         self.assertTrue(check)
 
-                        # Ask single values to the solver
-                        subs = {}
-                        for d in f.get_free_variables():
-                            m = s.get_value(d)
-                            subs[d] = m
-                        assert_model(f, subs, s)
-
-                        # Ask the eager model
-                        subs = {}
                         model = s.get_model()
-                        for d in f.get_free_variables():
-                            m = model.get_value(d)
-                            subs[d] = m
-                        assert_model(f, subs, s)
+                        self.assertTrue(model.satisfies(f, s))
 
                 except NoSolverAvailableError:
                     pass

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -240,7 +240,7 @@ class TestBasic(TestCase):
             self.assertEqual(satisfiability, s, f)
 
     def do_model(self, solver_name):
-        def assert_model(f, subs):
+        def assert_model(f, subs, solver):
             simp = f.substitute(subs).simplify()
             if not simp.is_true() and get_env().enable_div_by_0:
                 free_vars = simp.get_free_variables()
@@ -262,7 +262,7 @@ class TestBasic(TestCase):
 
                 subs = {}
                 for d in div_0:
-                    subs[d] = model.get_value(d)
+                    subs[d] = solver.get_value(d)
                     simp = simp.substitute(subs).simplify()
 
             self.assertEqual(simp, TRUE(), "%s -- %s :> %s" % (f, subs, simp))
@@ -282,7 +282,7 @@ class TestBasic(TestCase):
                         for d in f.get_free_variables():
                             m = s.get_value(d)
                             subs[d] = m
-                        assert_model(f, subs)
+                        assert_model(f, subs, s)
 
                         # Ask the eager model
                         subs = {}
@@ -290,7 +290,7 @@ class TestBasic(TestCase):
                         for d in f.get_free_variables():
                             m = model.get_value(d)
                             subs[d] = m
-                        assert_model(f, subs)
+                        assert_model(f, subs, s)
 
                 except NoSolverAvailableError:
                     pass


### PR DESCRIPTION
* Check if we are trying to create an expression `Div(x, Real(0))`, if so, raise a User warning, if the configuration flag `enable_div_by_0`.
* Check for div by 0 in simplifier
* Extend TheoryOracle to return a non-linear theory for expressions with division by 
---
*Old Proposal*
When creating a Div expression, we check whether the right hand side is a 0. If so, we replace the entire expression with a new variable. In this way, we preserve the SMTLIB semantics of Div, while keeping the model extraction and other operations simple.

Since getting a result due to a division by zero is always surprising, we add a user warning when performing the translation and make it possible to disable it with the configuration variable `Environment.replace_div_by_0`

See discussion in https://github.com/pysmt/pysmt/issues/631