### PR TITLE
Make sudoku.py Python3 compatible

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -36,3 +36,4 @@ Vijay Raghavan <vijaysgr8@gmail.com>
 Wael-Amine Boutglay <btwael@gmail.com>
 Yoni Zohar <yoni206@gmail.com>
 Yuri Malheiros <yurimalheiros@gmail.com>
+Aryan Kumar <akumm2k@gmail.com>

--- a/examples/sudoku/sudoku.py
+++ b/examples/sudoku/sudoku.py
@@ -156,7 +156,7 @@ def main():
                         help='The sudoku base size', default=3)
 
     parser.add_argument('--solver', '-s', metavar='name', type=str,
-                        choices=['auto'] + env.factory.all_solvers().keys(),
+                        choices=['auto'] + list(env.factory.all_solvers().keys()),
                         default='auto',
                         help='The solver to use (default: auto)')
 
@@ -182,14 +182,14 @@ def main():
         constraints = read_constraints(args.problem)
         res = sudoku.solve(constraints)
         if res is None:
-            print "No solution exists"
+            print("No solution exists")
         else:
             for row in res:
-                print "\t".join(str(x) for x in row)
+                print("\t".join(str(x) for x in row))
     else:
-        print "No problem specified! Either use the gui.py script or pass" \
+        print("No problem specified! Either use the gui.py script or pass" \
             " a problem with --problem flag. Example problems are available" \
-            " in the problems/ folder."
+            " in the problems/ folder.")
 
 
 


### PR DESCRIPTION
The pull request fixes the print statements to support python3 and concatenation of a list to a `dict_keys` object [here](https://github.com/akumm2k/pysmt/blob/a1214157332a06404e506feb1c16bf5e3ba274f8/examples/sudoku/sudoku.py#L159).