### PR TITLE
Added Psuedo-Boolean for Z3

### DIFF
--- a/pysmt/fnode.py
+++ b/pysmt/fnode.py
@@ -44,9 +44,10 @@ from pysmt.operators import (FORALL, EXISTS, AND, OR, NOT, IMPLIES, IFF,
                              STR_TO_INT, INT_TO_STR,
                              STR_CHARAT,
                              ARRAY_SELECT, ARRAY_STORE, ARRAY_VALUE,
-                             ALGEBRAIC_CONSTANT)
+                             ALGEBRAIC_CONSTANT,
+                             PBLE, PBGE, PBEQ)
 
-from pysmt.operators import  (BOOL_OPERATORS, THEORY_OPERATORS,
+from pysmt.operators import  (BOOL_OPERATORS, PSEUDO_BOOLEAN, THEORY_OPERATORS,
                               BV_OPERATORS, IRA_OPERATORS, ARRAY_OPERATORS,
                               STR_OPERATORS,
                               RELATIONS, CONSTANTS)
@@ -328,6 +329,18 @@ class FNode(object):
     def is_lt(self):
         """Test whether the node is the LT (less than) relation."""
         return self.node_type() == LT
+
+    def is_pble(self):
+        """Test whether the node is the PbLe operator."""
+        return self.node_type() == PBLE
+
+    def is_pbge(self):
+        """Test whether the node is the PbGe operator."""
+        return self.node_type() == PBGE
+
+    def is_pbeq(self):
+        """Test whether the node is the PbEq operator."""
+        return self.node_type() == PBEQ
 
     def is_bool_op(self):
         """Test whether the node is a Boolean operator."""
@@ -681,6 +694,14 @@ class FNode(object):
         """Return the list of quantified variables."""
         assert self.is_quantifier()
         return self._content.payload
+
+    def pb_coeffs(self):
+        """Return the tuple of the coefficients"""
+        return self._content.payload[0]
+
+    def pb_k(self):
+        """Return constant k"""
+        return self._content.payload[1]
 
     def algebraic_approx_value(self, precision=10):
         value = self.constant_value()

--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -565,6 +565,29 @@ class FormulaManager(object):
         else:
             return self.Equals(left, right)
 
+    # Pseudo-Booleans
+    def PbLe(self, vals, coeffs, k):
+        """ Creates a Pseudo-Boolean inequality k constraint.
+        e.g.) PbLe((x, y, z), (2, 3, 4), 6) encodes of a formula 2x + 3y + 4z <= 6
+
+        :param vals: BOOL Symbols tuple or list of variables.
+        :param coeffs: integer tuple or list of coefficients.
+        :param k: integer constant
+        """
+        return self.create_node(node_type=op.PBLE, args=vals, payload=(coeffs, k))
+
+    def PbGe(self, vals, coeffs, k):
+        """ Creates a Pseudo-Boolean inequality k constraint.
+        e.g.) PbGe((x, y, z), (2, 3, 4), 6) encodes of a formula 2x + 3y + 4z >= 6
+        """
+        return self.create_node(node_type=op.PBGE, args=vals, payload=(coeffs, k))
+
+    def PbEq(self, vals, coeffs, k):
+        """ Creates a Pseudo-Boolean inequality k constraint.
+        e.g.) PbEq((x, y, z), (2, 3, 4), 6) encodes of a formula 2x + 3y + 4z = 6
+        """
+        return self.create_node(node_type=op.PBEQ, args=vals, payload=(coeffs, k))
+
     # BitVectors
     def BV(self, value, width=None):
         """Return a constant of type BitVector.

--- a/pysmt/operators.py
+++ b/pysmt/operators.py
@@ -24,7 +24,7 @@ these operators.
 from itertools import chain
 
 
-ALL_TYPES = list(range(0,66))
+ALL_TYPES = list(range(0,69))
 
 (
 FORALL, EXISTS, AND, OR, NOT, IMPLIES, IFF, # Boolean Logic (0-6)
@@ -78,13 +78,18 @@ DIV,                                        # Arithmetic Division (62)
 POW,                                        # Arithmetic Power (63)
 ALGEBRAIC_CONSTANT,                         # Algebraic Number (64)
 BV_TONATURAL,                               # BV to Natural Conversion (65)
+PBLE,                                       # Pseudo-Boolean LE (66)
+PBGE,                                       # Pseudo-Boolean GE (67)
+PBEQ,                                       # Pseudo-Boolean EQUAL (68)
 ) = ALL_TYPES
 
 QUANTIFIERS = frozenset([FORALL, EXISTS])
 
 BOOL_CONNECTIVES = frozenset([AND, OR, NOT, IMPLIES, IFF])
 
-BOOL_OPERATORS = frozenset(QUANTIFIERS | BOOL_CONNECTIVES)
+PSEUDO_BOOLEAN = frozenset([PBLE, PBGE, PBEQ])
+
+BOOL_OPERATORS = frozenset(QUANTIFIERS | PSEUDO_BOOLEAN | BOOL_CONNECTIVES)
 
 CONSTANTS = frozenset([BOOL_CONSTANT, REAL_CONSTANT, INT_CONSTANT,
                        BV_CONSTANT, STR_CONSTANT, ALGEBRAIC_CONSTANT])
@@ -222,4 +227,7 @@ __OP_STR__ = {
     DIV: "DIV",
     POW: "POW",
     ALGEBRAIC_CONSTANT: "ALGEBRAIC_CONSTANT",
+    PBLE: "PBLE",
+    PBGE: "PBGE",
+    PBEQ: "PBEQ"
 }

--- a/pysmt/printers.py
+++ b/pysmt/printers.py
@@ -323,6 +323,34 @@ class HRPrinter(TreeWalker):
     walk_bv_mul = walk_times
     walk_bv_sub = walk_minus
 
+    def walk_pble(self, formula):
+        return self._walk_pb("pble", formula)
+
+    def walk_pbge(self, formula):
+        return self._walk_pb("pbge", formula)
+
+    def walk_pbeq(self, formula):
+        return self._walk_pb("pbeq", formula)
+
+    def _walk_pb(self, operator, formula):
+        args = formula.args()
+        coeffs = formula.pb_coeffs()
+
+        self.write("(")
+
+        h = 0
+        for i, j in zip(coeffs, args):
+            self.write("%s" % i)
+            self.write("%s" % j)
+            if (h < len(coeffs) - 1):
+                self.write(" + ")
+            h += 1
+
+        self.write(" %s " % operator)
+        self.write("%s" % formula.pb_k())
+
+        self.write(")")
+
 #EOC HRPrinter
 
 

--- a/pysmt/shortcuts.py
+++ b/pysmt/shortcuts.py
@@ -371,6 +371,26 @@ def EqualsOrIff(left, right):
     """
     return get_env().formula_manager.EqualsOrIff(left, right)
 
+#
+# Pseudo-Booleans
+#
+def PbLe(vals, coeffs, k):
+    """Returns Pseudo-Boolean function.
+        coeffs[0]*vals[0] + ... + coeffs[n]*vals[n] <= k
+    """
+    return get_env().formula_manager.PbLe(vals, coeffs, k)
+
+def PbGe(vals, coeffs, k):
+    """Returns Pseudo-Boolean function.
+        coeffs[0]*vals[0] + ... + coeffs[n]*vals[n] >= k
+    """
+    return get_env().formula_manager.PbGe(vals, coeffs, k)
+
+def PbEq(vals, coeffs, k):
+    """Returns Pseudo-Boolean function.
+        coeffs[0]*vals[0] + ... + coeffs[n]*vals[n] = k
+    """
+    return get_env().formula_manager.PbEq(vals, coeffs, k)
 
 #
 # Bit Vectors

--- a/pysmt/smtlib/printers.py
+++ b/pysmt/smtlib/printers.py
@@ -267,6 +267,27 @@ class SmtPrinter(TreeWalker):
             yield assign[k]
             self.write(")")
 
+    def walk_pble(self, formula):
+        return self._walk_pb("pble", formula)
+
+    def walk_pbge(self, formula):
+        return self._walk_pb("pbge", formula)
+
+    def walk_pbeq(self, formula):
+        return self._walk_pb("pbeq", formula)
+
+    def _walk_pb(self, operator, formula):
+        self.write("((_ %s " % operator)
+        self.write("%s" % formula.pb_k())
+
+        for s in formula.pb_coeffs():
+            self.write(" %s" % s)
+
+        self.write(")")
+
+        for t in formula.args():
+            self.write(" %s" % t)
+        self.write(")")
 
 class SmtDagPrinter(DagWalker):
 

--- a/pysmt/test/examples.py
+++ b/pysmt/test/examples.py
@@ -37,7 +37,7 @@ from pysmt.shortcuts import (Symbol, Function,
                              StrIndexOf, StrLength, StrPrefixOf, StrReplace,
                              StrSubstr, StrSuffixOf, StrToInt,
                              IntToStr, BVToNatural,
-                             Store, Select, Array, Type)
+                             Store, Select, Array, Type, PbLe)
 
 from pysmt.typing import REAL, BOOL, INT, BV8, BV16, BVType, ARRAY_INT_INT
 from pysmt.typing import FunctionType, ArrayType, STRING
