### PR TITLE
 CLA: Add utility to check for CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,13 @@
+on: [push]
+
+jobs:
+  CheckCLA:
+    runs-on: ubuntu-latest
+    name: Checks that all committers are in CONTRIBUTORS
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run Check
+        run: ./ci/cla.sh

--- a/.mailmap
+++ b/.mailmap
@@ -21,3 +21,4 @@ Yoni Zohar <yoni206@gmail.com>  yoni206 <yoni206@users.noreply.github.com>
 Yuri Malheiros <yurimalheiros@gmail.com>  yurimalheiros <yurimalheiros@gmail.com>
 Enrico Magnago <en.magnago@gmail.com> Enrico Magnago <EnricoMagnago@users.noreply.github.com>
 Enrico Magnago <en.magnago@gmail.com> en <en.magnago@gmail.com>
+Caleb Donovick <donovick@cs.stanford.edu> Caleb Donovick <cdonovick@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,21 @@
+# Canonical Name <canonical@email>  Other Name <other@email>
+# Note: Canonical name and email must match CONTRIBUTORS
+#
+Ahmed Irfan <ahmed.irfan@alumni.unitn.it>  Ahmed Irfan <43099566+ahmed-irfan@users.noreply.github.com>
+Ahmed Irfan <ahmed.irfan@alumni.unitn.it>  Ahmed Irfan <ahmed.irfan@alumni.unitn.it>
+Ahmed Irfan <ahmed.irfan@alumni.unitn.it>  Ahmed Irfan <irfan@fbk.eu>
+Andrea Micheli <micheli.andrea@gmail.com>  mikand <micheli.andrea@gmail.com>
+Andrea Micheli <micheli.andrea@gmail.com>  MikAnd <micheli.andrea@gmail.com>
+Ankit raj ojha <anoj123anru@gmail.com>  ankit01ojha <anoj123anru@gmail.com>
+Cristian Mattarei <cristian.mattarei@gmail.com>  Cristian Mattarei <mattarei@stanford.edu>
+Samuele Gallerani <samuele@gallerani.com>  fontealpina <fontealpina@users.noreply.github.com>
+Samuele Gallerani <samuele@gallerani.com>  Gallerani <samuele@gallerani.com>
+Taylor Hodge <j.taylor.hodge@gmail.com>  Jason Taylor Hodge <j.taylor.hodge@gmail.com>
+Leonard Truong <lenny@stanford.edu>  Lenny Truong <lenny@stanford.edu>
+Lukas Dresel <lukas.dresel@cs.ucsb.edu>  Lukas-Dresel <Lukas-Dresel@users.noreply.github.com>
+Marco Gario <marco.gario@gmail.com>  marcogario <marco.gario@email.it>
+Marco Gario <marco.gario@gmail.com>  Marco Gario <marco.gario@email.it>
+Marco Gario <marco.gario@gmail.com>  Marco Gario <marcogario@github.com>
+Radomir Stevanovic <radomir.stevanovic@gmail.com>  Radomir Stevanovic <radomir@dwavesys.com>
+Yoni Zohar <yoni206@gmail.com>  yoni206 <yoni206@users.noreply.github.com>
+Yuri Malheiros <yurimalheiros@gmail.com>  yurimalheiros <yurimalheiros@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -19,3 +19,5 @@ Marco Gario <marco.gario@gmail.com>  Marco Gario <marcogario@github.com>
 Radomir Stevanovic <radomir.stevanovic@gmail.com>  Radomir Stevanovic <radomir@dwavesys.com>
 Yoni Zohar <yoni206@gmail.com>  yoni206 <yoni206@users.noreply.github.com>
 Yuri Malheiros <yurimalheiros@gmail.com>  yurimalheiros <yurimalheiros@gmail.com>
