### PR TITLE
Remove six and python 2 compatibility code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,8 +178,6 @@ Additionally, you can use any SMT-LIB 2 compliant solver.
 PySMT assumes that the python bindings for the SMT Solver are
 installed and accessible from your ``PYTHONPATH``.
 
-pySMT works on both Python 3.5 and Python 2.7.
-
 Installation
 ============
 You can install the latest stable release of pySMT from PyPI::
@@ -207,7 +205,7 @@ By default the solvers are downloaded, unpacked and built in your home directory
 in the ``.smt_solvers`` folder. Compiled libraries and actual solver packages are
 installed in the relevant ``site-packages`` directory (e.g. virtual environment's
 packages root or local user-site). ``pysmt-install`` has many options to
-customize its behavior. If you have multiple versions of python in your system, 
+customize its behavior. If you have multiple versions of python in your system,
 we recommend the following syntax to run pysmt-install: ``python -m pysmt install``.
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -201,7 +201,6 @@ jobs:
     displayName: 'Install Twine'
   - script: './make_distrib.sh'
     displayName: 'Make Distrib'
-  - script: 'cd dist; zip PySMT*.whl six.py'
   - task: TwineAuthenticate@0
     inputs:
       externalFeeds: PyPI

--- a/ci/install_unix.sh
+++ b/ci/install_unix.sh
@@ -83,7 +83,6 @@ fi
 
 # Install dependencies
 $PIP_INSTALL configparser
-$PIP_INSTALL six
 $PIP_INSTALL wheel
 $PIP_INSTALL pytest
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,2 @@
 pytest
 wheel
-six

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -258,7 +258,7 @@ Package creation and local testing
 
 The utility script ``make_distrib.sh`` to create a distribution
 package is located in the root directory of the project. This will
-create various formats, and download the latest version of six.
+create various formats.
 
 After running this script, the package ``dist/PySMT-a.b.c.tar.gz``
 (where a.b.c are the release number), needs to be uploaded to
@@ -291,8 +291,7 @@ finally push the tag to github ``git push origin va.b.c``.
 
 Now on github, it is possible to create the release associated with
 this tag. The description of the release is the copy-paste of the
-Changelog. Additionally, we include the wheel file (remember to
-include six!) and the tar.gz .
+Changelog. Additionally, we include the wheel file and the tar.gz .
 
 Immediately after tagging, make a commit on master bumping the
 version. By default we use ``(a, b, c+1, "dev", 1)``.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -11,7 +11,7 @@ simple problem using it.
 Installation
 ------------
 
-To run pySMT you need Python 3.5+ or Python 2.7 installed.
+To run pySMT you need Python 3.5+ installed.
 If no solver is installed, pySMT can still create and dump the SMT
 problem in SMT-LIB format. pySMT works with any SMT-LIB compatible
 solver. Moreover, pySMT can leverage the API of the following solvers:

--- a/examples/model_checking.py
+++ b/examples/model_checking.py
@@ -20,8 +20,6 @@
 #     "Efficient implementation of property directed reachability",
 #     FMCAD 2011
 #
-from six.moves import xrange
-
 from pysmt.shortcuts import Symbol, Not, And, Or, EqualsOrIff, Implies
 from pysmt.shortcuts import is_sat, is_unsat, Solver, TRUE
 from pysmt.typing import BOOL
@@ -128,7 +126,7 @@ class BMCInduction(object):
         E.g. T(0,1) & T(1,2) & ... & T(k-1,k)
         """
         res = []
-        for i in xrange(k+1):
+        for i in range(k+1):
             subs_i = self.get_subs(i)
             res.append(self.system.trans.substitute(subs_i))
         return And(res)
@@ -138,9 +136,9 @@ class BMCInduction(object):
         each time encodes a different state
         """
         res = []
-        for i in xrange(k+1):
+        for i in range(k+1):
             subs_i = self.get_subs(i)
-            for j in xrange(i+1, k+1):
+            for j in range(i+1, k+1):
                 state = []
                 subs_j = self.get_subs(j)
                 for v in self.system.variables:
@@ -153,7 +151,7 @@ class BMCInduction(object):
     def get_k_hypothesis(self, prop, k):
         """Hypothesis for k-induction: each state up to k-1 fulfills the property"""
         res = []
-        for i in xrange(k):
+        for i in range(k):
             subs_i = self.get_subs(i)
             res.append(prop.substitute(subs_i))
         return And(res)
@@ -176,7 +174,7 @@ class BMCInduction(object):
     def check_property(self, prop):
         """Interleaves BMC and K-Ind to verify the property."""
         print("Checking property %s..." % prop)
-        for b in xrange(100):
+        for b in range(100):
             f = self.get_bmc(prop, b)
             print("   [BMC]    Checking bound %d..." % (b+1))
             if is_sat(f):

--- a/examples/smtlib.py
+++ b/examples/smtlib.py
@@ -10,7 +10,7 @@
 # 4. How to access annotations from SMT-LIB files
 # 5. How to extend the parser with custom commands
 #
-from six.moves import cStringIO # Py2-Py3 Compatibility
+from io import StringIO
 
 from pysmt.smtlib.parser import SmtLibParser
 
@@ -41,9 +41,9 @@ DEMO_SMTLIB=\
 parser = SmtLibParser()
 
 # The method SmtLibParser.get_script takes a buffer in input. We use
-# cStringIO to simulate an open file.
+# StringIO to simulate an open file.
 # See SmtLibParser.get_script_fname() if to pass the path of a file.
-script = parser.get_script(cStringIO(DEMO_SMTLIB))
+script = parser.get_script(StringIO(DEMO_SMTLIB))
 
 # The SmtLibScript provides an iterable representation of the commands
 # that are present in the SMT-LIB file.
@@ -79,7 +79,7 @@ print(f)
 # be dumped into a file (see SmtLibScript.to_file).  The flag daggify,
 # specifies whether the printing is done as a DAG or as a tree.
 
-buf_out = cStringIO()
+buf_out = StringIO()
 script.serialize(buf_out, daggify=True)
 print(buf_out.getvalue())
 
@@ -212,7 +212,7 @@ class TSSmtLibParser(SmtLibParser):
 from pysmt.exceptions import UnknownSmtLibCommandError
 
 try:
-    parser.get_script(cStringIO(EXT_SMTLIB))
+    parser.get_script(StringIO(EXT_SMTLIB))
 except UnknownSmtLibCommandError as ex:
     print("Unsupported command: %s" % ex)
 

--- a/examples/smtlib.py
+++ b/examples/smtlib.py
@@ -218,6 +218,6 @@ except UnknownSmtLibCommandError as ex:
 
 # The new parser can parse our example, and returns the (init, trans) pair
 ts_parser = TSSmtLibParser()
-init, trans = ts_parser.get_ts(cStringIO(EXT_SMTLIB))
+init, trans = ts_parser.get_ts(StringIO(EXT_SMTLIB))
 print("INIT: %s" % init.serialize())
 print("TRANS: %s" % trans.serialize())

--- a/examples/sudoku/gui.py
+++ b/examples/sudoku/gui.py
@@ -21,8 +21,8 @@ class GridWindow(Gtk.Window):
         self.sudoku = Sudoku(size)
 
         # Draw the window
-        self.table = [[Gtk.Entry() for _ in xrange(size**2)]
-                                   for _ in xrange(size**2)]
+        self.table = [[Gtk.Entry() for _ in range(size**2)]
+                                   for _ in range(size**2)]
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.add(vbox)
 
@@ -62,9 +62,9 @@ class GridWindow(Gtk.Window):
 
         # First, we compute the user constraints to feed into the Sudoku solver
         constraints = []
-        for i in xrange(sq_size):
+        for i in range(sq_size):
             row = []
-            for j in xrange(sq_size):
+            for j in range(sq_size):
                 txt = self.table[i][j].get_text()
                 try:
                     n = int(txt)

