### PR TITLE
Walker functions removal

### DIFF
--- a/pysmt/environment.py
+++ b/pysmt/environment.py
@@ -86,9 +86,9 @@ class Environment(object):
         # (e.g. substitution and simplification).
         self.allow_empty_var_names = False
 
-        # Dynamic Walker Configuration Map
+        # Dynamic Walker Configuration(s)
         # See: add_dynamic_walker_function
-        self.dwf = {}
+        self._dwf = set()
 
     @property
     def formula_manager(self):
@@ -156,12 +156,10 @@ class Environment(object):
         See :py:meth:`pysmt.walkers.generic.Walker.walk_error` for
         more information.
         """
-        # self.dwf is a map of maps: {nodetype, {walker: function}}
-        if nodetype not in self.dwf:
-            self.dwf[nodetype] = {}
-
-        assert walker not in self.dwf[nodetype], "Redefinition"
-        self.dwf[nodetype][walker] = function
+        # self._dwf is a set (nodetype, walker) and is used to
+        # track down redefinitions (as they can be otherwise hard to debug).
+        assert (nodetype, walker) not in self._dwf, "Dynamic Walker Redefinition!"
+        walker.set_handler(function, nodetype)
 
     @property
     def factory(self):

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -63,12 +63,16 @@ class SizeOracle(walkers.DagWalker):
                          SizeOracle.MEASURE_SYMBOLS: self.walk_count_symbols,
                          SizeOracle.MEASURE_BOOL_DAG: self.walk_count_bool_dag,
                         }
+        self._walking_fun = None
 
+    @walkers.handles(*op.ALL_TYPES)
+    def measure(self, formula, args, **kwargs):
+        return self._walking_fun(formula, args, **kwargs)
 
     def set_walking_measure(self, measure):
         if measure not in self.measure_to_fun:
             raise NotImplementedError
-        self.set_function(self.measure_to_fun[measure], *op.ALL_TYPES)
+        self._walking_fun = self.measure_to_fun[measure]
 
     def _get_key(self, formula, measure, **kwargs):
         """Memoize using a tuple (measure, formula)."""

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -70,8 +70,7 @@ class Simplifier(pysmt.walkers.DagWalker):
 
         args = [self.walk(s, **kwargs) for s in formula.args()]
 
-        f = self.functions[formula.node_type()]
-        res = f(formula, args=args, **kwargs)
+        res = self.__class__.super(self, formula, args=args, **kwargs)
         ltype = get_type(formula)
         rtype = get_type(res)
         test = Equals(formula, res) if ltype != BOOL else Iff(formula, res)

--- a/pysmt/smtlib/printers.py
+++ b/pysmt/smtlib/printers.py
@@ -343,8 +343,7 @@ class SmtDagPrinter(DagWalker):
         if formula.is_quantifier():
             # 1. We invoke the relevant function (walk_exists or
             #    walk_forall) to print the formula
-            fun = self.functions[formula.node_type()]
-            res = fun(formula, args=None, **kwargs)
+            res = self.__class__.super(self, formula, args=None, **kwargs)
 
             # 2. We memoize the result
             key = self._get_key(formula, **kwargs)

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -44,6 +44,7 @@ from pysmt.decorators import clear_pending_pop, catch_conversion_error
 from pysmt.solvers.qelim import QuantifierEliminator
 from pysmt.solvers.interpolation import Interpolator
 from pysmt.walkers.identitydag import IdentityDagWalker
+from pysmt.walkers.generic import handles
 
 
 class MSatEnv(object):
@@ -1115,10 +1116,7 @@ if hasattr(mathsat, "MSAT_EXIST_ELIM_ALLSMT_FM"):
             self.msat_env = MSatEnv(self.msat_config)
             mathsat.msat_destroy_config(self.msat_config)
 
-            self.set_function(self.walk_identity, op.SYMBOL, op.REAL_CONSTANT,
-                              op.BOOL_CONSTANT, op.INT_CONSTANT)
             self.logic = logic
-
             self.algorithm = algorithm
             self.converter = MSatConverter(environment, self.msat_env)
 
@@ -1174,6 +1172,10 @@ if hasattr(mathsat, "MSAT_EXIST_ELIM_ALLSMT_FM"):
             variables = formula.quantifier_vars()
             subf = args[0]
             return self.exist_elim(variables, subf)
+
+        @handles(op.SYMBOL, op.REAL_CONSTANT, op.BOOL_CONSTANT, op.INT_CONSTANT)
+        def walk_identity(self, formula, _, **kwargs):
+            return super(MSatQuantifierEliminator, self).walk_identity(formula, **kwargs)
 
         def _exit(self):
             del self.msat_env

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -1174,8 +1174,8 @@ if hasattr(mathsat, "MSAT_EXIST_ELIM_ALLSMT_FM"):
             return self.exist_elim(variables, subf)
 
         @handles(op.SYMBOL, op.REAL_CONSTANT, op.BOOL_CONSTANT, op.INT_CONSTANT)
-        def walk_identity(self, formula, _, **kwargs):
-            return super(MSatQuantifierEliminator, self).walk_identity(formula, **kwargs)
+        def walk_identity(self, formula, args, **kwargs):
+            return super(IdentityDagWalker, self).walk_identity(formula, **kwargs)
 
         def _exit(self):
             del self.msat_env

--- a/pysmt/substituter.py
+++ b/pysmt/substituter.py
@@ -153,8 +153,7 @@ class Substituter(pysmt.walkers.IdentityDagWalker):
 
             # 3. We invoke the relevant function (walk_exists or
             #    walk_forall) to compute the substitution
-            fun = self.functions[formula.node_type()]
-            res = fun(formula, args=[res_formula], **kwargs)
+            res = self.__class__.super(self, formula, args=[res_formula], **kwargs)
 
             # 4. We memoize the result
             key = self._get_key(formula, **kwargs)

--- a/pysmt/test/test_dwf.py
+++ b/pysmt/test/test_dwf.py
@@ -73,3 +73,4 @@ class TestDwf(TestCase):
         new_t = new_node_type()
         new_types_set = set(all_types())
         self.assertEqual(new_types_set - old_types_set, set([new_t]))
+

--- a/pysmt/test/test_walkers.py
+++ b/pysmt/test/test_walkers.py
@@ -21,7 +21,7 @@ from pysmt.shortcuts import And, Or, Iff, Not, Function, Real
 from pysmt.shortcuts import LT, GT, Plus, Minus, Equals
 from pysmt.shortcuts import get_env, substitute, TRUE
 from pysmt.typing import INT, BOOL, REAL, FunctionType
-from pysmt.walkers import TreeWalker, DagWalker, IdentityDagWalker
+from pysmt.walkers import TreeWalker, DagWalker, IdentityDagWalker, handles
 from pysmt.test import TestCase, main
 from pysmt.formula import FormulaManager
 from pysmt.test.examples import get_example_formulae
@@ -110,16 +110,16 @@ class TestWalkers(TestCase):
 
     def test_identity_walker_simple(self):
 
-        def walk_and_to_or(formula, args, **kwargs):
-            return Or(args)
+        class MyWalker(IdentityDagWalker):
+            @handles(op.AND)
+            def walk_and_to_or(self, formula, args, **kwargs):
+                return Or(args)
 
-        def walk_or_to_and(formula, args, **kwargs):
-            return And(args)
+            @handles(op.OR)
+            def walk_or_to_and(self, formula, args, **kwargs):
+                return And(args)
 
-        walker = IdentityDagWalker(env=get_env())
-
-        walker.set_function(walk_and_to_or, op.AND)
-        walker.set_function(walk_or_to_and, op.OR)
+        walker = MyWalker(env=get_env())
 
         x, y, z = Symbol('x'), Symbol('y'), Symbol('z')
 

--- a/pysmt/walkers/dag.py
+++ b/pysmt/walkers/dag.py
@@ -16,6 +16,7 @@
 #   limitations under the License.
 #
 from pysmt.walkers.tree import Walker
+from pysmt.walkers.generic import nt_to_fun
 
 
 class DagWalker(Walker):
@@ -65,14 +66,9 @@ class DagWalker(Walker):
         """
         key = self._get_key(formula, **kwargs)
         if key not in self.memoization:
