### PR TITLE
Fix missing file in Manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include LICENSE README.rst
 recursive-include docs *.rst
+include pysmt/test/configs/*
+


### PR DESCRIPTION
Fix for https://github.com/pysmt/pysmt/issues/608. The config was missing from the MANIFEST file and thus not being included.