### PR TITLE
Upgrade Z3 to 4.8.17

### DIFF
--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -35,7 +35,7 @@ INSTALLERS = [
     Installer(MSatInstaller,    "5.6.7", {}),
     Installer(CVC4Installer,    "1.7-prerelease",
               {"git_version" : "391ab9df6c3fd9a3771864900c1718534c1e4666"}),
-    Installer(Z3Installer,      "4.8.7", {"osx": "10.14.6"}),
+    Installer(Z3Installer,      "4.8.17", {"osx": "10.16"}),
     Installer(YicesInstaller,   "2.6.2",
               {"yicespy_version": "f0768ffeec15ea310f830d10878971c9998454ac"}),
     Installer(BtorInstaller,    "3.2.1", {}),


### PR DESCRIPTION
Upgrades z3 to the latest release. This does not include the logic necessary for picking the arm release.

I see that z3 has been publishing the python packages to pypi, so I wonder if we should try to simplify the solver to just use the python package (pip install). 