### PR TITLE
Bug in times distributor

### DIFF
--- a/pysmt/rewritings.py
+++ b/pysmt/rewritings.py
@@ -608,6 +608,7 @@ class AIGer(DagWalker):
 
 from itertools import product
 
+
 class TimesDistributor(IdentityDagWalker):
     """Normalize the use of multiplication by pushing it into the leafs.
 
@@ -667,9 +668,8 @@ class TimesDistributor(IdentityDagWalker):
         if not rhs.is_plus():
             return self.Plus(lhs, Times(minus_one, rhs))
         new_args = [lhs]
-        for r in rhs.args():
-            new_args.append(Times(minus_one, r))
-            return self.Plus(new_args)
+        new_args.extend(Times(minus_one, r) for r in rhs.args())
+        return self.Plus(new_args)
 
 # EOC TimesDistributivity
 
@@ -770,12 +770,12 @@ class Ackermannizer(IdentityDagWalker):
 
 class DisjointSet(object):
     """A simple implementation of the DisjointSet data-structure.
-    
+
     It supports also ranking-based DisjointSet and it can be enabled
-    by: 
+    by:
 
     1. defining a binary compare function for the  to be stored in
-    a DisjointSet. 
+    a DisjointSet.
 
     2. Set the compare function while creating the DisjointSet object.
     """
@@ -915,7 +915,7 @@ def propagate_toplevel(formula, env=None, do_simplify=True, preserve_equivalence
 
     disjoint_set = DisjointSet(compare_fun=compare)
     relevant = set()
-    
+
     for c in conjunctive_partition(formula):
         if c.is_equals():
             l, r = c.args()

--- a/pysmt/rewritings.py
+++ b/pysmt/rewritings.py
@@ -630,6 +630,8 @@ class TimesDistributor(IdentityDagWalker):
            Compute the cartesian product (itertools.product)
 
         """
+        import pdb
+        pdb.set_trace()
         # Check if there is at least one Plus to distribute over,
         # otherwise we are done. Note that walk_minus rewrites the
         # minus as a plus
@@ -663,12 +665,12 @@ class TimesDistributor(IdentityDagWalker):
         else:
             assert expr_type.is_int_type()
             minus_one = self.iminus_one
-        Times = self.Times
         lhs, rhs = args
-        if not rhs.is_plus():
-            return self.Plus(lhs, Times(minus_one, rhs))
-        new_args = [lhs]
-        new_args.extend(Times(minus_one, r) for r in rhs.args())
+        # we assume that rhs is either a sum or times cannot distribute.
+        rhs = [rhs] if not rhs.is_plus() else list(rhs.args())
+        # we need to keep the plus flat: no nested sums (see walk_times).
+        new_args = [lhs] if not lhs.is_plus() else list(lhs.args())
+        new_args.extend(self.Times(minus_one, r) for r in rhs)
         return self.Plus(new_args)
 
 # EOC TimesDistributivity

--- a/pysmt/rewritings.py
+++ b/pysmt/rewritings.py
@@ -630,8 +630,6 @@ class TimesDistributor(IdentityDagWalker):
            Compute the cartesian product (itertools.product)
 
         """
-        import pdb
-        pdb.set_trace()
         # Check if there is at least one Plus to distribute over,
         # otherwise we are done. Note that walk_minus rewrites the
         # minus as a plus

--- a/pysmt/test/test_rewritings.py
+++ b/pysmt/test/test_rewritings.py
@@ -19,6 +19,7 @@ from pysmt.shortcuts import (And, Iff, Or, Symbol, Implies, Not,
                              Exists, ForAll,
                              Times, Plus, Minus, Equals, Real,
                              LT,
+                             Int,
                              is_valid, is_sat, Function)
 from pysmt.test import TestCase, skipIfNoSolverForLogic, main
 from pysmt.rewritings import prenex_normal_form, nnf, conjunctive_partition, aig
@@ -26,7 +27,7 @@ from pysmt.rewritings import disjunctive_partition, propagate_toplevel
 from pysmt.rewritings import TimesDistributor, Ackermannizer
 from pysmt.test.examples import get_example_formulae
 from pysmt.exceptions import SolverReturnedUnknownResultError
-from pysmt.logics import BOOL, QF_NRA, QF_LRA, QF_AUFLIA
+from pysmt.logics import BOOL, QF_NRA, QF_LRA, QF_LIA, QF_AUFLIA
 from pysmt.typing import REAL, INT, FunctionType
 
 
@@ -345,6 +346,21 @@ class TestRewritings(TestCase):
                 if old is new: continue # Nothing changed
                 self.assertValid(Equals(old, new),
                                  (old, new), solver_name="z3")
+
+    @skipIfNoSolverForLogic(QF_LIA)
+    def test_minus(self):
+        x = Symbol("x", INT)
+        y = Symbol("y", INT)
+        i_0 = Int(0)
+        m_1 = Int(-1)
+        src = Plus(x, y)
+        src = Minus(x, src)
+        src = LT(src, i_0)
+        td = TimesDistributor()
+        res = td.walk(src)
+        self.assertValid(Iff(src, res))
+
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
I found a simple bug in times distributor.   
These commits should fix the issue and add a simple test case. 

The current implementation of TimesDistributor rewrites the inequality `(x - (x + y)) < 0` into `(x + (-1 * x)) < 0`.