### PR TITLE
Integer div

### DIFF
--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -262,7 +262,9 @@ class FormulaManager(object):
 
     def Div(self, left, right):
         """ Creates an expression of the form: left / right """
-        if right.is_constant(types.REAL, 0) and self.env.enable_div_by_0:
+        if (right.is_constant(types.REAL, 0) or
+            right.is_constant(types.INT, 0)) \
+           and self.env.enable_div_by_0:
             # Allow division by 0 byt warn the user
             # This can only happen in non-linear logics
             warnings.warn("Warning: Division by 0")
@@ -270,8 +272,6 @@ class FormulaManager(object):
             # If right is a constant we rewrite as left * 1/right
             inverse = Fraction(1) / right.constant_value()
             return self.Times(left, self.Real(inverse))
-        elif right.is_constant(types.INT):
-            raise NotImplementedError
 
         # This is a non-linear expression
         return self.create_node(node_type=op.DIV,

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -16,6 +16,7 @@
 #   limitations under the License.
 #
 from six.moves import xrange
+import math
 
 import pysmt.walkers
 from pysmt.walkers import handles
@@ -982,7 +983,13 @@ class Simplifier(pysmt.walkers.DagWalker):
                 return self.manager.Real(l / r)
             else:
                 assert sl.is_int_constant()
-                return self.manager.Int(l / r)
+                # smtlib2 semantics of integer division:
+                # l > 0 : l / r == floor(float(l) / r)
+                # l < 0 : l / r == ceil(float(l) / r)
+                if l > 0:
+                    return self.manager.Int(math.floor(float(l) / r))
+                if l < 0:
+                    return self.manager.Int(math.ceil(float(l) / r))
 
         if sl.is_constant():
             if sl.is_zero():

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -405,7 +405,6 @@ class MSatConverter(Converter, DagWalker):
             mathsat.MSAT_TAG_LEQ: self._back_adapter(self.mgr.LE),
             mathsat.MSAT_TAG_PLUS: self._back_adapter(self.mgr.Plus),
             mathsat.MSAT_TAG_TIMES: self._back_adapter(self.mgr.Times),
-            mathsat.MSAT_TAG_DIVIDE: self._back_adapter(self.mgr.Div),
             mathsat.MSAT_TAG_BV_MUL: self._back_adapter(self.mgr.BVMul),
             mathsat.MSAT_TAG_BV_ADD: self._back_adapter(self.mgr.BVAdd),
             mathsat.MSAT_TAG_BV_UDIV: self._back_adapter(self.mgr.BVUDiv),
@@ -461,7 +460,6 @@ class MSatConverter(Converter, DagWalker):
             mathsat.MSAT_TAG_LEQ: self._sig_most_generic_bool_binary,
             mathsat.MSAT_TAG_PLUS:  self._sig_most_generic_bool_binary,
             mathsat.MSAT_TAG_TIMES: self._sig_most_generic_bool_binary,
-            mathsat.MSAT_TAG_DIVIDE: self._sig_most_generic_bool_binary,
             mathsat.MSAT_TAG_BV_MUL: self._sig_binary,
             mathsat.MSAT_TAG_BV_ADD: self._sig_binary,
             mathsat.MSAT_TAG_BV_UDIV:self._sig_binary,
@@ -981,29 +979,6 @@ class MSatConverter(Converter, DagWalker):
             else:
                 res = mathsat.msat_make_times(self.msat_env(), res, x)
         return res
-
-    def walk_div(self, formula, args, **kwargs):
-        if self.env.stc.get_type(formula).is_real_type():
-            return mathsat.msat_make_divide(self.msat_env(), args[0], args[1])
-        assert self.env.stc.get_type(formula).is_int_type()
-        # smtlib2 semantics: den >= 0 ? floor(num / den) : ceil(num / den)
-        # In the following we rewrite ceil(a) as -floor(-a)
-        num = args[0]
-        den = args[1]
-        zero = mathsat.msat_make_number(self.msat_env(), "0")
-        neg = mathsat.msat_make_number(self.msat_env(), "-1")
-        # den >= 0
-        cond = mathsat.msat_make_leq(self.msat_env(), zero, den)
-        # floor(num / den)
-        div = mathsat.msat_make_divide(self.msat_env(), num, den)
-        div = mathsat.msat_make_floor(self.msat_env(), div)
-        # - floor(num / -den)
-        n_div = mathsat.msat_make_times(self.msat_env(), neg, den)
-        n_div = mathsat.msat_make_divide(self.msat_env(), num, n_div)
-        n_div = mathsat.msat_make_floor(self.msat_env(), n_div)
-        n_div = mathsat.msat_make_times(self.msat_env(), neg, n_div)
-        # den >= 0 ? floor(num / den) : - floor(num / -den)
-        return mathsat.msat_make_term_ite(self.msat_env(), cond, div, n_div)
 
     def walk_function(self, formula, args, **kwargs):
         name = formula.function_name()

--- a/pysmt/test/test_nia.py
+++ b/pysmt/test/test_nia.py
@@ -18,27 +18,75 @@
 from pysmt.shortcuts import *
 from pysmt.typing import INT, REAL, FunctionType
 from pysmt.test import TestCase, main
-from pysmt.logics import QF_UFNIA, UFNIA
+from pysmt.logics import QF_NIA, NIA
+
 
 class TestNIA(TestCase):
 
-    def test_nia_const_div_const(self):
-        """Integer division between constants"""
+    def test_nia_pos_const_div_pos_const(self):
+        """Integer division between positive constants"""
         a = Symbol("a", INT)
         i_2 = Int(2)
         i_5 = Int(5)
 
-        # a = 5/2
+        # a = 5 / 2 = 2
         check = And(Equals(a, Div(i_5, i_2)))
-        for sname in get_env().factory.all_solvers(logic=QF_UFNIA):
+        for sname in get_env().factory.all_solvers(logic=QF_NIA):
             with Solver(name=sname) as s:
                 s.add_assertion(check)
                 c = s.solve()
                 self.assertTrue(c)
                 self.assertEqual(s.get_value(a), i_2)
 
-    def test_nia_symb_div_const(self):
-        """Symbol divided by constant"""
+    def test_nia_pos_const_div_neg_const(self):
+        """Integer division between positive and negative constants"""
+        a = Symbol("a", INT)
+        m_2 = Int(-2)
+        i_5 = Int(5)
+
+        # a = 5 / (-2) = -2
+        check = And(Equals(a, Div(i_5, m_2)))
+        for sname in get_env().factory.all_solvers(logic=QF_NIA):
+            with Solver(name=sname) as s:
+                s.add_assertion(check)
+                c = s.solve()
+                self.assertTrue(c)
+                self.assertEqual(s.get_value(a), m_2)
+
+    def test_nia_neg_const_div_pos_const(self):
+        """Integer division between negative and positive constants"""
+        a = Symbol("a", INT)
+        m_5 = Int(-5)
+        m_3 = Int(-3)
+        i_2 = Int(2)
+
+        # a = -5 / 2 = -3
+        check = And(Equals(a, Div(m_5, i_2)))
+        for sname in get_env().factory.all_solvers(logic=QF_NIA):
+            with Solver(name=sname) as s:
+                s.add_assertion(check)
+                c = s.solve()
+                self.assertTrue(c)
+                self.assertEqual(s.get_value(a), m_3)
+
+    def test_nia_neg_const_div_neg_const(self):
+        """Integer division between negative constants"""
+        a = Symbol("a", INT)
+        m_5 = Int(-5)
+        m_2 = Int(-2)
+        i_3 = Int(3)
+
+        # a = -5 / (-2) = 3
+        check = And(Equals(a, Div(m_5, m_2)))
+        for sname in get_env().factory.all_solvers(logic=QF_NIA):
+            with Solver(name=sname) as s:
+                s.add_assertion(check)
+                c = s.solve()
+                self.assertTrue(c)
+                self.assertEqual(s.get_value(a), i_3)
+
+    def test_nia_pos_symb_div_pos_const(self):
+        """Positive symbol divided by positive constant"""
         a = Symbol("a", INT)
         i_2 = Int(2)
         i_3 = Int(3)
@@ -47,12 +95,65 @@ class TestNIA(TestCase):
 
         # a > 6 & a/2 = 3
         check = And(GT(a, i_6), Equals(Div(a, i_2), i_3))
-        for sname in get_env().factory.all_solvers(logic=QF_UFNIA):
+        for sname in get_env().factory.all_solvers(logic=QF_NIA):
             with Solver(name=sname) as s:
                 s.add_assertion(check)
                 c = s.solve()
                 self.assertTrue(c)
                 self.assertEqual(s.get_value(a), i_7)
+
+    def test_nia_pos_symb_div_neg_const(self):
+        """Positive symbol divided by negative constant"""
+        a = Symbol("a", INT)
+        m_2 = Int(-2)
+        m_3 = Int(-3)
+        i_6 = Int(6)
+        i_7 = Int(7)
+
+        # a > 6 & a / -2 = -3
+        check = And(GT(a, i_6), Equals(Div(a, m_2), m_3))
+        for sname in get_env().factory.all_solvers(logic=QF_NIA):
+            with Solver(name=sname) as s:
+                s.add_assertion(check)
+                c = s.solve()
+                self.assertTrue(c)
+                self.assertEqual(s.get_value(a), i_7)
+
+    def test_nia_neg_symb_div_pos_const(self):
+        """Negative symbol divided by positive constant"""
+        a = Symbol("a", INT)
+        i_2 = Int(2)
+        m_4 = Int(-4)
+        m_6 = Int(6)
+        m_7 = Int(-7)
+        m_8 = Int(-8)
+
+        # a != -8 & a < -6 & a/2 = -4
+        check = And(Not(Equals(a, m_8)), LT(a, m_6), Equals(Div(a, i_2), m_4))
+        for sname in get_env().factory.all_solvers(logic=QF_NIA):
+            with Solver(name=sname) as s:
+                s.add_assertion(check)
+                c = s.solve()
+                self.assertTrue(c)
+                self.assertEqual(s.get_value(a), m_7)
+
+    def test_nia_neg_symb_div_neg_const(self):
+        """Negative symbol divided by negative constant"""
+        a = Symbol("a", INT)
+        m_2 = Int(-2)
+        i_4 = Int(4)
+        m_6 = Int(6)
+        m_7 = Int(-7)
+        m_8 = Int(-8)
+
+        # a != -8 & a < -6 & a / -2 = 4
+        check = And(Not(Equals(a, m_8)), LT(a, m_6), Equals(Div(a, m_2), i_4))
+        for sname in get_env().factory.all_solvers(logic=QF_NIA):
+            with Solver(name=sname) as s:
+                s.add_assertion(check)
+                c = s.solve()
+                self.assertTrue(c)
+                self.assertEqual(s.get_value(a), m_7)
 
     def test_nia_const_div_symb(self):
         """Constant divided by symbol"""
@@ -63,7 +164,7 @@ class TestNIA(TestCase):
 
         # a > 0 & 5/a = 2
         check = And(GT(a, i_0), Equals(Div(i_5, a), i_2))
-        for sname in get_env().factory.all_solvers(logic=QF_UFNIA):
+        for sname in get_env().factory.all_solvers(logic=QF_NIA):
             with Solver(name=sname) as s:
                 s.add_assertion(check)
                 c = s.solve()
@@ -81,7 +182,7 @@ class TestNIA(TestCase):
         # a = 5 & b > 0 & (a / b) = 2
         check = And(Equals(a, i_5), GT(b, i_0),
                     Equals(Div(a, b), i_2))
-        for sname in get_env().factory.all_solvers(logic=QF_UFNIA):
+        for sname in get_env().factory.all_solvers(logic=QF_NIA):
             with Solver(name=sname) as s:
                 s.add_assertion(check)
                 c = s.solve()

--- a/pysmt/test/test_nia.py
+++ b/pysmt/test/test_nia.py
@@ -1,0 +1,89 @@
+#
+# This file is part of pySMT.
+#
+#   Copyright 2014 Andrea Micheli and Marco Gario
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+from pysmt.shortcuts import *
+from pysmt.typing import INT, REAL, FunctionType
+from pysmt.test import TestCase, main
+from pysmt.logics import QF_UFNIA, UFNIA
+
+class TestNIA(TestCase):
+
+    def test_nia_const_div_const(self):
+        """Integer division between constants"""
+        a = Symbol("a", INT)
+        i_2 = Int(2)
+        i_5 = Int(5)
+
+        # a = 5/2
+        check = And(Equals(a, Div(i_5, i_2)))
+        for sname in get_env().factory.all_solvers(logic=QF_UFNIA):
+            with Solver(name=sname) as s:
+                s.add_assertion(check)
+                c = s.solve()
+                self.assertTrue(c)
+                self.assertEqual(s.get_value(a), i_2)
+
+    def test_nia_symb_div_const(self):
+        """Symbol divided by constant"""
+        a = Symbol("a", INT)
+        i_2 = Int(2)
+        i_3 = Int(3)
+        i_6 = Int(6)
+        i_7 = Int(7)
+
+        # a > 6 & a/2 = 3
+        check = And(GT(a, i_6), Equals(Div(a, i_2), i_3))
+        for sname in get_env().factory.all_solvers(logic=QF_UFNIA):
+            with Solver(name=sname) as s:
+                s.add_assertion(check)
+                c = s.solve()
+                self.assertTrue(c)
+                self.assertEqual(s.get_value(a), i_7)
+
+    def test_nia_const_div_symb(self):
+        """Constant divided by symbol"""
+        a = Symbol("a", INT)
+        i_0 = Int(0)
+        i_2 = Int(2)
+        i_5 = Int(5)
+
+        # a > 0 & 5/a = 2
+        check = And(GT(a, i_0), Equals(Div(i_5, a), i_2))
+        for sname in get_env().factory.all_solvers(logic=QF_UFNIA):
+            with Solver(name=sname) as s:
+                s.add_assertion(check)
+                c = s.solve()
+                self.assertTrue(c)
+                self.assertEqual(s.get_value(a), i_2)
+
+    def test_nia_symb_div_symb(self):
+        """Symbol divided by symbol"""
+        a = Symbol("a", INT)
+        b = Symbol("b", INT)
+        i_0 = Int(0)
+        i_2 = Int(2)
+        i_5 = Int(5)
+
+        # a = 5 & b > 0 & (a / b) = 2
+        check = And(Equals(a, i_5), GT(b, i_0),
+                    Equals(Div(a, b), i_2))
+        for sname in get_env().factory.all_solvers(logic=QF_UFNIA):
+            with Solver(name=sname) as s:
+                s.add_assertion(check)
+                c = s.solve()
+                self.assertTrue(c)
+                self.assertEqual(s.get_value(b), i_2)


### PR DESCRIPTION
This should improve the support for integer division.

In formula.py:
* I have removed an unnecessary exception that was raised if the rhs of a division was an integer constant.
* The warning "division by 0" is raised also in the case of integer division.

In simplifier.py:
* I think the simplification was buggy in python3 since the `/` operator performs division between rationals.
* In addition the standard C-like integer division is not consistent with the smtlib2 semantics.
As far as I understand the semantics of division between integers of smtlib2 is as follows:
`n / d` is `floor(float(n) / d)` if `d > 0` and `ceil(float(n) / d)` if `d < 0`.
http://smtlib.cs.uiowa.edu/theories-Ints.shtml

In msat.py:
* an integer division is rewritten in terms of `floor` and `divide` operations, where `divide` is the division between reals.

In test_nia.py:
* added some simple test cases for the integer division. I don't know if there was already a test file performing similar tests on NIA.