### PR TITLE
Handling of algebraic constants in simplify

### DIFF
--- a/pysmt/factory.py
+++ b/pysmt/factory.py
@@ -102,7 +102,7 @@ class Factory(object):
 
 
     def get_unsat_core_solver(self, name=None, logic=None,
-                              unsat_cores_mode="all"):
+                              unsat_cores_mode="all", **options):
         SolverClass, closer_logic = \
            self._get_solver_class(solver_list=self._all_unsat_core_solvers,
                                   solver_type="Solver supporting Unsat Cores",
@@ -113,7 +113,8 @@ class Factory(object):
         return SolverClass(environment=self.environment,
                            logic=closer_logic,
                            generate_models=True,
-                           unsat_cores_mode=unsat_cores_mode)
+                           unsat_cores_mode=unsat_cores_mode,
+                           **options)
 
     def get_quantifier_eliminator(self, name=None, logic=None):
         SolverClass, closer_logic = \
@@ -439,10 +440,11 @@ class Factory(object):
                                **options)
 
     def UnsatCoreSolver(self, name=None, logic=None,
-                        unsat_cores_mode="all"):
+                        unsat_cores_mode="all", **options):
         return self.get_unsat_core_solver(name=name,
                                           logic=logic,
-                                          unsat_cores_mode=unsat_cores_mode)
+                                          unsat_cores_mode=unsat_cores_mode,
+                                          **options)
 
     def QuantifierEliminator(self, name=None, logic=None):
         return self.get_quantifier_eliminator(name=name, logic=logic)

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -191,12 +191,13 @@ class TheoryOracle(walkers.DagWalker):
 
     @walkers.handles(op.REAL_CONSTANT, op.BOOL_CONSTANT)
     @walkers.handles(op.INT_CONSTANT, op.BV_CONSTANT)
+    @walkers.handles(op.ALGEBRAIC_CONSTANT)
     @walkers.handles(op.STR_CONSTANT)
     def walk_constant(self, formula, args, **kwargs):
         """Returns a new theory object with the type of the constant."""
         #pylint: disable=unused-argument
         theory_out = Theory()
-        if formula.is_real_constant():
+        if formula.is_real_constant() or formula.is_algebraic_constant():
             theory_out.real_arithmetic = True
             theory_out.real_difference = True
         elif formula.is_int_constant():

--- a/pysmt/shortcuts.py
+++ b/pysmt/shortcuts.py
@@ -910,7 +910,7 @@ def Solver(name=None, logic=None, **kwargs):
                                     logic=logic,
                                     **kwargs)
 
-def UnsatCoreSolver(name=None, logic=None, unsat_cores_mode="all"):
+def UnsatCoreSolver(name=None, logic=None, unsat_cores_mode="all", **kwargs):
     """Returns a solver supporting unsat core extraction.
 
     :param name: Specify the name of the solver
@@ -921,7 +921,8 @@ def UnsatCoreSolver(name=None, logic=None, unsat_cores_mode="all"):
     """
     return get_env().factory.UnsatCoreSolver(name=name,
                                              logic=logic,
-                                             unsat_cores_mode=unsat_cores_mode)
+                                             unsat_cores_mode=unsat_cores_mode,
+                                             **kwargs)
 
 
 def QuantifierEliminator(name=None, logic=None):

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -354,8 +354,12 @@ class Simplifier(pysmt.walkers.DagWalker):
         new_args = sorted(new_args, key=FNode.node_id)
         return self.manager.Times(new_args)
 
-
     def walk_pow(self, formula, args, **kwargs):
+        if args[0].is_algebraic_constant():
+            from pysmt.constants import Numeral
+            l = args[0].constant_value()
+            r = args[1].constant_value()
+            return self.manager._Algebraic(Numeral(l**r))
         if args[0].is_real_constant():
             l = args[0].constant_value()
             r = args[1].constant_value()
@@ -371,6 +375,13 @@ class Simplifier(pysmt.walkers.DagWalker):
 
         sl = args[0]
         sr = args[1]
+
+        if sl.is_algebraic_constant() and \
+           sr.is_algebraic_constant():
+            from pysmt.constants import Numeral
+            l = sl.constant_value()
+            r = sr.constant_value()
+            return self.mananger._Algebraic(Numeral(l - r))
 
         if sl.is_real_constant() and sr.is_real_constant():
             l = sl.constant_value()

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -285,12 +285,10 @@ class Simplifier(pysmt.walkers.DagWalker):
         new_pos_args = []
         new_neg_args = []
         constant_add = 0