-            try:
-                f = self.functions[formula.node_type()]
-            except KeyError:
-                f = self.walk_error
-
             args = [self.memoization[self._get_key(s, **kwargs)] \
                     for s in self._get_children(formula)]
-            self.memoization[key] = f(formula, args=args, **kwargs)
+            self.memoization[key] = self.__class__.super(self, formula, args=args, **kwargs)
         else:
             pass
 

--- a/pysmt/walkers/generic.py
+++ b/pysmt/walkers/generic.py
@@ -59,7 +59,7 @@ class MetaNodeTypeHandler(type):
     """Metaclass used to intepret the nodehandler decorator. """
     def __new__(cls, name, bases, dct):
         obj = type.__new__(cls, name, bases, dct)
-        for k,v in dct.items():
+        for _, v in dct.items():
             if hasattr(v, "nodetypes"):
                 obj.set_handler(v, *v.nodetypes)
         return obj
@@ -86,15 +86,13 @@ class Walker(object, metaclass=MetaNodeTypeHandler):
             except AttributeError:
                 self.functions[o] = self.walk_error
 
-    def set_function(self, function, *node_types):
-        """Overrides the default walking function for each of the specified
-        node_types with the given function
+    def set_function(self, _, *__):
+        """Instance-based walkers (<=0.6.0) walkers are deprecated.
+        You should use new-style/class based walkers.
         """
-        from warnings import warn
-        warn("Instance-based walkers (<=0.6.0) walkers are deprecated. "
-             "You should use new-style/class based walkers", stacklevel=2)
-        for nt in node_types:
-            self.functions[nt] = function
+        raise NotImplementedError(
+            "Instance-based walkers (<=0.6.0) walkers are deprecated."
+            "You should use new-style/class based walkers.")
 
     @classmethod
     def set_handler(cls, function, *node_types):

--- a/pysmt/walkers/generic.py
+++ b/pysmt/walkers/generic.py
@@ -87,9 +87,6 @@ class Walker(object, metaclass=MetaNodeTypeHandler):
                 self.functions[o] = self.walk_error
 
     def set_function(self, _, *__):
-        """Instance-based walkers (<=0.6.0) walkers are deprecated.
-        You should use new-style/class based walkers.
-        """
         raise NotImplementedError(
             "Instance-based walkers (<=0.6.0) walkers are deprecated."
             "You should use new-style/class based walkers.")

--- a/pysmt/walkers/tree.py
+++ b/pysmt/walkers/tree.py
@@ -37,19 +37,14 @@ class TreeWalker(Walker):
         return
 
     def walk(self, formula, threshold=None):
-        """Generic walk method, will apply the function defined by the map
-        self.functions.
+        """Generic walk method, will apply the function associated with
+        the node.
 
         If threshold parameter is specified, the walk_threshold
         function will be called for all nodes with depth >= threshold.
         """
 