--- a/examples/sudoku/sudoku.py
+++ b/examples/sudoku/sudoku.py
@@ -57,8 +57,8 @@ class Sudoku(object):
         """
         sq_size = self.size**2
         ty = self.get_type()
-        var_table = [[FreshSymbol(ty) for _ in xrange(sq_size)]
-                          for _ in xrange(sq_size)]
+        var_table = [[FreshSymbol(ty) for _ in range(sq_size)]
+                          for _ in range(sq_size)]
 
         solver = Solver(logic=logic, name=solver_name)
         # Sudoku constraints
@@ -66,18 +66,18 @@ class Sudoku(object):
         for row in var_table:
             for var in row:
                 solver.add_assertion(Or([Equals(var, self.const(i))
-                                         for i in xrange(1, sq_size + 1)]))
+                                         for i in range(1, sq_size + 1)]))
 
         # each row and each column contains all different numbers
-        for i in xrange(sq_size):
+        for i in range(sq_size):
             solver.add_assertion(AllDifferent(var_table[i]))
             solver.add_assertion(AllDifferent([x[i] for x in var_table]))
 
         # each square contains all different numbers
-        for sx in xrange(self.size):
-            for sy in xrange(self.size):
+        for sx in range(self.size):
+            for sy in range(self.size):
                 square = [var_table[i + sx * self.size][j + sy * self.size]
-                          for i in xrange(self.size) for j in xrange(self.size)]
+                          for i in range(self.size) for j in range(self.size)]
                 solver.add_assertion(AllDifferent(square))
 
         return solver, var_table
@@ -134,9 +134,9 @@ def read_constraints(fname):
     r = reader(fname)
     size = int(next(r))
     constraints = []
-    for _ in xrange(size**2):
+    for _ in range(size**2):
         row = []
-        for _ in xrange(size**2):
+        for _ in range(size**2):
             w = next(r)
             if w != "X":
                 row.append(int(w))

--- a/make_distrib.sh
+++ b/make_distrib.sh
@@ -16,9 +16,3 @@ python setup.py sdist --format=gztar
 
 # Wheel file
 python setup.py bdist_wheel --universal
-
-
-wget https://bitbucket.org/gutworth/six/raw/e5218c3f66a2614acb7572204a27e2b508682168/six.py -O dist/six.py
-echo "To create a self-contained wheel pkg, manually add six:"
-echo " $ zip PySMT-version.whl six.py"
-echo "A copy of six.py has been downloaded in dist/"

--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from six.moves import input
-
 import os
 import argparse
 import sys

--- a/pysmt/cmd/installers/base.py
+++ b/pysmt/cmd/installers/base.py
@@ -17,17 +17,15 @@ import sys
 import shutil
 import zipfile
 import tarfile
-import six
 import struct
 import subprocess
+import urllib.request
 
 from contextlib import contextmanager
 from distutils import spawn
 from distutils.dist import Distribution
 
-import six.moves
-from six.moves import xrange
-from six.moves.urllib.error import HTTPError, URLError
+from urllib.error import HTTPError, URLError
 
 
 @contextmanager
@@ -102,7 +100,7 @@ class SolverInstaller(object):
     def download(self):
         """Downloads the archive from one of the mirrors"""
         if not os.path.exists(self.archive_path):
-            for turn in xrange(self.trials_404):
+            for turn in range(self.trials_404):
                 for i, link in enumerate(self.download_links()):
                     try:
                         return self.do_download(link, self.archive_path)
@@ -163,7 +161,7 @@ class SolverInstaller(object):
     @staticmethod
     def do_download(url, file_name):
         """Downloads the given url into the given file name"""
-        u = six.moves.urllib.request.urlopen(url)
+        u = urllib.request.urlopen(url)
         f = open(file_name, 'wb')
         meta = u.info()
         if meta.get("Content-Length") and len(meta.get("Content-Length")) > 0:
@@ -210,7 +208,7 @@ class SolverInstaller(object):
         """Executes an arbitrary program"""
         environment = os.environ.copy()
         if env_variables is not None:
-            for k,v in six.iteritems(env_variables):
+            for k,v in env_variables.items():
                 environment[k] = v
 
         stderr = None

--- a/pysmt/cmd/installers/pico.py
+++ b/pysmt/cmd/installers/pico.py
@@ -15,7 +15,7 @@ import sys, os
 import json
 import codecs
 
-from six.moves.urllib import request as urllib2
+import urllib.request
 
 from pysmt.cmd.installers.base import SolverInstaller, TemporaryPath
 
@@ -39,7 +39,7 @@ class PicoSATInstaller(SolverInstaller):
         self.complete_version = "%s.%s" % (self.solver_version,
                                            self.pypicosat_minor_version)
         pypi_link = "https://pypi.python.org/pypi/pyPicoSAT/%s/json" % self.complete_version
-        response = urllib2.urlopen(pypi_link)
+        response = urllib.request.urlopen(pypi_link)
         reader = codecs.getreader("utf-8")
         pypi_json = json.load(reader(response))
 

--- a/pysmt/cmd/shell.py
+++ b/pysmt/cmd/shell.py
@@ -104,7 +104,7 @@ class PysmtShell(object):
                 print("unsat")
         elif name == GET_VALUE:
             print("(")
-            for k, r in result.iteritems():
+            for k, r in result.items():
                 print("  (%s %s)" % (k,r))
             print(")")
 

--- a/pysmt/configuration.py
+++ b/pysmt/configuration.py
@@ -39,7 +39,7 @@ of the solver.
 """
 
 import os.path
-import six.moves.configparser as cp
+import configparser as cp
 from warnings import warn
 
 from pysmt.logics import get_logic_by_name

--- a/pysmt/constants.py
+++ b/pysmt/constants.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import os
-from six import PY2
+
 from pysmt.exceptions import PysmtImportError
 # The environment variable can be used to force the configuration
 # of the Fraction class.
@@ -83,10 +83,7 @@ def is_pysmt_fraction(var):
 if USE_GMPY:
     Integer = mpz
 else:
-    if PY2:
-        Integer = long
-    else:
-        Integer = int
+    Integer = int
 IntegerClass = type(Integer(1))
 
 
@@ -105,8 +102,6 @@ def is_python_integer(var):
     """
     if type(var) == mpz_type:
         return True
-    if PY2 and type(var) == long:
-        return True
     if type(var) == int:
         return True
     return False
@@ -120,8 +115,6 @@ def is_python_rational(var):
     if type(var) == mpz_type or type(var) == mpq_type:
         return True
     if type(var) == pyFraction:
-        return True
-    if PY2 and type(var) == long:
         return True
     if type(var) == int:
         return True
@@ -143,14 +136,9 @@ def pysmt_integer_from_integer(value):
     return Integer(value)
 
 
-if PY2:
-    def to_python_integer(value):
-        """Return the python integer value."""
-        return long(value)
-else:
-    def to_python_integer(value):
-        """Return the python integer value."""
-        return int(value)
+def to_python_integer(value):
+    """Return the python integer value."""
+    return int(value)
 
 
 if USE_GMPY:

--- a/pysmt/factory.py
+++ b/pysmt/factory.py
@@ -24,7 +24,6 @@ particular solver.
 """
 
 from functools import partial
