### PR TITLE
Fix "get_model" when called from a generic solver (Fix #674)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -30,5 +30,6 @@ Suresh Gl <sureshgl009@gmail.com>
 Taylor Hodge <j.taylor.hodge@gmail.com>
 Varun Patro <varun.kumar.patro@gmail.com>
 Vijay Raghavan <vijaysgr8@gmail.com>
+Wael-Amine Boutglay <btwael@gmail.com>
 Yoni Zohar <yoni206@gmail.com>
 Yuri Malheiros <yurimalheiros@gmail.com>

--- a/pysmt/smtlib/solver.py
+++ b/pysmt/smtlib/solver.py
@@ -209,8 +209,12 @@ class SmtLibSolver(Solver):
             print("%s = %s" % (v, self.get_value(v)))
 
     def get_model(self):
-        self._send_command(SmtLibCommand(smtcmd.GET_MODEL, []))
-        return EagerModel(assignment=dict(self._get_value_answer()), environment=self.environment)
+        assignment = {}
+        for s in self.declared_vars[-1]:
+            if s.is_term():
+                v = self.get_value(s)
+                assignment[s] = v
+        return EagerModel(assignment=assignment, environment=self.environment)
 
     def _exit(self):
         self._send_command(SmtLibCommand(smtcmd.EXIT, []))

--- a/pysmt/smtlib/solver.py
+++ b/pysmt/smtlib/solver.py
@@ -209,12 +209,8 @@ class SmtLibSolver(Solver):
             print("%s = %s" % (v, self.get_value(v)))
 
     def get_model(self):
-        assignment = {}
-        for s in self.environment.formula_manager.get_all_symbols():
-            if s.is_term():
-                v = self.get_value(s)
-                assignment[s] = v
-        return EagerModel(assignment=assignment, environment=self.environment)
+        self._send_command(SmtLibCommand(smtcmd.GET_MODEL, []))
+        return EagerModel(assignment=dict(self._get_value_answer()), environment=self.environment)
 
     def _exit(self):
         self._send_command(SmtLibCommand(smtcmd.EXIT, []))

--- a/pysmt/test/smtlib/test_generic_wrapper.py
+++ b/pysmt/test/smtlib/test_generic_wrapper.py
@@ -113,6 +113,26 @@ class TestGenericWrapper(TestCase):
             self.assertFalse(model.get_value(b).is_true())
             self.assertTrue(model.get_value(a).is_true())
 
+    @skipIf(len(ALL_WRAPPERS) == 0, "No wrapper available")
+    def test_generic_wrapper_model_env_unused_vars(self):
+        a = Symbol("A", BOOL)
+        b = Symbol("B", BOOL)
+        c = Symbol("C", BOOL)
+        d = Symbol("D", BOOL)
+        unused = And(c, d)
+        f = And(a, Not(b))
+
+        for n in self.all_solvers:
+            model = None
+            with Solver(name=n, logic=QF_BOOL) as s:
+                s.add_assertion(f)
+                res = s.solve()
+                self.assertTrue(res)
+                model = s.get_model()
+
+            self.assertFalse(model.get_value(b).is_true())
+            self.assertTrue(model.get_value(a).is_true())
+
 
     @skipIf(len(ALL_WRAPPERS) == 0, "No wrapper available")
     def test_custom_types(self):


### PR DESCRIPTION
This fixes the problem raised in this issue #674. "get_model" of generic solver fails because it call "get_value" for all variables in the environment, this may cause an error as some variables do not appear in the formula.

An error is raised when the parser fails to extract the value of a variable (doesn't appear in the formula) from the response of the generic solver.