### PR TITLE
Integer div

### DIFF
--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -1027,11 +1027,11 @@ class Simplifier(pysmt.walkers.DagWalker):
             else:
                 assert sl.is_int_constant()
                 # smtlib2 semantics of integer division:
-                # l > 0 : l / r == floor(float(l) / r)
-                # l < 0 : l / r == ceil(float(l) / r)
-                if l > 0:
+                # r > 0 : l / r == floor(float(l) / r)
+                # r < 0 : l / r == ceil(float(l) / r)
+                if r > 0:
                     return self.manager.Int(math.floor(float(l) / r))
-                if l < 0:
+                if r < 0:
                     return self.manager.Int(math.ceil(float(l) / r))
 
         if sl.is_constant():


### PR DESCRIPTION
In #667 I wrongly defined the integer division as based on the sign of the numerator.    
However, in https://smtlib.cs.uiowa.edu/theories-Ints.shtml it is defined depending on the sign of the denominator.
This should fix this issue.