@@ -58,6 +58,9 @@ def get_full_example_formulae(environment=None):
         environment = get_env()
 
     with environment:
+        a = Int(1)
+        b = Int(2)
+        c = Int(3)
         x = Symbol("x", BOOL)
         y = Symbol("y", BOOL)
         p = Symbol("p", INT)
@@ -133,6 +136,16 @@ def get_full_example_formulae(environment=None):
                     is_sat=False,
                     logic=pysmt.logics.QF_BOOL
                 ),
+
+            #
+            #  PSEUDO-BOOLEAN
+            #
+            Example(hr="1x + 2y <= 3",
+                    expr=PbLe((x,y), (a, b), c),
+                    is_valid=False,
+                    is_sat=True,
+                    logic=pysmt.logics.QF_BOOL
+                    ),
 
             #
             #  LIA

--- a/pysmt/test/test_pb.py
+++ b/pysmt/test/test_pb.py
@@ -1,0 +1,99 @@
+#
+# This file is part of pySMT.
+#
+#   Copyright 2015 Andrea Micheli and Marco Gario
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from pysmt.shortcuts import Symbol, Int, is_sat
+from pysmt.typing import INT, REAL
+from pysmt.test import TestCase, skipIfSolverNotAvailable, main
+from pysmt.exceptions import PysmtTypeError
+
+
+
+class TestPB(TestCase):
+    def test_pb(self):
+        mgr = self.env.formula_manager
+        PbLe = mgr.PbLe
+        PbGe = mgr.PbGe
+        PbEq = mgr.PbEq
+
+        x = Symbol("x")
+        y = Symbol("y")
+        z = Symbol("z", INT)
+        w = x
+        c1 = Int(1)
+        c2 = Int(2)
+        c3 = Int(3)
+        c4 = Int(-4)
+        c5 = Int(-2)
+
+        #1x + 2y <= 3
+        f1 = PbLe((x, y), (c1, c2), c3)
+
+        #1x + 2y >= 3
+        f2 = PbGe((x, y), (c1, c2), c3)
+
+        #1x + 2y = 3
+        f3 = PbEq((x, y), (c1, c2), c3)
+
+        #1w + 2y <= 3
+        f4 = PbLe((w, y), (c1, c2), c3)
+
+        #2x + (-4)y <= -2
+        f5 = PbLe((x, y), (c2, c4), c5)
+
+        self.assertEqual(f1, f4)
+
+        self.assertTrue(is_sat(f1, "z3"))
+        self.assertTrue(is_sat(f2, "z3"))
+        self.assertTrue(is_sat(f3, "z3"))
+        self.assertTrue(is_sat(f4, "z3"))
+        self.assertTrue(is_sat(f5, "z3"))
+
+        #Test PB node
+        self.assertIsNotNone(f1)
+        self.assertIsNotNone(f2)
+        self.assertIsNotNone(f3)
+        self.assertTrue(f1.is_pble())
+        self.assertTrue(f2.is_pbge())
+        self.assertTrue(f3.is_pbeq())
+
+
+        #Type check of arguments
+        #Can't use python integer for coefficients and constant
+        with self.assertRaises(PysmtTypeError):
+            PbLe((x, z), (1, 2), 3)
+        with self.assertRaises(PysmtTypeError):
+            PbLe((x, y), (c1, 2), 3)
+        with self.assertRaises(PysmtTypeError):
+            PbLe((x, y), (1, 2), c3)
+
+        with self.assertRaises(PysmtTypeError):
+            PbGe((x, z), (1, 2), 3)
+        with self.assertRaises(PysmtTypeError):
+            PbGe((x, y), (c1, 2), 3)
+        with self.assertRaises(PysmtTypeError):
+            PbGe((x, y), (1, 2), c3)
+
+        with self.assertRaises(PysmtTypeError):
+            PbEq((x, z), (1, 2), 3)
+        with self.assertRaises(PysmtTypeError):
+            PbEq((x, y), (c1, 2), 3)
+        with self.assertRaises(PysmtTypeError):
+            PbEq((x, y), (1, 2), c3)
+
+if __name__ == '__main__':
+    main()

