### PR TITLE
Generic interpolator (based on interpolation proposal for smtlib)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -30,5 +30,6 @@ Suresh Gl <sureshgl009@gmail.com>
 Taylor Hodge <j.taylor.hodge@gmail.com>
 Varun Patro <varun.kumar.patro@gmail.com>
 Vijay Raghavan <vijaysgr8@gmail.com>
+Wael-Amine Boutglay <btwael@gmail.com>
 Yoni Zohar <yoni206@gmail.com>
 Yuri Malheiros <yurimalheiros@gmail.com>

--- a/pysmt/factory.py
+++ b/pysmt/factory.py
@@ -67,6 +67,7 @@ class Factory(object):
         self._all_qelims = None
         self._all_interpolators = None
         self._generic_solvers = {}
+        self._generic_interpolators = {}
 
         #
         if solver_preference_list is None:
@@ -207,11 +208,28 @@ class Factory(object):
         # Extend preference list accordingly
         self.solver_preference_list.append(name)
 
+    def add_generic_interpolator(self, name, args, logics):
+        from pysmt.smtlib.interpolator import SmtLibInterpolator
+        if name in self._all_solvers:
+            raise SolverRedefinitionError("Solver %s already defined" % name)
+        self._generic_interpolators[name] = (args, logics)
+        interpolator = partial(SmtLibInterpolator, args, LOGICS=logics)
+        interpolator.LOGICS = logics
+        self._all_interpolators[name] = interpolator
+        # Extend preference list accordingly
+        self.interpolation_preference_list.append(name)
+
     def is_generic_solver(self, name):
         return name in self._generic_solvers
 
     def get_generic_solver_info(self, name):
         return self._generic_solvers[name]
+
+    def is_generic_interpolator(self, name):
+        return name in self._generic_interpolators
+
+    def get_generic_interpolator_info(self, name):
+        return self._generic_interpolators[name]
 
     def _get_available_solvers(self):
         installed_solvers = {}

--- a/pysmt/smtlib/commands.py
+++ b/pysmt/smtlib/commands.py
@@ -32,6 +32,7 @@ EXIT='exit'
 GET_ASSERTIONS='get-assertions'
 GET_ASSIGNMENT='get-assignment'
 GET_INFO='get-info'
+GET_INTERPOLANTS = 'get-interpolants'
 GET_MODEL='get-model'
 GET_OPTION='get-option'
 GET_PROOF='get-proof'
@@ -82,4 +83,8 @@ SMT_LIB_2_5 = SMT_LIB_2_0 + [
     RESET_ASSERTIONS,
 ]
 
-ALL_COMMANDS = SMT_LIB_2_5
+EXTENSIONS = [
+    GET_INTERPOLANTS
+]
+
+ALL_COMMANDS = SMT_LIB_2_5 + EXTENSIONS