+        stack = list(args)
         ttype = self.env.stc.get_type(args[0])
-        pysmt_num = self.manager.Real if ttype.is_real_type() \
-            else self.manager.Int
         is_algebraic = False
         symb_to_coef = defaultdict(int)
-        stack = list(args)
         while len(stack) > 0:
             x = stack.pop()
             if x.is_constant():
@@ -300,10 +298,7 @@ class Simplifier(pysmt.walkers.DagWalker):
             elif x.is_symbol():
                 symb_to_coef[x] += 1
             elif x.is_plus():
-                stack.extend(x.args())
-            elif x.is_minus():
-                stack.append(x.arg(0))
-                stack.append(self.manager.Times(pysmt_num(-1), x.arg(1)))
+                stack += x.args()
             elif x.is_times():
                 coef = 1
                 symbs = []
@@ -320,6 +315,9 @@ class Simplifier(pysmt.walkers.DagWalker):
                 symb_to_coef[symbs] += coef
             else:
                 new_pos_args.append(x)
+
+        pysmt_num = self.manager.Real if ttype.is_real_type() \
+            else self.manager.Int
 
         new_pos_args.extend([self.manager.Times(k, pysmt_num(v))
                              if v != 1 else k

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -15,8 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from collections import defaultdict
-
 from six.moves import xrange
 
 import pysmt.walkers
@@ -282,75 +280,37 @@ class Simplifier(pysmt.walkers.DagWalker):
         return self.manager.Exists(varset, sf)
 
     def walk_plus(self, formula, args, **kwargs):
-        new_pos_args = []
-        new_neg_args = []
+        new_args = []
         constant_add = 0
         stack = list(args)
         ttype = self.env.stc.get_type(args[0])
         is_algebraic = False
-        symb_to_coef = defaultdict(int)
         while len(stack) > 0:
             x = stack.pop()
             if x.is_constant():
                 if x.is_algebraic_constant():
                     is_algebraic = True
                 constant_add += x.constant_value()
-            elif x.is_symbol():
-                symb_to_coef[x] += 1
             elif x.is_plus():
                 stack += x.args()
-            elif x.is_times():
-                coef = 1
-                symbs = []
-                factors = list(x.args())
-                for arg in factors:
-                    if arg.is_times():
-                        factors.extend(arg.args())
-                    elif arg.is_constant():
-                        coef *= arg.constant_value()
-                    else:
-                        symbs.append(arg)
-                symbs.sort()
-                symbs = self.manager.Times(symbs)
-                symb_to_coef[symbs] += coef
             else:
-                new_pos_args.append(x)
-
-        pysmt_num = self.manager.Real if ttype.is_real_type() \
-            else self.manager.Int
-
-        new_pos_args.extend([self.manager.Times(k, pysmt_num(v))
-                             if v != 1 else k
-                             for k, v in symb_to_coef.items() if v > 0])
-        new_neg_args.extend([self.manager.Times(k, pysmt_num(-v))
-                             if v != -1 else k
-                             for k, v in symb_to_coef.items() if v < 0])
+                new_args.append(x)
 
         const = None
         if is_algebraic:
             from pysmt.constants import Numeral
             const = self.manager._Algebraic(Numeral(constant_add))
+        elif ttype.is_real_type():
+            const = self.manager.Real(constant_add)
         else:
-            const = pysmt_num(constant_add)
+            assert ttype.is_int_type()
+            const = self.manager.Int(constant_add)
 
-        if len(new_pos_args) == 0 and len(new_neg_args) == 0:
+        if len(new_args) == 0:
             return const
-        elif constant_add != 0:
-            new_pos_args.append(const)
-
-        res = None
-        if new_pos_args:
-            res = self.manager.Plus(new_pos_args)
-        if new_neg_args:
-            neg = self.manager.Plus(new_neg_args)
-            if res:
-                res = self.manager.Minus(res, neg)
-            else:
-                m_one = self.manager.Real(-1) if ttype.is_real_type() \
-                        else self.manager.Int(-1)
-                res = self.manager.Times(m_one, neg)
-
-        return res
+        elif not const.is_zero():
+            new_args.append(const)
+        return self.manager.Plus(new_args)
 
     def walk_times(self, formula, args, **kwargs):
         new_args = []

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -335,11 +335,21 @@ class Simplifier(pysmt.walkers.DagWalker):
         if not const.is_zero():
             to_sum.append(const)
 
-        res = self.manager.Plus(to_sum)
+        assert to_sum or to_sub
+
+        res = self.manager.Plus(to_sum) if to_sum else None
 
         if to_sub:
             sub = self.manager.Plus(to_sub)
-            res = self.manager.Minus(res, sub)
+            if res:
+                res = self.manager.Minus(res, sub)
+            else:
+                if ttype.is_int_type():
+                    m_1 = self.manager.Int(-1)
+                else:
+                    assert ttype.is_real_type()
+                    m_1 = self.manager.Real(-1)
+                res = self.manager.Times(m_1, sub)
         return res
 
     def walk_times(self, formula, args, **kwargs):

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -395,19 +395,22 @@ class Simplifier(pysmt.walkers.DagWalker):
         return self.manager.Times(new_args)
 
     def walk_pow(self, formula, args, **kwargs):
+        if args[0].is_real_constant():
+            l = args[0].constant_value()
+            r = args[1].constant_value()
+            return self.manager.Real(l**r)
+
+        if args[0].is_int_constant():
+            l = args[0].constant_value()
+            r = args[1].constant_value()
+            return self.manager.Int(l**r)
+
         if args[0].is_algebraic_constant():
             from pysmt.constants import Numeral
             l = args[0].constant_value()
             r = args[1].constant_value()
             return self.manager._Algebraic(Numeral(l**r))
-        if args[0].is_real_constant():
-            l = args[0].constant_value()
-            r = args[1].constant_value()
-            return self.manager.Real(l**r)
-        elif args[0].is_int_constant():
-            l = args[0].constant_value()
-            r = args[1].constant_value()
-            return self.manager.Int(l**r)
+
         return self.manager.Pow(args[0], args[1])
 
     def walk_minus(self, formula, args, **kwargs):
@@ -415,13 +418,6 @@ class Simplifier(pysmt.walkers.DagWalker):
 
         sl = args[0]
         sr = args[1]
-
-        if sl.is_algebraic_constant() and \
-           sr.is_algebraic_constant():
-            from pysmt.constants import Numeral
-            l = sl.constant_value()
-            r = sr.constant_value()
-            return self.mananger._Algebraic(Numeral(l - r))
 
         if sl.is_real_constant() and sr.is_real_constant():
             l = sl.constant_value()
@@ -432,6 +428,13 @@ class Simplifier(pysmt.walkers.DagWalker):
             l = sl.constant_value()
             r = sr.constant_value()
             return self.manager.Int(l - r)
+
+        if sl.is_algebraic_constant() and \
+           sr.is_algebraic_constant():
+            from pysmt.constants import Numeral
+            l = sl.constant_value()
+            r = sr.constant_value()
+            return self.mananger._Algebraic(Numeral(l - r))
 
         if sr.is_constant() and sr.is_zero():
             return sl

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -280,47 +280,37 @@ class Simplifier(pysmt.walkers.DagWalker):
         return self.manager.Exists(varset, sf)
 
     def walk_plus(self, formula, args, **kwargs):
-        is_real = any(x.is_real_constant() for x in args)
-        is_int = any(x.is_int_constant() for x in args)
-        assert not (is_real and is_int)
-
-        if all(x.is_constant() for x in args):
-            res = sum(x.constant_value() for x in args)
-            if is_real:
-                return self.manager.Real(res)
+        new_args = []
+        constant_add = 0
+        stack = list(args)
+        ttype = self.env.stc.get_type(args[0])
+        is_algebraic = False
+        while len(stack) > 0:
+            x = stack.pop()
+            if x.is_constant():
+                if x.is_algebraic_constant():
+                    is_algebraic = True
+                constant_add += x.constant_value()
+            elif x.is_plus():
+                stack += x.args()
             else:
-                return self.manager.Int(res)
+                new_args.append(x)
 
-        ns = [x for x in args if not x.is_constant()]
-        if len(ns) < len(args):
-            num = sum(x.constant_value() for x in args if x.is_constant())
-            if num != 0:
-                if is_real:
-                    ns.append(self.manager.Real(num))
-                else:
-                    ns.append(self.manager.Int(num))
+        const = None
+        if is_algebraic:
+            from pysmt.constants import Numeral
+            const = self.manager._Algebraic(Numeral(constant_add))
+        elif ttype.is_real_type():
+            const = self.manager.Real(constant_add)
+        else:
+            assert ttype.is_int_type()
+            const = self.manager.Int(constant_add)
 
-        if len(ns) == 2:
-            minus_one = self.manager.Real(-1) if is_real else \
-                        self.manager.Int(-1)
-            # (+ (* -1 X) Y) => (- Y X)
-            if ns[0].is_times() and len(ns[0].args()) == 2:
-                t = ns[0]
-                if t.arg(0) == minus_one:
-                    return self.manager.Minus(ns[1], t.arg(1))
-                if t.arg(1) == minus_one:
-                    return self.manager.Minus(ns[1], t.arg(0))
-            # (+ Y (* -1 X)) => (- Y X)
-            if ns[1].is_times() and len(ns[0].args()) == 2:
-                t = ns[1]
-                if t.arg(0) == minus_one:
-                    return self.manager.Minus(ns[0], t.arg(1))
-                if t.arg(1) == minus_one:
-                    return self.manager.Minus(ns[0], t.arg(0))
-
-        if len(ns) == 1:
-            return ns[0]
-        return self.manager.Plus(ns)
+        if len(new_args) == 0:
+            return const
+        elif not const.is_zero():
+            new_args.append(const)
+        return self.manager.Plus(new_args)
 
     def walk_times(self, formula, args, **kwargs):
         new_args = []

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -285,10 +285,12 @@ class Simplifier(pysmt.walkers.DagWalker):
         new_pos_args = []
         new_neg_args = []
         constant_add = 0
-        stack = list(args)
         ttype = self.env.stc.get_type(args[0])
+        pysmt_num = self.manager.Real if ttype.is_real_type() \
+            else self.manager.Int
         is_algebraic = False
         symb_to_coef = defaultdict(int)
+        stack = list(args)
         while len(stack) > 0:
             x = stack.pop()
             if x.is_constant():
@@ -298,7 +300,10 @@ class Simplifier(pysmt.walkers.DagWalker):
             elif x.is_symbol():
                 symb_to_coef[x] += 1
             elif x.is_plus():
-                stack += x.args()
+                stack.extend(x.args())
+            elif x.is_minus():
+                stack.append(x.arg(0))
+                stack.append(self.manager.Times(pysmt_num(-1), x.arg(1)))
             elif x.is_times():
                 coef = 1
                 symbs = []
@@ -315,9 +320,6 @@ class Simplifier(pysmt.walkers.DagWalker):
                 symb_to_coef[symbs] += coef
             else:
                 new_pos_args.append(x)
-
-        pysmt_num = self.manager.Real if ttype.is_real_type() \
-            else self.manager.Int
 
         new_pos_args.extend([self.manager.Times(k, pysmt_num(v))
                              if v != 1 else k

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -827,6 +827,14 @@ class MSatConverter(Converter, DagWalker):
         rep = str(formula.constant_value())
         return mathsat.msat_make_number(self.msat_env(), rep)
 
+    def walk_algebraic_constant(self, formula, **kwargs):
+        val = formula.constant_value()
+        if val.is_irrational():
+            raise ConvertExpressionError("Cannot convert irrational constant")
+        num, den = val.numerator(), val.denominator()
+        rep = "{}/{}".format(str(num), str(den))
+        return mathsat.msat_make_number(self.msat_env(), rep)
+
     def walk_bool_constant(self, formula, **kwargs):
         if formula.constant_value():
             return mathsat.msat_make_true(self.msat_env())

--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -658,6 +658,14 @@ class Z3Converter(Converter, DagWalker):
         z3.Z3_inc_ref(self.ctx.ref(), z3term)
         return z3term
 
+    def walk_algebraic_constant(self, formula, **kwargs):
+        rep = str(formula.constant_value())
+        z3term = z3.Z3_mk_numeral(self.ctx.ref(),
+                                  rep,
+                                  self.z3RealSort.ast)
+        z3.Z3_inc_ref(self.ctx.ref(), z3term)
+        return z3term
+
     def walk_real_constant(self, formula, **kwargs):
         frac = formula.constant_value()
         n,d = frac.numerator, frac.denominator

--- a/pysmt/test/test_rewritings.py
+++ b/pysmt/test/test_rewritings.py
@@ -257,7 +257,7 @@ class TestRewritings(TestCase):
             except SolverReturnedUnknownResultError:
                 ok = not logic.quantifier_free
             self.assertTrue(ok)
-        
+
         f = And(LT(Real(4), Times(x, x)), Equals(y, x), Equals(y, Real(1)))
         fp = propagate_toplevel(f)
         self.assertTrue(fp.is_false())
@@ -332,7 +332,6 @@ class TestRewritings(TestCase):
                       s,
                       Real(-1))
         self.assertValid(Equals(fp, target), fp)
-        self.assertTrue(fp.is_plus(), fp)
 
     @skipIfNoSolverForLogic(QF_NRA)
     def test_times_distributivity_smtlib_nra(self):

--- a/pysmt/test/test_simplify.py
+++ b/pysmt/test/test_simplify.py
@@ -161,6 +161,23 @@ class TestSimplify(TestCase):
         self.assertValid(Equals(expr, res))
         self.assertIn(m_3, res.args())
 
+    @skipIfSolverNotAvailable("z3")
+    def test_times_algebraic(self):
+        from pysmt.constants import Numeral
+        env = get_env()
+        mgr = env.formula_manager
+        r0 = Symbol("r0", REAL)
+        p_2 = Real(2)
+        m_5 = mgr._Algebraic(Numeral(-5))
+        m_10 = mgr._Algebraic(Numeral(-10))
+
+        # -5 * r0 * 2
+        expr = Times(m_5, r0, p_2)
+        res = expr.simplify()
+        self.assertValid(Equals(expr, res))
+        self.assertIn(m_10, res.args())
+
+
     def test_and_flattening(self):
         x,y,z = (Symbol(name) for name in "xyz")
         f1 = And(x, y, z)

--- a/pysmt/test/test_simplify.py
+++ b/pysmt/test/test_simplify.py
@@ -145,6 +145,22 @@ class TestSimplify(TestCase):
                 # unexpected expression type.
                 self.assertTrue(False)
 
+    @skipIfSolverNotAvailable("z3")
+    def test_plus_algebraic(self):
+        from pysmt.constants import Numeral
+        env = get_env()
+        mgr = env.formula_manager
+        r0 = Symbol("r0", REAL)
+        p_2 = Real(2)
+        m_5 = mgr._Algebraic(Numeral(-5))
+        m_3 = mgr._Algebraic(Numeral(-3))
+
+        # r0 + 2 - 5
+        expr = Plus(r0, p_2, m_5)
+        res = expr.simplify()
+        self.assertValid(Equals(expr, res))
+        self.assertIn(m_3, res.args())
+
     def test_and_flattening(self):
         x,y,z = (Symbol(name) for name in "xyz")
         f1 = And(x, y, z)

--- a/pysmt/test/test_simplify.py
+++ b/pysmt/test/test_simplify.py
@@ -115,6 +115,7 @@ class TestSimplify(TestCase):
         f = f.simplify()
         self.assertNotIn(Real(1), f.args())
 
+    @skipIfSolverNotAvailable("z3")
     def test_plus_negatives(self):
         r0 = Symbol("r0", REAL)
         r1 = Symbol("r1", REAL)
@@ -144,6 +145,19 @@ class TestSimplify(TestCase):
             elif not curr.is_symbol():
                 # unexpected expression type.
                 self.assertTrue(False)
+
+    @skipIfSolverNotAvailable("z3")
+    def test_sum_all_negatives(self):
+        r0 = Symbol("r0", REAL)
+        r1 = Symbol("r1", REAL)
+        m_1 = Real(-1)
+
+        # -4 * r0 + (-1) * r1
+        neg_r1 = Times(m_1, r1)
+        m_4_r0 = Times(Real(-4), r0)
+        expr = Plus(m_4_r0, neg_r1)
+        res = expr.simplify()
+        self.assertValid(Equals(expr, res))
 
     @skipIfSolverNotAvailable("z3")
     def test_plus_algebraic(self):

--- a/pysmt/test/test_simplify.py
+++ b/pysmt/test/test_simplify.py
@@ -20,8 +20,8 @@ import pytest
 from pysmt.test import TestCase, skipIfSolverNotAvailable, main
 from pysmt.test.examples import get_example_formulae
 from pysmt.environment import get_env
-from pysmt.shortcuts import (Array, Store, Int, Symbol, Plus, Minus, Times,
-                             Real, Equals, Iff, And, Or, Not, FALSE, TRUE)
+from pysmt.shortcuts import (Array, Store, Int, Iff, Symbol, Plus, Equals, And,
+                             Real, Times, Not, FALSE, Or, TRUE)
 from pysmt.typing import INT, REAL
 from pysmt.simplifier import BddSimplifier
 from pysmt.logics import QF_BOOL
@@ -114,41 +114,6 @@ class TestSimplify(TestCase):
         f = Times(r, r, Real(1))
         f = f.simplify()
         self.assertNotIn(Real(1), f.args())
-
-
-    def test_simplify_times_minus_one_in_plus(self):
-        r0 = Symbol("r0", REAL)
-        r1 = Symbol("r1", REAL)
-        m_1 = Real(-1)
-        orig = Plus(r0, Times(r1, m_1))
-        simpl = orig.simplify()
-        self.assertEqual(simpl, Minus(r0, r1))
-
-
-    def test_simplify_coefficients_to_zero(self):
-        r0 = Symbol("r0", REAL)
-        m_2 = Real(-2)
-        p_2 = Real(2)
-        orig = Plus(Times(p_2, r0), Times(m_2, r0))
-        simpl = orig.simplify()
-        self.assertEqual(simpl, Real(0))
-
-    def test_simplify_coefficients(self):
-        r0 = Symbol("r0", REAL)
-        r1 = Symbol("r1", REAL)
-        r0r1 = Symbol("r0r1", REAL)
-        m_4 = Real(-5)
-        p_2 = Real(2)
-        p_3 = Real(3)
-        p_8 = Real(8)
-        orig = Plus(Times(m_4, r0), Times(p_3, r1))
-        orig = Plus(orig, Times(p_2, p_3, r0))
-        orig = Minus(orig, Times(p_3, r0r1))
-        orig = Plus(orig, Times(m_4, r0r1))
-        simpl = orig.simplify()
-        expected = Minus(Plus(Times(r1, p_3), r0), Times(r0r1, p_8))
-        self.assertEquals(simpl, expected)
-        self.assertValid(Equals(simpl, orig))
 
 
     def test_and_flattening(self):

--- a/pysmt/test/test_simplify.py
+++ b/pysmt/test/test_simplify.py
@@ -115,6 +115,35 @@ class TestSimplify(TestCase):
         f = f.simplify()
         self.assertNotIn(Real(1), f.args())
 
+    def test_plus_negatives(self):
+        r0 = Symbol("r0", REAL)
+        r1 = Symbol("r1", REAL)
+        p_1 = Real(1)
+        m_1 = Real(-1)
+        p_2 = Real(2)
+        m_4 = Real(-4)
+
+        # 4 * r0 + (-1) * r1 + 2 - 4
+        neg_r1 = Times(m_1, r1)
+        m_4_r0 = Times(Real(4), r0)
+        expr = Plus(m_4_r0, neg_r1, p_2, m_4)
+        res = expr.simplify()
+        self.assertValid(Equals(expr, res))
+        stack = [res]
+        while stack:
+            curr = stack.pop()
+            if curr.is_plus():
+                stack.extend(curr.args())
+            elif curr.is_minus():
+                stack.extend(curr.args())
+            elif curr.is_times():
+                stack.extend(curr.args())
+            elif curr.is_constant():
+                self.assertNotEqual(curr, m_1)
+                self.assertNotEqual(curr, p_1)
+            elif not curr.is_symbol():
+                # unexpected expression type.
+                self.assertTrue(False)
 
     def test_and_flattening(self):
         x,y,z = (Symbol(name) for name in "xyz")

--- a/pysmt/walkers/identitydag.py
+++ b/pysmt/walkers/identitydag.py
@@ -36,6 +36,9 @@ class IdentityDagWalker(DagWalker):
         return self.mgr.Symbol(formula.symbol_name(),
                                formula.symbol_type())
 
+    def walk_algebraic_constant(self, formula, args, **kwargs):
+        return self.mgr._Algebraic(formula.constant_value())
+
     def walk_real_constant(self, formula, args, **kwargs):
         return self.mgr.Real(formula.constant_value())
 


### PR DESCRIPTION
I found an issue in which the simplify procedure crashed because it could not handle an algebraic constant.
In my case the expression to be simplified was an addition.
The code `res = sum(x.constant_value() for x in args)` was returning a res of type z3.Numeral, which the later call to `self.manager.Real(res)` could not handle.

I copy pasted the structure used in walk_times for walk_plus, and tried to handle the algebraic constant also in the walk for the pow and minus operators.

I added the `walk_algebraic_constant` method to the identity walker.

This happened while using z3 as SMT solver.
The converter in z3.py was not able to handle node of type algebraic constant, I tried to implement it. I am not sure whether this is the correct or best way to implement it. In my use cases it seems to work. 


In addition, I have also added the possibility to specify some options for the UnsatCoreSolver.