### PR TITLE
CI: Avoid running on PR branch push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test and Deploy
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
 
 jobs:
   run-tests:
@@ -14,8 +18,8 @@ jobs:
     env:
       PYTHON_VERSION: 3.8
       PYSMT_SOLVER: ${{ matrix.pysmt_solver }}
-      AGENT_OS: ${{ matrix.os }} 
-    
+      AGENT_OS: ${{ matrix.os }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -64,10 +68,10 @@ jobs:
     env:
       PYTHON_VERSION: 3.8
       PYSMT_SOLVER: ${{ matrix.pysmt_solver }}
-      AGENT_OS: ${{ matrix.os }} 
-      PYSMT_CYTHON: ${{ matrix.pysmt_cython }} 
-      PYSMT_GMPY: ${{ matrix.pysmt_gmpy }} 
-    
+      AGENT_OS: ${{ matrix.os }}
+      PYSMT_CYTHON: ${{ matrix.pysmt_cython }}
+      PYSMT_GMPY: ${{ matrix.pysmt_gmpy }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -84,7 +88,7 @@ jobs:
       - name: Run Tests
         run: |
           bash ci/run.sh
-  
+
 
   deploy-pypi:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Refine the CI triggers to only run tests for pushes on `master` or PRs targeting `master`.