### PR TITLE
implement add_assertions method for solver.

### DIFF
--- a/pysmt/solvers/solver.py
+++ b/pysmt/solvers/solver.py
@@ -349,9 +349,9 @@ class IncrementalTrackingSolver(Solver):
         self._assertion_stack.append(tracked)
         self._last_command = "assert"
 
-    def add_assertions(self, formulae, names=None):
-        for idx, formula in enumerate(formulae):
-            self.add_assertion(formula, names[idx] if names else None)
+    def add_assertions(self, formulae):
+        for formula in formulae:
+            self.add_assertion(formula)
 
     def _solve(self, assumptions=None):
         raise NotImplementedError

--- a/pysmt/solvers/solver.py
+++ b/pysmt/solvers/solver.py
@@ -349,6 +349,10 @@ class IncrementalTrackingSolver(Solver):
         self._assertion_stack.append(tracked)
         self._last_command = "assert"
 
+    def add_assertions(self, formulae, names=None):
+        for idx, formula in enumerate(formulae):
+            self.add_assertion(formula, names[idx] if names else None)
+
     def _solve(self, assumptions=None):
         raise NotImplementedError
 

--- a/pysmt/solvers/solver.py
+++ b/pysmt/solvers/solver.py
@@ -202,6 +202,10 @@ class Solver(object):
         """Add assertion to the solver."""
         raise NotImplementedError
 
+    def add_assertions(self, formulae):
+        for formula in formulae:
+            self.add_assertion(formula)
+
     def print_model(self, name_filter=None):
         """Prints the model (if one exists).
 
@@ -348,10 +352,6 @@ class IncrementalTrackingSolver(Solver):
         tracked = self._add_assertion(formula, named=named)
         self._assertion_stack.append(tracked)
         self._last_command = "assert"
-
-    def add_assertions(self, formulae):
-        for formula in formulae:
-            self.add_assertion(formula)
 
     def _solve(self, assumptions=None):
         raise NotImplementedError

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -156,6 +156,19 @@ class TestBasic(TestCase):
             self.assertTrue(s.get_py_value(varA))
 
     @skipIfNoSolverForLogic(QF_BOOL)
+    def test_add_assertions(self):
+        varA = Symbol("A", BOOL)
+        varB = Symbol("B", BOOL)
+        varC = Symbol("C", BOOL)
+
+        assertions = [varA, Implies(varA, varB), Implies(varB, varC)]
+        for name in get_env().factory.all_solvers(logic=QF_BOOL):
+            with Solver(name) as solver:
+                solver.add_assertions(assertions)
+                solver.solve()
+                self.assertTrue(solver.get_py_value(And(assertions)))
+
+    @skipIfNoSolverForLogic(QF_BOOL)
     def test_incremental(self):
         a = Symbol('a', BOOL)
         b = Symbol('b', BOOL)


### PR DESCRIPTION
I often end up writing something like:
```
for constr in iterable:
     solver.add_assertion(constr)
```
so I thought having a method in solver to add all constraints from an iterable could be useful.    
This does not do anything clever like trying to optimise the addition of multiple constraints.

Another possibility could be to replicate what is done in the FormulaManager for methods such as `And` and `Or`, hence having a single method accepting both a single instance and an iterable.