+Enrico Magnago <en.magnago@gmail.com> Enrico Magnago <EnricoMagnago@users.noreply.github.com>
+Enrico Magnago <en.magnago@gmail.com> en <en.magnago@gmail.com>

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -1,5 +1,6 @@
-We welcome any type of contribution. Have a look at our additional information [1]
-and please open an issue before starting any major activity, so that we can discuss
+We welcome any type of contribution. Have a look at our additional information
+(including signing the Contributor License Agreement) at [1].
+Please open an issue before starting any major activity, so that we can discuss
 the details.
 
 [1] http://pysmt.readthedocs.io/en/latest/development.html

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,24 +1,28 @@
-Alberto Griggio
-Alexey Ignatiev
-Anant Prasad
-Andrea Micheli
-Ankit raj ojha
-Cristian Mattarei
-Daniel Ricardo dos Santos
-Haozhong Zhang
+Ahmed Irfan <ahmed.irfan@alumni.unitn.it>
+Alastair Reid <alastair.d.reid@gmail.com>
+Alberto Griggio <griggio@fbk.eu>
+Alexey Ignatiev <aignatiev@ciencias.ulisboa.pt>
+Anant Prasad <Anantprsd5@gmail.com>
+Andrea Micheli <micheli.andrea@gmail.com>
+Ankit raj ojha <anoj123anru@gmail.com>
+Cristian Mattarei <cristian.mattarei@gmail.com>
+Daniel Ricardo dos Santos <danielricardo.santos@gmail.com>
+Haozhong Zhang <hzzhan9@gmail.com>
 Kangjing Huang
-Lenny Truong
-Lukas Dresel
-Marco Gario
-Mathias Preiner
-Nitish
-Radomir Stevanovic
-Samuele Gallerani
+Leonard Truong <lenny@stanford.edu>
+Lukas Dresel <lukas.dresel@cs.ucsb.edu>
+Makai Mann <makaim@stanford.edu>
+Marco Gario <marco.gario@gmail.com>
+Mathias Preiner <mathias.preiner@gmail.com>
+Matthew Venn  <matt@mattvenn.net>
+Nitish  <nkd.2195@gmail.com>
+Radomir Stevanovic <radomir.stevanovic@gmail.com>
 Samuel Kolb
-Sebastiano Mariani
-Suresh Gl
-Taylor Hodge
-Varun Patro
-Vijay Raghavan
-Yoni Zohar
-Yuri Malheiros
+Samuele Gallerani <samuele@gallerani.com>
+Sebastiano Mariani <mariani.sebastiano@gmail.com>
+Suresh Gl <sureshgl009@gmail.com>
+Taylor Hodge <j.taylor.hodge@gmail.com>
+Varun Patro <varun.kumar.patro@gmail.com>
+Vijay Raghavan <vijaysgr8@gmail.com>
+Yoni Zohar <yoni206@gmail.com>
+Yuri Malheiros <yurimalheiros@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -20,8 +20,8 @@ Mathias Preiner <mathias.preiner@gmail.com>
 Matthew Venn  <matt@mattvenn.net>
 Nitish  <nkd.2195@gmail.com>
 Radomir Stevanovic <radomir.stevanovic@gmail.com>
-Samuele Gallerani <samuele@gallerani.com>
 Samuel Kolb
+Samuele Gallerani <samuele@gallerani.com>
 Sebastiano Mariani <mariani.sebastiano@gmail.com>
 Suresh Gl <sureshgl009@gmail.com>
 Taylor Hodge <j.taylor.hodge@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@ Alberto Griggio <griggio@fbk.eu>
 Alexey Ignatiev <aignatiev@ciencias.ulisboa.pt>
 Anant Prasad <Anantprsd5@gmail.com>
 Andrea Micheli <micheli.andrea@gmail.com>
+Andres Noetzli <andres.noetzli@gmail.com>
 Ankit raj ojha <anoj123anru@gmail.com>
 Cristian Mattarei <cristian.mattarei@gmail.com>
 Daniel Ricardo dos Santos <danielricardo.santos@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,8 +6,8 @@ Anant Prasad <Anantprsd5@gmail.com>
 Andrea Micheli <micheli.andrea@gmail.com>
 Andres Noetzli <andres.noetzli@gmail.com>
 Ankit raj ojha <anoj123anru@gmail.com>
-Cristian Mattarei <cristian.mattarei@gmail.com>
 Caleb Donovick <donovick@cs.stanford.edu>
+Cristian Mattarei <cristian.mattarei@gmail.com>
 Daniel Ricardo dos Santos <danielricardo.santos@gmail.com>
 Enrico Magnago <en.magnago@gmail.com>
 Haozhong Zhang <hzzhan9@gmail.com>