--- a/pysmt/smtlib/interpolator.py
+++ b/pysmt/smtlib/interpolator.py
@@ -1,0 +1,87 @@
+#
+# This file is part of pySMT.
+#
+#   Copyright 2014 Andrea Micheli and Marco Gario
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import pysmt.smtlib.commands as smtcmd
+from pysmt.exceptions import SolverReturnedUnknownResultError, UnknownSolverAnswerError
+from pysmt.smtlib.script import SmtLibCommand
+from pysmt.smtlib.solver import SmtLibSolver
+from pysmt.solvers.interpolation import Interpolator
+
+
+class SmtLibInterpolator(Interpolator):
+
+    def __init__(self, args, environment, logic, LOGICS=None, **options):
+        Interpolator.__init__(self)
+        options["produce_interpolants"] = True
+        self.options = (args, environment, logic, LOGICS, options)
+
+    def binary_interpolant(self, a, b):
+        """Returns a binary interpolant for the pair (a, b), if And(a, b) is
+        unsatisfaiable, or None if And(a, b) is satisfiable.
+
+        """
+        res = self.sequence_interpolant([a, b])
+        if res is None:
+            return res
+        return res[0]
+
+    def sequence_interpolant(self, formulas):
+        """Returns a sequence interpolant for the conjunction of formulas, or
+        None if the problem is satisfiable.
+
+        """
+        solver = SmtLibSolver(self.options[0], self.options[1], self.options[2], self.options[3], **self.options[4])
+        for f in formulas:
+            sorts = solver.to.get_types(f, custom_only=True)
+            for s in sorts:
+                if all(s not in ds for ds in solver.declared_sorts):
+                    solver._declare_sort(s)
+            deps = f.get_free_variables()
+            for d in deps:
+                if all(d not in dv for dv in solver.declared_vars):
+                    solver._declare_variable(d)
+
+        names = []
+        i = 0
+        for f in formulas:
+            self._send_named_assert_command(f, "IP_%d" % i, solver)
+            names.append("IP_%d" % i)
+            i += 1
+
+        solver._send_command(SmtLibCommand(smtcmd.CHECK_SAT, []))
+        ans = solver._get_answer()
+        if ans == "sat":
+            return None
+        elif ans == "unsat":
+            pass
+        elif ans == "unknown":
+            raise SolverReturnedUnknownResultError
+        else:
+            raise UnknownSolverAnswerError("Solver returned: " + ans)
+        solver._send_command(SmtLibCommand(smtcmd.GET_INTERPOLANTS, names))
+        res = solver.parser.get_interpolant_list(solver.solver_stdout)
+        solver._exit()
+        return res
+
+    def _send_named_assert_command(self, f, assert_name, solver):
+        cmd = SmtLibCommand(smtcmd.ASSERT, [f])
+        cmd.assert_name = assert_name
+        solver._send_silent_command(cmd)
+
+    def _exit(self):
+        pass

--- a/pysmt/smtlib/parser/parser.py
+++ b/pysmt/smtlib/parser/parser.py
@@ -1094,6 +1094,27 @@ class SmtLibParser(object):
         self.cache.unbind_all(symbols)
         return res
 
+    def get_interpolant_list(self, script):
+        """
+        Parse a list of interpolants produced by get-interpolants
+        commands in SmtLib
+        """
+        symbols = self.env.formula_manager.symbols
+        self.cache.update(symbols)
+        tokens = Tokenizer(script, interactive=self.interactive)
+        res = []
+        tokens.consume()
+        while True:
+            current = tokens.consume()
+            if current != "(":
+                break
+            else:
+                tokens.add_extra_token(current)
+            expr = self.get_expression(tokens)
+            res.append(expr)
+        self.cache.unbind_all(symbols)
+        return res
+
     def get_command(self, tokens):
         """Builds an SmtLibCommand instance out of a parsed term."""
         while True:

--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -73,9 +73,14 @@ class SmtLibCommand(namedtuple('SmtLibCommand', ['name', 'args'])):
                                             quote(self.args[1])))
 
         elif self.name == smtcmd.ASSERT:
-            outstream.write("(%s " % self.name)
-            printer.printer(self.args[0])
-            outstream.write(")")
+            if hasattr(self, 'assert_name'):
+                outstream.write("(%s (! " % self.name)
+                printer.printer(self.args[0])
+                outstream.write(" :named %s))" % self.assert_name)
+            else:
+                outstream.write("(%s " % self.name)
+                printer.printer(self.args[0])
+                outstream.write(")")
 
         elif self.name == smtcmd.GET_VALUE:
             outstream.write("(%s (" % self.name)
@@ -83,6 +88,13 @@ class SmtLibCommand(namedtuple('SmtLibCommand', ['name', 'args'])):
                 printer.printer(a)
                 outstream.write(" ")
             outstream.write("))")