--- a/pysmt/type_checker.py
+++ b/pysmt/type_checker.py
@@ -27,7 +27,7 @@ import pysmt.operators as op
 
 from pysmt.typing import BOOL, REAL, INT, BVType, ArrayType, STRING
 from pysmt.exceptions import PysmtTypeError
-
+from pysmt.constants import is_pysmt_integer, is_python_integer
 
 class SimpleTypeChecker(walkers.DagWalker):
 
@@ -56,6 +56,16 @@ class SimpleTypeChecker(walkers.DagWalker):
     @walkers.handles(op.AND, op.OR, op.NOT, op.IMPLIES, op.IFF)
     def walk_bool_to_bool(self, formula, args, **kwargs):
         #pylint: disable=unused-argument
+        return self.walk_type_to_type(formula, args, BOOL, BOOL)
+
+    @walkers.handles(op.PBLE, op.PBGE, op.PBEQ)
+    def walk_pb(self, formula, args, **kwargs):
+        assert formula is not None
+        for x in formula.pb_coeffs():
+            if isinstance(x, int) or (not x.is_int_constant()):
+                return None
+        if isinstance(formula.pb_k(), int) or (not formula.pb_k().is_int_constant()):
+            return None
         return self.walk_type_to_type(formula, args, BOOL, BOOL)
 
     def walk_real_to_bool(self, formula, args, **kwargs):