-from six import iteritems
 
 from pysmt.exceptions import (NoSolverAvailableError, SolverRedefinitionError,
                               NoLogicAvailableError,
@@ -272,7 +271,7 @@ class Factory(object):
         else:
             self._all_solvers = installed_solvers
 
-        for k,s in iteritems(self._all_solvers):
+        for k,s in self._all_solvers.items():
             try:
                 if s.UNSAT_CORE_SUPPORT:
                     self._all_unsat_core_solvers[k] = s
@@ -357,7 +356,7 @@ class Factory(object):
         """
         res = {}
         if logic is not None:
-            for s, v in iteritems(solver_list):
+            for s, v in solver_list.items():
                 for l in v.LOGICS:
                     if logic <= l:
                         res[s] = v

--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -34,7 +34,6 @@ else:
     from collections import Iterable
 
 import warnings
-from six.moves import xrange
 
 import pysmt.typing as types
 import pysmt.operators as op
@@ -928,7 +927,7 @@ class FormulaManager(object):
     def BVRepeat(self, formula, count=1):
         """Returns the concatenation of count copies of formula."""
         res = formula
-        for _ in xrange(count-1):
+        for _ in range(count-1):
             res = self.BVConcat(res, formula)
         return res
 

--- a/pysmt/logics.py
+++ b/pysmt/logics.py
@@ -19,7 +19,6 @@
 the SMTLIB and provides methods to compare and search for particular
 logics.
 """
-import six
 
 from pysmt.exceptions import UndefinedLogicError, NoLogicAvailableError
 
@@ -723,7 +722,7 @@ def convert_logic_from_string(name):
 
     This takes a logic or a string or None, and returns a logic or None.
     """
-    if name is not None and isinstance(name, six.string_types):
+    if name is not None and isinstance(name, str):
         name = get_logic_by_name(name)
     return name
 

--- a/pysmt/operators.py
+++ b/pysmt/operators.py
@@ -22,10 +22,9 @@ they will be rewritten (during construction) in order to only use
 these operators.
 """
 from itertools import chain
-from six.moves import xrange
 
 
-ALL_TYPES = list(xrange(0,66))
+ALL_TYPES = list(range(0,66))
 
 (
 FORALL, EXISTS, AND, OR, NOT, IMPLIES, IFF, # Boolean Logic (0-6)

--- a/pysmt/printers.py
+++ b/pysmt/printers.py
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from six.moves import cStringIO
+from io import StringIO
 
 import pysmt.operators as op
 from pysmt.walkers import TreeWalker
@@ -340,7 +340,7 @@ class HRSerializer(object):
         'printer' is the printer to call to perform the serialization.
         'threshold' is the thresholding value for the printing function.
         """
-        buf = cStringIO()
+        buf = StringIO()
         if printer is None:
             p = self.PrinterClass(buf)
         else:
@@ -389,7 +389,7 @@ class SmartPrinter(HRPrinter):
 
 def smart_serialize(formula, subs=None, threshold=None):
     """Creates and calls a SmartPrinter to perform smart serialization."""
-    buf = cStringIO()
+    buf = StringIO()
     p = SmartPrinter(buf, subs=subs)
     p.printer(formula, threshold=threshold)
     res = buf.getvalue()

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -15,7 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from six.moves import xrange
 import math
 
 import pysmt.walkers
@@ -903,7 +902,7 @@ class Simplifier(pysmt.walkers.DagWalker):
                 if width > r.bv_unsigned_value():
                     padlen = r.bv_unsigned_value()
 
-                for i in xrange(width-padlen, width):
+                for i in range(width-padlen, width):
                     n = set_bit(n, i, True)
                 ret = self.manager.BV(n, width)
             return ret

--- a/pysmt/smtlib/annotations.py
+++ b/pysmt/smtlib/annotations.py
@@ -15,7 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from six import iteritems
 
 class Annotations(object):
     """Handles and stores (key,value) annotations for formulae"""
@@ -89,7 +88,8 @@ class Annotations(object):
         specified value are returned.
         """
         res = []
-        for f,amap in iteritems(self._annotations):
+        for f, amap in self._annotations.items():
+            # MG: Revisit this code. Can this be simplified?
             if annotation in amap:
                 if value is None:
                     res.append(f)
@@ -106,9 +106,9 @@ class Annotations(object):
 
     def __str__(self):
         res = ["Annotations: {"]
-        for t, m in iteritems(self._annotations):
+        for t, m in self._annotations.items():
             res.append(str(t) + " -> ")
-            for a, lst in iteritems(m):
+            for a, lst in m.items():
                 res.append(":" + str(a) + "{")
                 for v in lst:
                     res.append(str(v) + ", ")

--- a/pysmt/smtlib/parser/parser.py
+++ b/pysmt/smtlib/parser/parser.py
@@ -19,8 +19,6 @@ import functools
 import itertools
 
 from warnings import warn
-from six import iteritems, PY2
-from six.moves import xrange
 from collections import deque
 
 import pysmt.smtlib.commands as smtcmd
@@ -39,10 +37,7 @@ def open_(fname):
     """Transparently handle .bz2 files."""
     if fname.endswith(".bz2"):
         import bz2
-        if PY2:
-            return bz2.BZ2File(fname, "r")
-        else:
-            return bz2.open(fname, "rt")
+        return bz2.open(fname, "rt")
     return open(fname)
 
 
@@ -131,7 +126,7 @@ class SmtLibExecutionCache(object):
 
     def update(self, value_map):
         """Binds all the symbols in 'value_map'"""
-        for k, val in iteritems(value_map):
+        for k, val in value_map.items():
             self.bind(k, val)
 
     def unbind_all(self, values):
@@ -885,7 +880,7 @@ class SmtLibParser(object):
 
         res = []
         current = None
-        for _ in xrange(min_size):
+        for _ in range(min_size):
             current = tokens.consume("Unexpected end of stream in %s "
                                              "command." % command)
             if current == ")":
@@ -898,7 +893,7 @@ class SmtLibParser(object):
                                        "command." % command,
                                        tokens.pos_info)
             res.append(current)
-        for _ in xrange(min_size, max_size + 1):
+        for _ in range(min_size, max_size + 1):
             current = tokens.consume("Unexpected end of stream in %s "
                                              "command." % command)
             if current == ")":

--- a/pysmt/smtlib/printers.py
+++ b/pysmt/smtlib/printers.py
@@ -16,8 +16,7 @@
 #   limitations under the License.
 #
 from functools import partial
-
-from six.moves import xrange, cStringIO
+from io import StringIO
 
 import pysmt.operators as op
 from pysmt.environment import get_env
@@ -254,7 +253,7 @@ class SmtPrinter(TreeWalker):
 
     def walk_array_value(self, formula):
         assign = formula.array_value_assigned_values_map()
-        for _ in xrange(len(assign)):
+        for _ in range(len(assign)):
             self.write("(store ")
 
         self.write("((as const %s) " % formula.get_type().as_smtlib(False))
@@ -607,7 +606,7 @@ class SmtDagPrinter(DagWalker):
         self.openings += 1
         self.write("(let ((%s " % sym)
 
-        for _ in xrange((len(args) - 1) // 2):
+        for _ in range((len(args) - 1) // 2):
             self.write("(store ")
 
         self.write("((as const %s) " % formula.get_type().as_smtlib(False))
@@ -634,7 +633,7 @@ def to_smtlib(formula, daggify=True):
 
     See :py:class:`SmtPrinter`
     """
-    buf = cStringIO()
+    buf = StringIO()
     p = None
     if daggify:
         p = SmtDagPrinter(buf)

--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -18,8 +18,7 @@
 
 import warnings
 from collections import namedtuple
-from six.moves import cStringIO
-from six.moves import xrange
+from io import StringIO
 
 import pysmt.smtlib.commands as smtcmd
 from pysmt.exceptions import (UnknownSmtLibCommandError, NoLogicAvailableError,
@@ -138,7 +137,7 @@ class SmtLibCommand(namedtuple('SmtLibCommand', ['name', 'args'])):
             raise UnknownSmtLibCommandError(self.name)
 
     def serialize_to_string(self, daggify=True):
-        buf = cStringIO()
+        buf = StringIO()
         self.serialize(buf, daggify=daggify)
         return buf.getvalue()
 
@@ -212,10 +211,10 @@ class SmtLibScript(object):
                 stack = []
                 backtrack = []
             elif cmd.name == smtcmd.PUSH:
-                for _ in xrange(cmd.args[0]):
+                for _ in range(cmd.args[0]):
                     backtrack.append(len(stack))
             elif cmd.name == smtcmd.POP:
-                for _ in xrange(cmd.args[0]):
+                for _ in range(cmd.args[0]):
                     l = backtrack.pop()
                     stack = stack[:l]
 

--- a/pysmt/smtlib/solver.py
+++ b/pysmt/smtlib/solver.py
@@ -16,8 +16,6 @@ import time
 from io import TextIOWrapper
 from subprocess import Popen, PIPE
 
-from six import PY2
-
 import pysmt.smtlib.commands as smtcmd
 from pysmt.solvers.eager import EagerModel
 from pysmt.smtlib.parser import SmtLibParser
@@ -88,12 +86,8 @@ class SmtLibSolver(Solver):
         # Give time to the process to start-up
         time.sleep(0.01)
         self.parser = SmtLibParser(interactive=True)
-        if PY2:
-            self.solver_stdin = self.solver.stdin
-            self.solver_stdout = self.solver.stdout
-        else:
-            self.solver_stdin = TextIOWrapper(self.solver.stdin)
-            self.solver_stdout = TextIOWrapper(self.solver.stdout)
+        self.solver_stdin = TextIOWrapper(self.solver.stdin)
+        self.solver_stdout = TextIOWrapper(self.solver.stdout)
 
         # Initialize solver
         self.options(self)

--- a/pysmt/solvers/bdd.py
+++ b/pysmt/solvers/bdd.py
@@ -15,8 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from six.moves import xrange
-
 from pysmt.exceptions import SolverAPINotFound
 
 try:
@@ -229,12 +227,12 @@ class BddSolver(Solver):
 
     @clear_pending_pop
     def push(self, levels=1):
-        for _ in xrange(levels):
+        for _ in range(levels):
             self.backtrack.append(len(self.assertions_stack))
 
     @clear_pending_pop
     def pop(self, levels=1):
-        for _ in xrange(levels):
+        for _ in range(levels):
             l = self.backtrack.pop()
             self.assertions_stack = self.assertions_stack[:l]
 

--- a/pysmt/solvers/cvc4.py
+++ b/pysmt/solvers/cvc4.py
@@ -17,8 +17,6 @@
 #
 from __future__ import absolute_import
 
-from six.moves import xrange
-
 from pysmt.exceptions import SolverAPINotFound
 
 try:
@@ -159,12 +157,12 @@ class CVC4Solver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
             # Therefore, we need to check that we can actually do a push
             raise NotImplementedError("The solver is not incremental")
 
-        for _ in xrange(levels):
+        for _ in range(levels):
             self.cvc4.push()
         return
 
     def pop(self, levels=1):
-        for _ in xrange(levels):
+        for _ in range(levels):
             self.cvc4.pop()
         return
 

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -16,7 +16,6 @@
 #   limitations under the License.
 #
 from warnings import warn
-from six.moves import xrange
 
 from pysmt.exceptions import SolverAPINotFound
 from pysmt.constants import Fraction, is_pysmt_fraction, is_pysmt_integer
@@ -325,12 +324,12 @@ class MathSAT5Solver(IncrementalTrackingSolver, UnsatCoreSolver,
 
     @clear_pending_pop
     def _push(self, levels=1):
-        for _ in xrange(levels):
+        for _ in range(levels):
             mathsat.msat_push_backtrack_point(self.msat_env())
 
     @clear_pending_pop
     def _pop(self, levels=1):
-        for _ in xrange(levels):
+        for _ in range(levels):
             mathsat.msat_pop_backtrack_point(self.msat_env())
 
     def _var2term(self, var):
@@ -734,12 +733,12 @@ class MSatConverter(Converter, DagWalker):
             if current not in self.back_memoization:
                 self.back_memoization[current] = None
                 stack.append(current)
-                for i in xrange(arity):
+                for i in range(arity):
                     son = mathsat.msat_term_get_arg(current, i)
                     stack.append(son)
             elif self.back_memoization[current] is None:
                 args=[self.back_memoization[mathsat.msat_term_get_arg(current,i)]
-                      for i in xrange(arity)]
+                      for i in range(arity)]
 
                 signature = self._get_signature(current, args)
                 new_args = []
@@ -1257,7 +1256,7 @@ class MSatInterpolator(Interpolator):
                 return None
 
             pysmt_ret = []
-            for i in xrange(1, len(groups)):
+            for i in range(1, len(groups)):
                 itp = mathsat.msat_get_interpolant(env, groups[:i])
                 f = self.converter.back(itp)
                 pysmt_ret.append(f)
@@ -1310,7 +1309,7 @@ class MSatBoolUFRewriter(IdentityDagWalker):
 
         # Base-case
         stack = []
-        for i in xrange(2**len(bool_args)):
+        for i in range(2**len(bool_args)):
             fname = self.mgr.Symbol("%s#%i" % (formula.function_name(),i), ftype)
             if len(ptype) == 0:
                 stack.append(fname)

--- a/pysmt/solvers/pico.py
+++ b/pysmt/solvers/pico.py
@@ -22,9 +22,6 @@ try:
 except ImportError:
     raise SolverAPINotFound
 
-from six.moves import xrange
-from six import iteritems
-
 import pysmt.logics
 from pysmt import typing as types
 from pysmt.solvers.solver import Solver, SolverOptions
@@ -282,7 +279,7 @@ class PicosatSolver(Solver):
 
     def get_model(self):
         assignment = {}
-        for var, vid in iteritems(self._var_ids):
+        for var, vid in self._var_ids.items():
             v = picosat.picosat_deref(self.pico, vid)
             assert v!=0, "Error when translating variable."
 
@@ -294,12 +291,12 @@ class PicosatSolver(Solver):
 
     @clear_pending_pop
     def push(self, levels=1):
-        for _ in xrange(levels):
+        for _ in range(levels):
             picosat.picosat_push(self.pico)
 
     @clear_pending_pop
     def pop(self, levels=1):
-        for _ in xrange(levels):
+        for _ in range(levels):
             picosat.picosat_pop(self.pico)
 
     def _exit(self):

--- a/pysmt/solvers/solver.py
+++ b/pysmt/solvers/solver.py
@@ -15,8 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from six.moves import xrange
-
 from pysmt.typing import BOOL
 from pysmt.solvers.options import SolverOptions
 from pysmt.decorators import clear_pending_pop
@@ -374,7 +372,7 @@ class IncrementalTrackingSolver(Solver):
     def push(self, levels=1):
         self._push(levels=levels)
         point = len(self._assertion_stack)
-        for _ in xrange(levels):
+        for _ in range(levels):
             self._backtrack_points.append(point)
         self._last_command = "push"
 
@@ -383,7 +381,7 @@ class IncrementalTrackingSolver(Solver):
 
     def pop(self, levels=1):
         self._pop(levels=levels)
-        for _ in xrange(levels):
+        for _ in range(levels):
             point = self._backtrack_points.pop()
             self._assertion_stack = self._assertion_stack[0:point]
         self._last_command = "pop"

--- a/pysmt/solvers/yices.py
+++ b/pysmt/solvers/yices.py
@@ -18,8 +18,6 @@
 import atexit
 from warnings import warn
 
-from six.moves import xrange
-
 from pysmt.exceptions import SolverAPINotFound
 
 try:
@@ -222,7 +220,7 @@ class YicesSolver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
 
     @clear_pending_pop
     def push(self, levels=1):
-        for _ in xrange(levels):
+        for _ in range(levels):
             c = yicespy.yices_push(self.yices)
             if c != 0:
                 # 4 is STATUS_UNSAT
@@ -238,7 +236,7 @@ class YicesSolver(Solver, SmtLibBasicSolver, SmtLibIgnoreMixin):
 
     @clear_pending_pop
     def pop(self, levels=1):
-        for _ in xrange(levels):
+        for _ in range(levels):
             if self.failed_pushes > 0:
                 self.failed_pushes -= 1
             else:

--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -28,8 +28,6 @@ except ImportError:
 # (see https://github.com/Z3Prover/z3/issues/1769)
 z3.set_param('model.compact', False)
 
-from six.moves import xrange
-
 
 import pysmt.typing as types
 import pysmt.operators as op
@@ -262,12 +260,12 @@ class Z3Solver(IncrementalTrackingSolver, UnsatCoreSolver,
 
     @clear_pending_pop
     def _push(self, levels=1):
-        for _ in xrange(levels):
+        for _ in range(levels):
             self.z3.push()
 
     @clear_pending_pop
     def _pop(self, levels=1):
-        for _ in xrange(levels):
+        for _ in range(levels):
             self.z3.pop()
 
     def print_model(self, name_filter=None):
@@ -532,7 +530,7 @@ class Z3Converter(Converter, DagWalker):
                     interp = model[interp_decl]
                     default = self.back(interp.else_value(), model=model)
                     assign = {}
-                    for i in xrange(interp.num_entries()):
+                    for i in range(interp.num_entries()):
                         e = interp.entry(i)
                         assert e.num_args() == 1
                         idx = self.back(e.arg_value(0), model=model)
@@ -583,7 +581,7 @@ class Z3Converter(Converter, DagWalker):
 
     def back_via_smtlib(self, expr):
         """Back convert a Z3 Expression by translation to SMT-LIB."""
-        from six import StringIO
+        from io import StringIO
         from pysmt.smtlib.parser import SmtLibZ3Parser
         parser = SmtLibZ3Parser(self.env)
 
@@ -831,7 +829,7 @@ class Z3Converter(Converter, DagWalker):
         z3term = z3.Z3_mk_const_array(self.ctx.ref(), arraysort, args[0])
         z3.Z3_inc_ref(self.ctx.ref(), z3term)
 
-        for i in xrange(1, len(args), 2):
+        for i in range(1, len(args), 2):
             c = args[i]
             z3term = self.walk_array_store(None, (z3term, c, args[i+1]))
             z3.Z3_inc_ref(self.ctx.ref(), z3term)

--- a/pysmt/substituter.py
+++ b/pysmt/substituter.py
@@ -17,8 +17,6 @@
 #
 import warnings
 
-from six import iteritems
-
 import pysmt.walkers
 from pysmt.walkers.generic import handles
 import pysmt.operators as op
@@ -74,7 +72,7 @@ class Substituter(pysmt.walkers.IdentityDagWalker):
             #    bound variables from the substitution map
             substitutions = kwargs["substitutions"]
             new_subs = {}
-            for k,v in iteritems(substitutions):
+            for k,v in substitutions.items():
                 # If at least one bound variable is in the cone of k,
                 # we do not consider this substitution in the body of
                 # the quantifier.

--- a/pysmt/test/smtlib/test_annotations.py
+++ b/pysmt/test/smtlib/test_annotations.py
@@ -16,7 +16,8 @@
 #   limitations under the License.
 #
 import os
-from six import StringIO
+
+from io import StringIO
 
 from pysmt.test.smtlib.parser_utils import SMTLIB_DIR
 from pysmt.smtlib.parser import SmtLibParser

--- a/pysmt/test/smtlib/test_fuzzed.py
+++ b/pysmt/test/smtlib/test_fuzzed.py
@@ -19,7 +19,7 @@ import os
 
 import pytest
 
-from six import StringIO
+from io import StringIO
 
 from pysmt.shortcuts import reset_env
 from pysmt.test import TestCase

--- a/pysmt/test/smtlib/test_griggio.py
+++ b/pysmt/test/smtlib/test_griggio.py
@@ -17,7 +17,7 @@
 #
 import os
 
-from six import StringIO
+from io import StringIO
 
 from pysmt.shortcuts import reset_env
 from pysmt.test import TestCase

--- a/pysmt/test/smtlib/test_parser_examples.py
+++ b/pysmt/test/smtlib/test_parser_examples.py
@@ -18,7 +18,7 @@
 import os
 from tempfile import mkstemp
 
-from six.moves import cStringIO
+from io import StringIO
 
 import pysmt.logics as logics
 from pysmt.test import TestCase, skipIfNoSolverForLogic, main
@@ -38,7 +38,7 @@ class TestSMTParseExamples(TestCase):
             if logic == logics.QF_BV:
                 # See test_parse_examples_bv
                 continue
-            buf = cStringIO()
+            buf = StringIO()
             script_out = smtlibscript_from_formula(f_out)
             script_out.serialize(outstream=buf)
             #print(buf)
@@ -63,11 +63,11 @@ class TestSMTParseExamples(TestCase):
         for (f_out, _, _, logic) in fs:
             if logic != logics.QF_BV:
                 continue
-            buf_out = cStringIO()
+            buf_out = StringIO()
             script_out = smtlibscript_from_formula(f_out)
             script_out.serialize(outstream=buf_out)
 
-            buf_in = cStringIO(buf_out.getvalue())
+            buf_in = StringIO(buf_out.getvalue())
             parser = SmtLibParser()
             script_in = parser.get_script(buf_in)
             f_in = script_in.get_last_formula()
@@ -81,10 +81,10 @@ class TestSMTParseExamples(TestCase):
             if logic == logics.QF_BV:
                 # See test_parse_examples_daggified_bv
                 continue
-            buf_out = cStringIO()
+            buf_out = StringIO()
             script_out = smtlibscript_from_formula(f_out)
             script_out.serialize(outstream=buf_out, daggify=True)
-            buf_in = cStringIO(buf_out.getvalue())
+            buf_in = StringIO(buf_out.getvalue())
             parser = SmtLibParser()
             script_in = parser.get_script(buf_in)
             f_in = script_in.get_last_formula()
@@ -98,10 +98,10 @@ class TestSMTParseExamples(TestCase):
             if logic != logics.QF_BV:
                 # See test_parse_examples_daggified
                 continue
-            buf_out = cStringIO()
+            buf_out = StringIO()
             script_out = smtlibscript_from_formula(f_out)
             script_out.serialize(outstream=buf_out, daggify=True)
-            buf_in = cStringIO(buf_out.getvalue())
+            buf_in = StringIO(buf_out.getvalue())
             parser = SmtLibParser()
             script_in = parser.get_script(buf_in)
             f_in = script_in.get_last_formula()
@@ -112,10 +112,10 @@ class TestSMTParseExamples(TestCase):
         fs = get_example_formulae()
 
         for (f_out, _, _, logic) in fs:
-            buf_out = cStringIO()
+            buf_out = StringIO()
             script_out = smtlibscript_from_formula(f_out)
             script_out.serialize(outstream=buf_out)
-            buf_in = cStringIO(buf_out.getvalue())
+            buf_in = StringIO(buf_out.getvalue())
             parser = SmtLibParser()
             script_in = parser.get_script(buf_in)
             for cmd in script_in:
@@ -155,7 +155,7 @@ class TestSMTParseExamples(TestCase):
         """
         parser = SmtLibParser()
         with self.assertRaises(PysmtSyntaxError):
-            parser.get_script(cStringIO(txt))
+            parser.get_script(StringIO(txt))
 
     def test_parse_consume(self):
         smt_script = """
@@ -163,7 +163,7 @@ class TestSMTParseExamples(TestCase):
         (define-fun STRING_cmd_line_arg_1_1000 () String "AAAAAAAAAAAA")
         )
         """
-        tokens = Tokenizer(cStringIO(smt_script), interactive=True)
+        tokens = Tokenizer(StringIO(smt_script), interactive=True)
         parser = SmtLibParser()
         tokens.consume()
         tokens.consume()
@@ -179,7 +179,7 @@ class TestSMTParseExamples(TestCase):
         (assert (and y (x z)))
         """
         parser = SmtLibParser()
-        script = parser.get_script(cStringIO(txt))
+        script = parser.get_script(StringIO(txt))
         self.assertEqual(len(get_env().formula_manager.get_all_symbols()),
                          len(script.get_declared_symbols()) + len(script.get_define_fun_parameter_symbols()))
 
@@ -193,7 +193,7 @@ class TestSMTParseExamples(TestCase):
         (assert (=  A B))
         (check-sat)"""
         parser = SmtLibParser()
-        script = parser.get_script(cStringIO(txt))
+        script = parser.get_script(StringIO(txt))
         f_in = script.get_last_formula()
         self.assertSat(f_in)
 

--- a/pysmt/test/smtlib/test_parser_extensibility.py
+++ b/pysmt/test/smtlib/test_parser_extensibility.py
@@ -16,7 +16,7 @@
 #   limitations under the License.
 #
 import collections
-from six.moves import cStringIO
+from io import StringIO
 
 from pysmt.test import TestCase, main
 from pysmt.smtlib.parser import SmtLibParser
@@ -93,8 +93,8 @@ class TestParserExtensibility(TestCase):
         (exit)
         """
         with self.assertRaises(UnknownSmtLibCommandError):
-            self.ts_parser.get_ts(cStringIO(txt))
-        script = self.smt_parser.get_script(cStringIO(txt))
+            self.ts_parser.get_ts(StringIO(txt))
+        script = self.smt_parser.get_script(StringIO(txt))
         self.assertIsNotNone(script)
 
     def test_basic(self):
@@ -106,8 +106,8 @@ class TestParserExtensibility(TestCase):
         (exit)
         """
         with self.assertRaises(UnknownSmtLibCommandError):
-            self.smt_parser.get_script(cStringIO(txt))
-        ts = self.ts_parser.get_ts(cStringIO(txt))
+            self.smt_parser.get_script(StringIO(txt))
+        ts = self.ts_parser.get_ts(StringIO(txt))
         self.assertIsNotNone(ts)
 
 

--- a/pysmt/test/smtlib/test_smtlibscript.py
+++ b/pysmt/test/smtlib/test_smtlibscript.py
@@ -15,9 +15,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from six.moves import cStringIO
+from io import StringIO
 
 import pysmt.smtlib.commands as smtcmd
+
 from pysmt.shortcuts import And, Or, Symbol, GT, Real, Not
 from pysmt.typing import REAL
 from pysmt.test import TestCase, main
@@ -68,7 +69,7 @@ class TestSmtLibScript(TestCase):
                                    '(declare-sort s1 1)', \
                                    '(declare-const c0 s0)', \
                                    '(declare-const c1 (s1 Int))'])
-        outstream = cStringIO(smtlib_script)
+        outstream = StringIO(smtlib_script)
         script = parser.get_script(outstream)
         script.evaluate(solver=mock)
 
@@ -87,7 +88,7 @@ class TestSmtLibScript(TestCase):
         script = smtlibscript_from_formula(f)
 
         self.assertIsNotNone(script)
-        outstream = cStringIO()
+        outstream = StringIO()
         script.serialize(outstream)
         output = outstream.getvalue()
         self.assertIn("(set-logic ", output)
@@ -97,14 +98,14 @@ class TestSmtLibScript(TestCase):
 
         # Use custom logic (as str)
         script2 = smtlibscript_from_formula(f, logic="BOOL")
-        outstream = cStringIO()
+        outstream = StringIO()
         script2.serialize(outstream)
         output = outstream.getvalue()
         self.assertIn("(set-logic BOOL)", output)
 
         # Use custom logic (as Logic obj)
         script3 = smtlibscript_from_formula(f, logic=QF_UFLIRA)
-        outstream = cStringIO()
+        outstream = StringIO()
         script3.serialize(outstream)
         output = outstream.getvalue()
         self.assertIn("(set-logic QF_UFLIRA)", output)
@@ -135,15 +136,15 @@ class TestSmtLibScript(TestCase):
         target_one = And(GT(r, Real(0)), x)
         target_two = And(GT(r, Real(0)), x, Not(y))
 
-        stream_in = cStringIO(smtlib_single)
+        stream_in = StringIO(smtlib_single)
         f = get_formula(stream_in)
         self.assertEqual(f, target_one)
 
-        stream_in = cStringIO(smtlib_double)
+        stream_in = StringIO(smtlib_double)
         f = get_formula(stream_in)
         self.assertEqual(f, target_two)
 
-        stream_in = cStringIO(smtlib_double)
+        stream_in = StringIO(smtlib_double)
         with self.assertRaises(PysmtValueError):
             f = get_formula_strict(stream_in)
 
@@ -151,7 +152,7 @@ class TestSmtLibScript(TestCase):
     def test_define_funs_same_args(self):
         # n is defined once as an Int and once as a Real
         smtlib_script = "\n".join(['(define-fun f ((n Int)) Int n)', '(define-fun f ((n Real)) Real n)'])
-        stream = cStringIO(smtlib_script)
+        stream = StringIO(smtlib_script)
         parser = SmtLibParser()
         _ = parser.get_script(stream)
         # No exceptions are thrown
@@ -160,7 +161,7 @@ class TestSmtLibScript(TestCase):
 
     def test_define_funs_arg_and_fun(self):
         smtlib_script = "\n".join(['(define-fun f ((n Int)) Int n)', '(declare-fun n () Real)'])
-        stream = cStringIO(smtlib_script)
+        stream = StringIO(smtlib_script)
         parser = SmtLibParser()
         _ = parser.get_script(stream)
         # No exceptions are thrown
@@ -227,7 +228,7 @@ class TestSmtLibScript(TestCase):
         nie = 0
         for cmd in DEMO_SMTSCRIPT:
             try:
-                next(parser.get_command_generator(cStringIO(cmd)))
+                next(parser.get_command_generator(StringIO(cmd)))
             except NotImplementedError:
                 nie += 1
         # There are currently 3 not-implemented commands

--- a/pysmt/test/test_bv_simplification.py
+++ b/pysmt/test/test_bv_simplification.py
@@ -15,8 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from six.moves import xrange
-
 from pysmt.shortcuts import Solver, BVAnd, BVOr, BVXor, BVConcat, BVULT, BVUGT, \
     BVULE, BVUGE, BVAdd, BVSub, BVMul, BVUDiv, BVURem, BVLShl, BVLShr, BVNot, \
     BVNeg, BVZExt, BVSExt, BVRor, BVRol, BV, BVExtract, BVSLT, BVSLE, BVComp, \
@@ -45,7 +43,7 @@ class TestBvSimplification(TestCase):
     def all_bv_numbers(self, width=None):
         if width is None:
             width = self.width
-        for x in xrange(2 ** width):
+        for x in range(2 ** width):
             yield BV(x, width)
 
     @skipIfSolverNotAvailable("msat")
@@ -83,8 +81,8 @@ class TestBvSimplification(TestCase):
 
     def extract(self):
         for l in self.all_bv_numbers():
-            for s in xrange(0, self.width):
-                for e in xrange(s, self.width):
+            for s in range(0, self.width):
+                for e in range(s, self.width):
                     self.check(BVExtract(l, start=s, end=e))
 
     def concat_different_length(self):
@@ -95,7 +93,7 @@ class TestBvSimplification(TestCase):
 
     def all_special(self):
         for l in self.all_bv_numbers():
-            for n in xrange(0, self.width + 1):
+            for n in range(0, self.width + 1):
                 for op in self.special_operators:
                     self.check(op(l, n))
 

--- a/pysmt/test/test_constants.py
+++ b/pysmt/test/test_constants.py
@@ -15,7 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from six import PY2
 from fractions import Fraction as pyFraction
 
 from pysmt.test import TestCase, main, skipIf
@@ -37,8 +36,6 @@ class TestConstants(TestCase):
         self.assertTrue(is_pysmt_integer(Integer(4)))
 
         self.assertTrue(is_python_integer(int(2)))
-        if PY2:
-            self.assertTrue(is_python_integer(long(2)))
         if HAS_GMPY:
             from gmpy2 import mpz
             self.assertTrue(is_python_integer(mpz(1)))
@@ -47,8 +44,6 @@ class TestConstants(TestCase):
             from gmpy2 import mpz, mpq
             self.assertTrue(is_python_rational(mpz(1)))
             self.assertTrue(is_python_rational(mpq(1)))
-        if PY2:
-            self.assertTrue(is_python_rational(long(1)))
 
         self.assertTrue(is_python_rational(pyFraction(5)))
         self.assertTrue(is_python_rational(3))
@@ -63,7 +58,7 @@ class TestConstants(TestCase):
         self.assertEqual(Integer(4), pysmt_integer_from_integer(pyFraction(4)))
 
     def test_to_python_integer(self):
-        res = long(4) if PY2 else int(4)
+        res = int(4)
         self.assertEqual(res, to_python_integer(pysmt_integer_from_integer(4)))
         self.assertEqual(res, to_python_integer(pysmt_integer_from_integer(Integer(4))))
         self.assertEqual(res, to_python_integer(pysmt_integer_from_integer(Fraction(4))))

--- a/pysmt/test/test_eager_model.py
+++ b/pysmt/test/test_eager_model.py
@@ -15,8 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from six.moves import xrange
-
 from pysmt.test import TestCase, main
 from pysmt.shortcuts import And, Or, FALSE, TRUE, FreshSymbol, Solver
 from pysmt.solvers.eager import EagerModel
@@ -87,7 +85,7 @@ class TestEagerModel(TestCase):
 
 
     def test_contains(self):
-        x, y, z = [FreshSymbol() for _ in xrange(3)]
+        x, y, z = [FreshSymbol() for _ in range(3)]
         d = {x: TRUE(), y: FALSE()}
         model = EagerModel(assignment=d)
         self.assertTrue(x in model)
@@ -95,7 +93,7 @@ class TestEagerModel(TestCase):
 
     @skipIfSolverNotAvailable("z3")
     def test_warp_solvermodel(self):
-        x, y, z = [FreshSymbol() for _ in xrange(3)]
+        x, y, z = [FreshSymbol() for _ in range(3)]
         with Solver(name='z3') as solver:
             solver.add_assertion(And(x,y,z))
             solver.solve()

--- a/pysmt/test/test_formula.py
+++ b/pysmt/test/test_formula.py
@@ -15,10 +15,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-
-from six.moves import xrange
-
 import pysmt
+
 from pysmt.typing import BOOL, REAL, INT, FunctionType, BV8, BVType
 from pysmt.shortcuts import Symbol, is_sat, Not, Implies, GT, Plus, Int, Real
 from pysmt.shortcuts import Minus, Times, Xor, And, Or, TRUE, Iff, FALSE, Ite
@@ -612,8 +610,8 @@ class TestFormulaManager(TestCase):
         f = self.mgr.AllDifferent(symbols)
 
         one = self.mgr.Int(1)
-        for i in xrange(many):
-            for j in xrange(many):
+        for i in range(many):
+            for j in range(many):
                 if i != j:
                     c = f.substitute({symbols[i]: one,
                                       symbols[j]: one}).simplify()
@@ -622,7 +620,7 @@ class TestFormulaManager(TestCase):
                                      "to be 1")
 
 