-        try:
-            f = self.functions[formula.node_type()]
-        except KeyError:
-            f = self.walk_error
-
-        iterator = f(formula)
+        iterator = self.__class__.super(self, formula)
         if iterator is None:
             return
 
@@ -63,11 +58,7 @@ class TreeWalker(Walker):
                     if iterator is not None:
                         stack.append(iterator)
                 else:
-                    try:
-                        cf = self.functions[child.node_type()]
-                    except KeyError:
-                        cf = self.walk_error
-                    iterator = cf(child)
+                    iterator = self.__class__.super(self, child)
                     if iterator is not None:
                         stack.append(iterator)
             except StopIteration:


### PR DESCRIPTION
The `functions` dictionary in the `Walker` was used to map each nodetype to the corresponding `walk` method. We called this "instance based walkers" because each instance could (in principle) associate different functions.

We changed this behavior long time ago (0.6), in favor of "class based walkers". The idea being that the walk method will follow the name of the node type: e.g., `walk_add` will be used for the `add` operator.

This PR removes the last uses of the `functions` dictionary.

TODO:
- [ ] The way I changed the DWF implementation does not allow the use of multiple environments (while the previous version did). It probably makes sense to explore if we want to keep this behavior.
- [ ] There are some tests for the walkers to update as they were testing the `functions` dictionary. It might make sense to update those tests to show the same behavior using the new approach.


Fixes https://github.com/pysmt/pysmt/issues/410