--- a/pysmt/walkers/identitydag.py
+++ b/pysmt/walkers/identitydag.py
@@ -88,6 +88,15 @@ class IdentityDagWalker(DagWalker):
                  for v in formula.quantifier_vars()]
         return self.mgr.Exists(qvars, args[0])
 
+    def walk_pble(self, formula, args, **kwargs):
+        return self.mgr.PbLe(args)
+
+    def walk_pbge(self, formula, args, **kwargs):
+        return self.mgr.PbGe(args)
+
+    def walk_pbeq(self, formula, args, **kwargs):
+        return self.mgr.PbEq(args)
+
     def walk_plus(self, formula, args, **kwargs):
         return self.mgr.Plus(args)
 


### PR DESCRIPTION
Thanks for contributing to pySMT!

To whom it may concern,

I'm Junichiro Kishi, a master's student who belongs Nagoya University, Japan.
Our research group has developed [CombSQL+](https://www.trs.css.i.nagoya-u.ac.jp/projects/CombSQLplus/), which is a combinatorial optimization solver based on SQL, and we use pySMT on CombSQL+ to use multiple SMT solvers on the same interface.

I added Psuedo-Boolean interface for Z3 to pySMT to speed up CombSQL+'s execution speed.

Because this is my first time contribution to another project, I may have made various mistakes. (but I intend to check it properly...)
We appreciate your feedbacks.

Sincerely, Junichiro Kishi.

Here are good things to check:

- [-] For bugs or new features, make sure there is a test showing the bug or demonstrating the use of the new feature
- [-] Are all tests green?
- [-] (First contribution only) You accepted the licensing terms by adding name and email to the CONTRIBUTORS file (see https://github.com/pysmt/pysmt/blob/master/docs/development.rst#licensing).