-        c = f.substitute(dict((symbols[i],self.mgr.Int(i)) for i in xrange(many)))
+        c = f.substitute(dict((symbols[i],self.mgr.Int(i)) for i in range(many)))
         self.assertEqual(c.simplify(), self.mgr.Bool(True),
                          "AllDifferent should be tautological for a set " \
                          "of different values")
@@ -1014,7 +1012,6 @@ class TestFormulaManager(TestCase):
     def test_integer(self):
         """Create Int using different constant types."""
         from pysmt.constants import HAS_GMPY
-        from six import PY2
 
         v_base = Integer(1)
         c_base = self.mgr.Int(v_base)
@@ -1022,11 +1019,6 @@ class TestFormulaManager(TestCase):
         v_int = int(1)
         c_int = self.mgr.Int(v_int)
         self.assertIs(c_base, c_int)
-
-        if PY2:
-            v_long = long(1)
-            c_long = self.mgr.Int(v_long)
-            self.assertIs(c_base, c_long)
 
         if HAS_GMPY:
             from gmpy2 import mpz

--- a/pysmt/test/test_printing.py
+++ b/pysmt/test/test_printing.py
@@ -15,8 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from six.moves import cStringIO
-from six.moves import xrange
+from io import StringIO
 
 from pysmt.shortcuts import Or, And, Not, Plus, Iff, Implies
 from pysmt.shortcuts import Exists, ForAll, Ite, ExactlyOne