+
+        elif self.name == smtcmd.GET_INTERPOLANTS:
+            outstream.write("(%s " % self.name)
+            for a in self.args:
+                outstream.write(a)
+                outstream.write(" ")
+            outstream.write(")")
 
         elif self.name in [smtcmd.CHECK_SAT, smtcmd.EXIT,
                            smtcmd.RESET_ASSERTIONS, smtcmd.GET_UNSAT_CORE,

--- a/pysmt/smtlib/solver.py
+++ b/pysmt/smtlib/solver.py
@@ -209,8 +209,12 @@ class SmtLibSolver(Solver):
             print("%s = %s" % (v, self.get_value(v)))
 
     def get_model(self):
-        self._send_command(SmtLibCommand(smtcmd.GET_MODEL, []))
-        return EagerModel(assignment=dict(self._get_value_answer()), environment=self.environment)
+        assignment = {}
+        for s in self.declared_vars[-1]:
+            if s.is_term():
+                v = self.get_value(s)
+                assignment[s] = v
+        return EagerModel(assignment=assignment, environment=self.environment)
 
     def _exit(self):
         self._send_command(SmtLibCommand(smtcmd.EXIT, []))

--- a/pysmt/smtlib/solver.py
+++ b/pysmt/smtlib/solver.py
@@ -96,6 +96,8 @@ class SmtLibSolver(Solver):
             self.solver_stdout = TextIOWrapper(self.solver.stdout)
 
         # Initialize solver
+        if options.get("produce_interpolants"):
+            self.set_option(":produce-interpolants", "true")
         self.options(self)
         self.set_logic(logic)
 

--- a/pysmt/smtlib/solver.py
+++ b/pysmt/smtlib/solver.py
@@ -209,12 +209,8 @@ class SmtLibSolver(Solver):
             print("%s = %s" % (v, self.get_value(v)))
 
     def get_model(self):
-        assignment = {}
-        for s in self.environment.formula_manager.get_all_symbols():
-            if s.is_term():
-                v = self.get_value(s)
-                assignment[s] = v
-        return EagerModel(assignment=assignment, environment=self.environment)
+        self._send_command(SmtLibCommand(smtcmd.GET_MODEL, []))
+        return EagerModel(assignment=dict(self._get_value_answer()), environment=self.environment)
 
     def _exit(self):
         self._send_command(SmtLibCommand(smtcmd.EXIT, []))

--- a/pysmt/solvers/options.py
+++ b/pysmt/solvers/options.py
@@ -59,7 +59,7 @@ class SolverOptions(object):
 
     def __init__(self, generate_models=True, incremental=True,
                  unsat_cores_mode=None, random_seed=None,
-                 solver_options=None):
+                 solver_options=None, produce_interpolants=False):
 
         if generate_models not in (True, False):
             raise ValueError("Invalid value %s for 'generate_models'" \
@@ -90,6 +90,8 @@ class SolverOptions(object):
         else:
             solver_options = dict()
         self.solver_options = solver_options
+
+        self.produce_interpolants = produce_interpolants
 
     @abc.abstractmethod
     def __call__(self, solver):

--- a/pysmt/test/smtlib/test_generic_wrapper.py
+++ b/pysmt/test/smtlib/test_generic_wrapper.py
@@ -113,6 +113,26 @@ class TestGenericWrapper(TestCase):
             self.assertFalse(model.get_value(b).is_true())
             self.assertTrue(model.get_value(a).is_true())
 
+    @skipIf(len(ALL_WRAPPERS) == 0, "No wrapper available")
+    def test_generic_wrapper_model_env_unused_vars(self):
+        a = Symbol("A", BOOL)
+        b = Symbol("B", BOOL)
+        c = Symbol("C", BOOL)
+        d = Symbol("D", BOOL)
+        unused = And(c, d)
+        f = And(a, Not(b))
+
+        for n in self.all_solvers:
+            model = None
+            with Solver(name=n, logic=QF_BOOL) as s:
+                s.add_assertion(f)
+                res = s.solve()
+                self.assertTrue(res)
+                model = s.get_model()
+
+            self.assertFalse(model.get_value(b).is_true())
+            self.assertTrue(model.get_value(a).is_true())
+
 
     @skipIf(len(ALL_WRAPPERS) == 0, "No wrapper available")
     def test_custom_types(self):


### PR DESCRIPTION
This allow to define a generic interpolator based on the the following [proposal](https://ultimate.informatik.uni-freiburg.de/smtinterpol/proposal.pdf).

It was tested with SMTInterpol. Many other solvers don't follow this proposal. Or only follow some of it (opensmt by example: usi-verification-and-security/opensmt#213).

Remarque: For `QF_Lia`, SMTInterpol may produce interpolant with `div` or `mod`, this can be added to the smtlib parser but this is not included in this pull request.