### PR TITLE
Fix Boolector install script

### DIFF
--- a/pysmt/cmd/installers/btor.py
+++ b/pysmt/cmd/installers/btor.py
@@ -47,13 +47,12 @@ class BtorInstaller(SolverInstaller):
         import distutils.sysconfig as sysconfig
         import sys
         PYTHON_LIBRARY = os.environ.get('PYSMT_PYTHON_LIBDIR')
-        if not PYTHON_LIBRARY:
-            PYTHON_LIBRARY = sysconfig.get_config_var('LIBDIR')
         PYTHON_INCLUDE_DIR = sysconfig.get_python_inc()
         PYTHON_EXECUTABLE = sys.executable
-        CMAKE_OPTS = ' -DPYTHON_LIBRARY=' + PYTHON_LIBRARY
-        CMAKE_OPTS += ' -DPYTHON_INCLUDE_DIR=' + PYTHON_INCLUDE_DIR
+        CMAKE_OPTS = ' -DPYTHON_INCLUDE_DIR=' + PYTHON_INCLUDE_DIR
         CMAKE_OPTS += ' -DPYTHON_EXECUTABLE=' + PYTHON_EXECUTABLE
+        if PYTHON_LIBRARY:
+            CMAKE_OPTS += ' -DPYTHON_LIBRARY=' + PYTHON_LIBRARY
 
         # Unpack
         SolverInstaller.untar(os.path.join(self.base_dir, self.archive_name),


### PR DESCRIPTION
The install script for Boolector sets `-DPYTHON_LIBRARY` by reading
`sysconfig.get_config_var('LIBDIR')`, which returns the directory that
holds the Python library. This variable gets read by Boolector's build
system when calling `find_package(PythonLibs ...)`. The problem is that
CMake's `FindPythonLibs` doesn't expect a directory but rather the full
path to Python's library [0]. This results in warnings such as:

```
WARNING: Target "pyboolector" requests linking to directory "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib".  Targets may link only to libraries.  CMake is dropping the item.
```

and makes the build fail on macOS. When linking `pyboolector.so` the
linker fails due to missing references to symbols such as
`_PyBaseObject_Type`.

Additionally, setting `PYTHON_LIBRARY` should not be necessary since
CMake's documentation claims that [0]:

> If calling both `find_package(PythonInterp)` and
> `find_package(PythonLibs)`, call `find_package(PythonInterp)` first to
> get the currently active Python version by default with a consistent
> version of `PYTHON_LIBRARIES`.

Boolector does just that [1], so setting the `PYTHON_EXECUTABLE` should
be sufficient. This commit removes the call to
`sysconfig.get_config_var('LIBDIR')`. I have tested the installation on
both macOS and Arch Linux and it worked as expected.

[0] https://cmake.org/cmake/help/latest/module/FindPythonLibs.html
[1] https://github.com/Boolector/boolector/blob/03d76134f86170ab0767194c339fd080e92ad371/CMakeLists.txt#L132-L142

Signed-off-by: Andres Noetzli <andres.noetzli@gmail.com>