@@ -142,7 +141,7 @@ class TestPrinting(TestCase):
     def test_threshold_printing(self):
         x = Symbol("x")
         f = And(x,x)
-        for _ in xrange(10):
+        for _ in range(10):
             f = And(f,f)
 
         short_f_str = str(f)
@@ -152,11 +151,11 @@ class TestPrinting(TestCase):
     def test_daggify(self):
         x = Symbol("x")
         f = And(x,x)
-        for _ in xrange(10):
+        for _ in range(10):
             f = And(f,f)
 
-        tree_buf = cStringIO()
-        dag_buf = cStringIO()
+        tree_buf = StringIO()
+        dag_buf = StringIO()
         tree_printer = SmtPrinter(tree_buf)
         dag_printer = SmtDagPrinter(dag_buf)
 
@@ -187,7 +186,7 @@ class TestPrinting(TestCase):
         self.assertIsNotNone(res)
         self.assertEqual(str(f), res)
 
-        fvars = [Symbol("x%d" % i) for i in xrange(5)]
+        fvars = [Symbol("x%d" % i) for i in range(5)]
         ex = ExactlyOne(fvars)
         substitutions = {ex: "ExactlyOne(%s)" % ",".join(str(v) for v in fvars)}
         old_str = ex.serialize()
@@ -200,7 +199,7 @@ class TestPrinting(TestCase):
         limit = sys.getrecursionlimit()
         f = FreshSymbol()
         p = FreshSymbol()
