### PR TITLE
Upgrade MathSAT to 5.6.6

### DIFF
--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -32,7 +32,7 @@ from pysmt import __version__ as pysmt_version
 Installer = namedtuple("Installer",
                        ["InstallerClass", "version", "extra_params"])
 INSTALLERS = [
-    Installer(MSatInstaller,    "5.6.1", {}),
+    Installer(MSatInstaller,    "5.6.6", {}),
     Installer(CVC4Installer,    "1.7-prerelease",
               {"git_version" : "391ab9df6c3fd9a3771864900c1718534c1e4666"}),
     Installer(Z3Installer,      "4.8.7", {"osx": "10.14.6"}),


### PR DESCRIPTION
This is pre-work for https://github.com/pysmt/pysmt/pull/719. 
Since the changes to 5.6.7 are failing the CI for osx, I wanted to make sure there was no issue up to 5.6.6 (from 5.6.1).