### PR TITLE
Parse logic str in Portfolio

### DIFF
--- a/pysmt/solvers/portfolio.py
+++ b/pysmt/solvers/portfolio.py
@@ -20,6 +20,7 @@ from multiprocessing import Process, Queue, Pipe
 
 from pysmt.solvers.solver import IncrementalTrackingSolver, SolverOptions
 from pysmt.decorators import clear_pending_pop
+from pysmt.logics import convert_logic_from_string
 
 
 LOGGER = logging.getLogger(__name__)
@@ -70,6 +71,7 @@ class Portfolio(IncrementalTrackingSolver):
 
         One process will be used for each of the solvers.
         """
+        logic = convert_logic_from_string(logic)
         IncrementalTrackingSolver.__init__(self,
                                            environment=environment,
                                            logic=logic,


### PR DESCRIPTION
Portfolio does not rely on the factory infrastructure, but instead we
instantiate the class directly. In the factory module we take care of
converting the logic from str to a pysmt.logic object.
This step was missing in the Portfolio constructor.

We could do the conversion later, but I think it makes sense to ensure
that logic is always a pysmt object.

Fixes #708.