-        for _ in xrange(limit):
+        for _ in range(limit):
             f = Or(p, And(f, p))
         self.assertTrue(f.size() >= limit)
         s = f.serialize()

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -15,8 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from six.moves import xrange
-from six.moves import cStringIO
+from io import StringIO
 
 import pysmt.logics as logics
 import pysmt.smtlib.commands as smtcmd
@@ -228,7 +227,7 @@ class TestRegressions(TestCase):
     def test_determinism(self):
         def get_set(env):
             mgr = env.formula_manager
-            r = set(mgr.Symbol("x%d" % i) for i in xrange(1000))
+            r = set(mgr.Symbol("x%d" % i) for i in range(1000))
             for (f, _, _, _) in get_example_formulae(env):
                 r |= set([f])
             return r
@@ -237,9 +236,9 @@ class TestRegressions(TestCase):
         l1 = list(get_set(get_env()))
 
         # We try this ten times...
-        for _ in xrange(10):
+        for _ in range(10):
             # Do something to screw up memory layout...
-            for y in (Symbol("y%d" % i) for i in xrange(1000)):
+            for y in (Symbol("y%d" % i) for i in range(1000)):
                 self.assertIsNotNone(y)
 
             with Environment() as new_env:
@@ -281,14 +280,14 @@ class TestRegressions(TestCase):
         smtlib_input = "(declare-fun z () Bool)"\
                        "(define-fun .def_1 ((z Bool)) Bool (and z z))"
         parser = SmtLibParser()
