### PR TITLE
Fix to correctly pass logic to solvers started by Portfolio

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,6 +10,7 @@ Caleb Donovick <donovick@cs.stanford.edu>
 Cristian Mattarei <cristian.mattarei@gmail.com>
 Daniel Ricardo dos Santos <danielricardo.santos@gmail.com>
 Enrico Magnago <en.magnago@gmail.com>
+Eric Kilmer <eric.d.kilmer@gmail.com>
 Haozhong Zhang <hzzhan9@gmail.com>
 Ioannis Filippidis <jfilippidis@gmail.com>
 Kamyar Mohajerani <kammoh@gmail.com>

--- a/pysmt/solvers/portfolio.py
+++ b/pysmt/solvers/portfolio.py
@@ -77,7 +77,7 @@ class Portfolio(IncrementalTrackingSolver):
         self.solvers = []
         self._process_solver_set(solvers_set)
         # Check that the names are valid ?
-        all_solvers = set(self.environment.factory.all_solvers())
+        all_solvers = set(self.environment.factory.all_solvers(logic=logic))
         not_found = set(s for s,_ in self.solvers) - all_solvers
         if len(not_found) != 0:
             raise ValueError("Cannot find solvers %s" % not_found)
@@ -143,7 +143,7 @@ class Portfolio(IncrementalTrackingSolver):
             _p = Process(name="%d (%s)" % (idx, sname),
                          target=_run_solver,
                          args=("%d (%s)" % (idx, sname),
-                               sname, options, formula,
+                               sname, self.logic, options, formula,
                                signaling_queue, child_ctrl_pipe))
             processes.append(_p)
             _p.start()
@@ -212,7 +212,7 @@ class Portfolio(IncrementalTrackingSolver):
 # EOC Portfolio
 
 # Function to pass to the solver
-def _run_solver(idx, solver, options, formula, signaling_queue, ctrl_pipe):
+def _run_solver(idx, solver, logic, options, formula, signaling_queue, ctrl_pipe):
     """Function used by the child Process to handle Portfolio requests.
 
     solver  : name of the solver
@@ -224,7 +224,7 @@ def _run_solver(idx, solver, options, formula, signaling_queue, ctrl_pipe):
     from pysmt.environment import get_env
 
     Solver = get_env().factory.Solver
-    with Solver(name=solver, **options) as s:
+    with Solver(name=solver, logic=logic, **options) as s:
         s.add_assertion(formula)
         try:
             local_res = s.solve()

--- a/pysmt/test/test_portfolio.py
+++ b/pysmt/test/test_portfolio.py
@@ -36,7 +36,7 @@ class PortfolioTestCase(TestCase):
     def test_basic(self):
         with Portfolio(["z3", "msat", "cvc4"],
                        environment=self.env,
-                       logic="QF_LRA") as p:
+                       logic=QF_LRA) as p:
             for example in get_example_formulae():
                 if not example.logic <= QF_LRA: continue
                 res = p.is_sat(example.expr)
@@ -109,11 +109,9 @@ class PortfolioTestCase(TestCase):
             is_sat(TRUE(), portfolio=["supersolver"])
 
     @skipIfSolverNotAvailable("msat")
-    @skipIfSolverNotAvailable("picosat")
-    @skipIfSolverNotAvailable("btor")
-    @skipIfSolverNotAvailable("bdd")
+    @skipIfSolverNotAvailable("cvc4")
     def test_get_value(self):
-        with Portfolio(["msat", "picosat", "btor", "bdd"],
+        with Portfolio(["msat", "cvc4"],
                        logic=QF_UFLIRA,
                        environment=self.env,
                        incremental=False,


### PR DESCRIPTION
Thank you for this project!

I encountered an issue while using `Portfolio` where the solvers weren't respecting the passed `logic`. I found that they were using the default logic ([`QF_UFLIRA`](https://github.com/pysmt/pysmt/blob/22520e2a012c980285fae10fe8aa388e263ea317/pysmt/factory.py#L47)), and these changes were required in order to start each solver with the correct logic, as passed to `Portfolio`.