@@ -20,8 +20,8 @@ Mathias Preiner <mathias.preiner@gmail.com>
 Matthew Venn  <matt@mattvenn.net>
 Nitish  <nkd.2195@gmail.com>
 Radomir Stevanovic <radomir.stevanovic@gmail.com>
-Samuel Kolb
 Samuele Gallerani <samuele@gallerani.com>
+Samuel Kolb
 Sebastiano Mariani <mariani.sebastiano@gmail.com>
 Suresh Gl <sureshgl009@gmail.com>
 Taylor Hodge <j.taylor.hodge@gmail.com>

--- a/ci/cla.sh
+++ b/ci/cla.sh
@@ -5,11 +5,11 @@ LC_COLLATE=C # Enforce known sort order
 
 committers=$(git shortlog -se HEAD | cut -f2,3 | sort)
 missing_authors=$(echo "$committers" | comm -13 CONTRIBUTORS -)
-missing_authors=$(echo ${missing_authors} | grep -v "Caleb Donovick <donovick@cs.stanford.edu>")
-missing_authors=$(echo ${missing_authors} | grep -v "Guillem Francès <guillem.frances@upf.edu>")
-missing_authors=$(echo ${missing_authors} | grep -v "Matthew Fernandez <matthew.fernandez@gmail.com>")
+missing_authors=$(echo ${missing_authors} | sed 's/Caleb Donovick <donovick@cs.stanford.edu>//' )
+missing_authors=$(echo ${missing_authors} | sed 's/Guillem Francès <guillem.frances@upf.edu>//' )
+missing_authors=$(echo ${missing_authors} | sed 's/Matthew Fernandez <matthew.fernandez@gmail.com>//' )
 
-if [ "$missing_authors" ]
+if [ -n "$missing_authors" ]
 then
   echo "$missing_authors" | awk '{print "::error file=CONTRIBUTORS,line=0::💥 MISSING: " $0}'
 
@@ -23,5 +23,4 @@ else
   echo "== Note: The following contributors were checked"
   echo "$(echo $committers | comm -12 CONTRIBUTORS -)"
   echo "All good!"
-  exit 0
 fi

--- a/ci/cla.sh
+++ b/ci/cla.sh
@@ -5,6 +5,9 @@ LC_COLLATE=C # Enforce known sort order
 
 committers=$(git shortlog -se HEAD | cut -f2,3 | sort)
 missing_authors=$(echo "$committers" | comm -13 CONTRIBUTORS -)
+missing_authors=$(echo ${missing_authors} | grep -v "Caleb Donovick <donovick@cs.stanford.edu>")
+missing_authors=$(echo ${missing_authors} | grep -v "Guillem Francès <guillem.frances@upf.edu>")
+missing_authors=$(echo ${missing_authors} | grep -v "Matthew Fernandez <matthew.fernandez@gmail.com>")
 
 if [ "$missing_authors" ]
 then

--- a/ci/cla.sh
+++ b/ci/cla.sh
@@ -21,6 +21,6 @@ then
   exit 1
 else
   echo "== Note: The following contributors were checked"
-  echo "$(echo $committers | comm -12 CONTRIBUTORS -)"
+  echo "$committers" | comm -12 CONTRIBUTORS -
   echo "All good!"
 fi

--- a/ci/cla.sh
+++ b/ci/cla.sh
@@ -4,23 +4,26 @@ set -e
 LC_COLLATE=C # Enforce known sort order
 
 committers=$(git shortlog -se HEAD | cut -f2,3 | sort)
-missing_authors=$(echo "$committers" | comm -13 CONTRIBUTORS -)
+
+# Sort contributors (different systems have slightly different soting logics)
+cat CONTRIBUTORS | sort > SCONTRIBUTORS
+missing_authors=$(echo "$committers" | comm -13 SCONTRIBUTORS -)
 missing_authors=$(echo ${missing_authors} | sed 's/Caleb Donovick <donovick@cs.stanford.edu>//' )
 missing_authors=$(echo ${missing_authors} | sed 's/Guillem Francès <guillem.frances@upf.edu>//' )
 missing_authors=$(echo ${missing_authors} | sed 's/Matthew Fernandez <matthew.fernandez@gmail.com>//' )
 
 if [ -n "$missing_authors" ]
 then