-        buffer_ = cStringIO(smtlib_input)
+        buffer_ = StringIO(smtlib_input)
         parser.get_script(buffer_)
 
     def test_parse_define_fun_bind(self):
         smtlib_input = "(declare-fun y () Bool)"\
                        "(define-fun .def_1 ((z Bool)) Bool (and z z))"
         parser = SmtLibParser()
-        buffer_ = cStringIO(smtlib_input)
+        buffer_ = StringIO(smtlib_input)
         parser.get_script(buffer_)
 
     def test_parse_bvx_var(self):
@@ -298,7 +297,7 @@ class TestRegressions(TestCase):
         (assert (bvult (_ bv0 8) (bvmul (bvadd bv1 (_ bv1 8)) (_ bv5 8))))
         (check-sat)"""
         parser = SmtLibParser()
-        buffer_ = cStringIO(smtlib_input)
+        buffer_ = StringIO(smtlib_input)
         script = parser.get_script(buffer_)
         # Check Parsed result
         iscript = iter(script)
@@ -390,7 +389,7 @@ class TestRegressions(TestCase):
     def test_smtlib_define_fun_serialization(self):
         smtlib_input = "(define-fun init ((x Bool)) Bool (and x (and x (and x (and x (and x (and x x)))))))"
         parser = SmtLibParser()
-        buffer_ = cStringIO(smtlib_input)
+        buffer_ = StringIO(smtlib_input)
         s = parser.get_script(buffer_)
         for c in s:
             res = c.serialize_to_string(daggify=False)
@@ -430,7 +429,7 @@ class TestRegressions(TestCase):
         (declare-const s Int)
         (check-sat)"""
         parser = SmtLibParser()
