### PR TITLE
Upgrade MathSAT to 5.6.7

### DIFF
--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -32,7 +32,7 @@ from pysmt import __version__ as pysmt_version
 Installer = namedtuple("Installer",
                        ["InstallerClass", "version", "extra_params"])
 INSTALLERS = [
-    Installer(MSatInstaller,    "5.6.6", {}),
+    Installer(MSatInstaller,    "5.6.7", {}),
     Installer(CVC4Installer,    "1.7-prerelease",
               {"git_version" : "391ab9df6c3fd9a3771864900c1718534c1e4666"}),
     Installer(Z3Installer,      "4.8.7", {"osx": "10.14.6"}),

--- a/pysmt/cmd/installers/msat.py
+++ b/pysmt/cmd/installers/msat.py
@@ -26,21 +26,24 @@ class MSatInstaller(SolverInstaller):
                  mirror_link=None):
 
         # Getting the right archive name
-        os_name = self.os_name
-        arch = self.architecture
-        ext = "tar.gz"
-        if os_name == "windows":
-            ext = "zip"
-            arch = "msvc"
-            if self.architecture == "x86_64":
-                os_name = "win64"
-            else:
-                os_name = "win32"
-        elif os_name == "darwin":
-            os_name = "darwin-libcxx"
+        archive_name_template = "mathsat-{version}-{os}-{arch}.{ext}"
+        format = {
+                "version": solver_version,
+                "os" : self.os_name,
+                "arch": self.architecture,
+                "ext": "tar.gz"
+        }
+        if self.os_name == "windows":
+            format["ext"] = "zip"
+            format["arch"] = "msvc"
+            format["os"] = "win64" if self.architecture == "x86_64" else "win32"
+        elif self.os_name == "darwin":
+            # Since version 5.6.7 the architecture is not included in the
+            # pkg name for the OSX release as it is considered a "univeral binary"
+            archive_name_template = "mathsat-{version}-{os}.{ext}"
+            format["os"] = "osx"
 
-        archive_name = "mathsat-%s-%s-%s.%s" % (solver_version, os_name,
-                                                arch, ext)
+        archive_name = archive_name_template.format(**format)
 
         native_link = "http://mathsat.fbk.eu/download.php?file={archive_name}"
 
@@ -103,7 +106,7 @@ class MSatInstaller(SolverInstaller):
         # Fix issue in MathSAT 5.5.1 linking to incorrect directory on OSX
         if self.os_name == "darwin":
             soname = glob.glob(self.bindings_dir + "/_mathsat*.so")[0]
-            old_path = "/Users/griggio/Documents/src/mathsat_release/build/libmathsat.dylib"
+            old_path = "/Users/alb/src/build_mathsat5/opt/libmathsat.dylib"
             new_path = "%s/libmathsat.dylib" % self.bindings_dir
             SolverInstaller.run("install_name_tool -change %s %s %s" %
                                 (old_path, new_path, soname))


### PR DESCRIPTION
Update MathSAT to 5.6.7. This includes changes on how the OSX version is package to be architecture independent (thus support the M1 architecture).

See https://github.com/pysmt/pysmt/issues/709