-  echo "$missing_authors" | awk '{print "::error file=CONTRIBUTORS,line=0::💥 MISSING: " $0}'
+  echo "$missing_authors" | awk '{print "::error file=SCONTRIBUTORS,line=0::💥 MISSING: " $0}'
 
   echo "💥 Some committers do NOT appear in CONTRIBUTORS 💥"
   echo ""
   echo "$missing_authors"
   echo "== Note: The following contributors are not committers. Do we need to update .mailmap? =="
-  echo "$committers" | comm -23 CONTRIBUTORS -
+  echo "$committers" | comm -23 SCONTRIBUTORS -
   exit 1
 else
   echo "== Note: The following contributors were checked"
-  echo "$committers" | comm -12 CONTRIBUTORS -
+  echo "$committers" | comm -12 SCONTRIBUTORS -
   echo "All good!"
 fi

--- a/ci/cla.sh
+++ b/ci/cla.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+LC_COLLATE=C # Enforce known sort order
+
+committers=$(git shortlog -se HEAD | cut -f2,3 | sort)
+missing_authors=$(echo "$committers" | comm -13 CONTRIBUTORS -)
+
+if [ "$missing_authors" ]
+then
+  echo "$missing_authors" | awk '{print "::error file=CONTRIBUTORS,line=0::💥 MISSING: " $0}'
+
+  echo "💥 Some committers do NOT appear in CONTRIBUTORS 💥"
+  echo ""
+  echo "$missing_authors"
+  echo "== Note: The following contributors are not committers. Do we need to update .mailmap? =="
+  echo "$committers" | comm -23 CONTRIBUTORS -
+  exit 1
+else
+  echo "== Note: The following contributors were checked"
+  echo "$(echo $committers | comm -12 CONTRIBUTORS -)"
+  echo "All good!"
+  exit 0
+fi

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -45,13 +45,10 @@ Certificate of Origin” approach as done by the Linux kernel. ::
       indefinitely and may be redistributed consistent with this project
       or the open source license(s) involved.
 
-During a Pull-Request you will be asked to complete the form at CLAHub:
-https://www.clahub.com/agreements/pysmt/pysmt . You will only have to
-complete this once, but this applies to **all** your contributions.
-
-If you are doing a drive-by patch (e.g., fixing a typo) and sending
-directly a patch, you can skip the CLA, by sending a signed patch. A
-signed patch can be obtained when committing using ``git commit -s``.
+During a Pull-Request you will be asked to edit the CONTRIBUTORS file to
+add your name and email address. By doing so, you agree to the CLA.
+You will only have to complete this once, but this applies to **all** your
+contributions.
 
 Tests
 ======

--- a/pysmt/__init__.py
+++ b/pysmt/__init__.py
@@ -16,7 +16,7 @@
 #   limitations under the License.
 #
 
-VERSION = (0, 9, 0)
+VERSION = (0, 9, 1, "dev", 1)
 
 # Try to provide human-readable version of latest commit for dev versions
 # E.g. v0.5.1-4-g49a49f2-wip


### PR DESCRIPTION
We require all contributors to submit a change to CONTRIBUTORS as a way to confirming acceptance of the CLA.

To check this, we compare the git log with the entries in the CONTRIBUTORS file.

Since users might have sent commits with different names/emails, we introduce a `.mailmap` to provide canonical names.

The CONTRIBUTORS data has been updated with the content of CLAHub.

We seem to be missing a few:
![image](https://user-images.githubusercontent.com/1058447/82739212-18edeb00-9d3e-11ea-9fef-f55ab6090556.png)


Require CLA:
* Caleb Donovick b0f031d9f595dddbd4febd3dd3bad487f3e112d9
* en.magnago 2b9a879ac9fbe9253d05655b3212dd0a13a37273

Typos in documentation (might consider whitelisting these changes)
* Guillem Francès 6562e2662496291a5578facecb140d7f41f8ab4d
* Matthew Fernandez 39e6d252239d63472b2a28a901bd0bcce42237dd