-        buffer_ = cStringIO(smtlib_input)
+        buffer_ = StringIO(smtlib_input)
         script = parser.get_script(buffer_)
         self.assertIsNotNone(script)
 
@@ -448,7 +447,7 @@ class TestRegressions(TestCase):
         smtlib_input = "(declare-const x x x Int)" +\
                        "(check-sat)"
         parser = SmtLibParser()
-        buffer_ = cStringIO(smtlib_input)
+        buffer_ = StringIO(smtlib_input)
         try:
             parser.get_script(buffer_)
             self.assertFalse(True)
@@ -459,7 +458,7 @@ class TestRegressions(TestCase):
     def test_parse_bvconst_width(self):
         smtlib_input = "(assert (> #x10 #x10))"
         parser = SmtLibParser()
-        buffer_ = cStringIO(smtlib_input)
+        buffer_ = StringIO(smtlib_input)
         expr = parser.get_script(buffer_).get_last_formula()
         const = expr.args()[0]
         self.assertEqual(const.bv_width(), 8, const.bv_width())
@@ -497,7 +496,7 @@ class TestRegressions(TestCase):
         """
 
         p = SmtLibParser()
-        buffer = cStringIO(script)
+        buffer = StringIO(script)
         s = p.get_script(buffer)
         self.assertEqual('a"b', s.commands[1].args[0].arg(1).constant_value())
         self.assertEqual('"', s.commands[2].args[0].arg(1).constant_value())
@@ -528,7 +527,7 @@ class TestRegressions(TestCase):
         (check-sat)
         '''
         from pysmt.smtlib.parser import get_formula_strict
-        f = get_formula_strict(cStringIO(smt_script))
+        f = get_formula_strict(StringIO(smt_script))
         self.assertSat(f, solver_name='yices')
 
     @skipIfSolverNotAvailable("yices")
@@ -542,7 +541,7 @@ class TestRegressions(TestCase):
         (check-sat)
         '''
         from pysmt.smtlib.parser import get_formula_strict
-        f = get_formula_strict(cStringIO(smt_script))
+        f = get_formula_strict(StringIO(smt_script))
         self.assertSat(f, solver_name='yices')
 
     def test_get_atoms_array_select(self):

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -15,10 +15,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from six.moves import xrange
-from six import PY2
-
 import pysmt.operators as op
+
 from pysmt.shortcuts import Symbol, FreshSymbol, And, Not, GT, Function, Plus
 from pysmt.shortcuts import Bool, TRUE, Real, LE, FALSE, Or, Equals, Implies
 from pysmt.shortcuts import Solver
@@ -351,7 +349,7 @@ class TestBasic(TestCase):
                         self.assertIsNone(f_i)
 
     def test_solving_under_assumption(self):
-        v1, v2 = [FreshSymbol() for _ in xrange(2)]
+        v1, v2 = [FreshSymbol() for _ in range(2)]
         xor = Or(And(v1, Not(v2)), And(Not(v1), v2))
 
         for name in get_env().factory.all_solvers():
@@ -549,9 +547,6 @@ class TestBasic(TestCase):
     @skipIfNoSolverForLogic(QF_LRA)
     def test_logic_as_string(self):
         self.assertEqual(convert_logic_from_string("QF_LRA"), QF_LRA)
-        if PY2:
-            self.assertEqual(convert_logic_from_string(unicode("QF_LRA")),
-                             QF_LRA)
         with self.assertRaises(UndefinedLogicError):
             convert_logic_from_string("PAPAYA")
         self.assertIsNone(convert_logic_from_string(None))

--- a/pysmt/test/test_sorts.py
+++ b/pysmt/test/test_sorts.py
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from six import StringIO
+from io import StringIO
 
 from pysmt.shortcuts import FreshSymbol, EqualsOrIff, Select, TRUE, FALSE, Function
 from pysmt.shortcuts import Array, BV

--- a/pysmt/test/test_walkers.py
+++ b/pysmt/test/test_walkers.py
@@ -15,8 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from six.moves import xrange
-
 import pysmt.operators as op
 from pysmt.shortcuts import FreshSymbol, Symbol, Int, Bool, ForAll
 from pysmt.shortcuts import And, Or, Iff, Not, Function, Real
@@ -214,7 +212,7 @@ class TestWalkers(TestCase):
 
     def test_iterative_get_free_variables(self):
         f = Symbol("x")
-        for _ in xrange(1000):
+        for _ in range(1000):
             f = And(f, f)
 
         cone = f.get_free_variables()

--- a/pysmt/utils.py
+++ b/pysmt/utils.py
@@ -77,14 +77,3 @@ def quote(name, style='|'):
         return "%s%s%s" % (style, name, style)
     else:
         return name
-
-
-def open_(fname):
-    """Transparently handle .bz2 files."""
-    if fname.endswith(".bz2"):
-        import bz2
-        if PY2:
-            return bz2.BZ2File(fname, "r")
-        else:
-            return bz2.open(fname, "rt")
-    return open(fname)

--- a/pysmt/walkers/generic.py
+++ b/pysmt/walkers/generic.py
@@ -16,7 +16,7 @@
 #   limitations under the License.
 #
 from functools import partial
-from six import with_metaclass
+
 import sys
 if sys.version_info >= (3, 3):
     from collections.abc import Iterable
@@ -65,7 +65,7 @@ class MetaNodeTypeHandler(type):
         return obj
 
 
-class Walker(with_metaclass(MetaNodeTypeHandler)):
+class Walker(object, metaclass=MetaNodeTypeHandler):
     """Base Abstract Walker class.
 
     Do not subclass directly, use DagWalker or TreeWalker, instead.

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,6 @@ Additionally, you can use any SMT-LIB 2 compliant solver.
 PySMT assumes that the python bindings for the SMT Solver are installed and
 accessible from your PYTHONPATH.
 
-pySMT works on both Python 3 and Python 2.
-
 
 Wanna know more?
 ================
@@ -59,7 +57,6 @@ setup(
     license='APACHE',
     description='A solver-agnostic library for SMT Formulae manipulation and solving',
     long_description=long_description,
-    install_requires=["six"],
     entry_points={
         'console_scripts': [
             'pysmt-install = pysmt.cmd.install:main',


### PR DESCRIPTION
We officially [dropped support for python 2 in 0.9.0 (2020-04-26)](https://github.com/pysmt/pysmt/blob/master/docs/CHANGES.rst#090-2020-04-26----pysmt-as-module).

We now remove the dependency from six and all its uses in the code. This means that pySMT now does not work anymore with python 2!

This change is motivated by python 2 EOL and aimed at reducing maintenance overhead.

Thanks to the six.py team for the awesome work!