### PR TITLE
Polarity-based CNF

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -42,3 +42,4 @@ Luca Framba <framba@fbk.eu> Framba Luca <framba@fbk.eu>
 Luca Framba <framba@fbk.eu> Framba Luca <luca.framba@outlook.it>
 Gianluca Redondi <gianluca.redondi@gmail.com> gianredondi <60613602+gianredondi@users.noreply.github.com>
 Gianluca Redondi <gianluca.redondi@gmail.com> gredondi <gianredondi@github.com>
+Gabriele Masina <gabriele.masina@virgilio.it> masinag <gabriele.masina@virgilio.it>

--- a/pysmt/rewritings.py
+++ b/pysmt/rewritings.py
@@ -57,7 +57,7 @@ class CNFizer(DagWalker):
         """
         tl, _cnf = self.walk(formula)
         if len(_cnf) == 0:
-            return [frozenset([tl])]
+            return frozenset([frozenset([tl])])
         res = []
         for clause in _cnf:
             if len(clause) == 0:

--- a/pysmt/rewritings.py
+++ b/pysmt/rewritings.py
@@ -53,10 +53,12 @@ class CNFizer(DagWalker):
     def convert(self, formula):
         """Convert formula into an Equisatisfiable CNF.
 
-        Returns a set of clauses: a set of set of literals.
+        Returns a set of clauses: a set of sets of literals.
         """
         tl, _cnf = self.walk(formula)
-        res = [frozenset([tl])]
+        if len(_cnf) == 0:
+            return [frozenset([tl])]
+        res = []
         for clause in _cnf:
             if len(clause) == 0:
                 return CNFizer.FALSE_CNF
@@ -66,6 +68,14 @@ class CNFizer(DagWalker):
                     # Prune clauses that are trivially TRUE
                     simp = None
                     break
+                elif lit == tl:
+                    # Prune clauses as ~tl -> l1 v ... v lk
+                    simp = None
+                    break
+                elif lit == self.mgr.Not(tl).simplify():
+                    # Simplify tl -> l1 v ... v lk
+                    # into l1 v ... v lk
+                    continue
                 elif not lit.is_false():
                     # Prune FALSE literals
                     simp.append(lit)

--- a/pysmt/rewritings.py
+++ b/pysmt/rewritings.py
@@ -126,10 +126,7 @@ class CNFizer(DagWalker):
         elif a.is_false():
             return self.mgr.TRUE(), CNFizer.TRUE_CNF
         else:
-            k = self._key_var(formula)
-            return k, _cnf | frozenset([frozenset([self.mgr.Not(k),
-                                                  self.mgr.Not(a).simplify()]),
-                                       frozenset([k, a])])
+            return self.mgr.Not(a).simplify(), _cnf
 
     def walk_implies(self, formula,  args, **kwargs):
         a, cnf_a = args[0]

--- a/pysmt/rewritings.py
+++ b/pysmt/rewritings.py
@@ -221,6 +221,160 @@ class CNFizer(DagWalker):
 # EOC CNFizer
 
 
+class PolarityCNFizer(CNFizer):
+    """
+    Convert formula into an Equisatisfiable CNF using the polarity-based transformation.
+    """
+
+    def _get_children(self, formula, pol=None):
+        if formula.is_not():
+            return [(formula.arg(0), not pol)]
+
+        elif formula.is_implies():
+            return [(formula.arg(0), not pol), (formula.arg(1), pol)]
+
+        elif formula.is_iff():
+            return [(formula.arg(0), pol), (formula.arg(1), pol),
+                    (formula.arg(0), not pol), (formula.arg(1), not pol)]
+
+        elif formula.is_and() or formula.is_or() or formula.is_quantifier():
+            return [(a, pol) for a in formula.args()]
+
+        elif formula.is_ite():
+            # This must be a boolean ITE as we do not recur within
+            # theory atoms
+            assert self.env.stc.get_type(formula).is_bool_type()
+            i, t, e = formula.args()
+            return [(i, pol), (i, not pol), (t, pol), (e, not pol)]
+
+        else:
+            assert formula.is_str_op() or \
+                   formula.is_symbol() or \
+                   formula.is_function_application() or \
+                   formula.is_bool_constant() or \
+                   formula.is_theory_relation(), str(formula)
+            return []
+
+    def _push_with_children_to_stack(self, formula, pol=None, **kwargs):
+        self.stack.append((True, formula, pol))
+
+        for s, p in self._get_children(formula, pol):
+            # Add only if not memoized already
+            key = self._get_key(s, p, **kwargs)
+            if key not in self.memoization:
+                self.stack.append((False, s, p))
+
+    def _compute_node_result(self, formula, pol=None, **kwargs):
+        key = self._get_key(formula, pol, **kwargs)
+        if key not in self.memoization:
+            try:
+                f = self.functions[formula.node_type()]
+            except KeyError:
+                f = self.walk_error
+
+            args = [self.memoization[self._get_key(s, p, **kwargs)] \
+                    for s, p in self._get_children(formula, pol)]
+
+            self.memoization[key] = f(formula, args=args, pol=pol, **kwargs)
+        else:
+            pass
+
+    def _process_stack(self, **kwargs):
+        while self.stack:
+            (was_expanded, formula, pol) = self.stack.pop()
+            if was_expanded:
+                self._compute_node_result(formula, pol, **kwargs)
+            else:
+                self._push_with_children_to_stack(formula, pol, **kwargs)
+
+    def iter_walk(self, formula, **kwargs):
+        self.stack.append((False, formula, True))
+        self._process_stack(**kwargs)
+        res_key = self._get_key(formula, pol=True, **kwargs)
+        return self.memoization[res_key]
+
+    def _get_key(self, formula, pol=None, **kwargs):
+        return formula, pol
+
+    def walk_and(self, formula, args, pol=None, **kwargs):
+        if len(args) == 1:
+            return args[0]
+
+        k = self._key_var(formula)
+        _cnf = [clause for a, c in args for clause in c]
+        if pol:
+            _cnf.extend(frozenset([a, self.mgr.Not(k)]) for a, _ in args)
+        else:
+            _cnf.extend([frozenset([k] + [self.mgr.Not(a).simplify() for a, _ in args])])
+
+        return k, frozenset(_cnf)
+
+    def walk_or(self, formula, args, pol=None, **kwargs):
+        if len(args) == 1:
+            return args[0]
+        k = self._key_var(formula)
+        _cnf = [clause for a, c in args for clause in c]
+        if pol:
+            _cnf.extend(frozenset([k, self.mgr.Not(a).simplify()]) for a, c in args)
+        else:
+            _cnf.extend([frozenset([self.mgr.Not(k)] + [a for a, _ in args])])
+
+        return k, frozenset(_cnf)
+
+    def walk_implies(self, formula, args, pol=None, **kwargs):
+        a, cnf_a = args[0]
+        b, cnf_b = args[1]
+
+        k = self._key_var(formula)
+        not_a = self.mgr.Not(a).simplify()
+        not_b = self.mgr.Not(b).simplify()
+        not_k = self.mgr.Not(k)
+        _cnf = []
+        if pol:
+            _cnf.extend([frozenset([not_a, b, not_k])])
+        else:
+            _cnf.extend([frozenset([a, k]), frozenset([not_b, k])])
+
+        return k, (cnf_a | cnf_b | frozenset(_cnf))
+
+    def walk_iff(self, formula, args, pol=None, **kwargs):
+        a, cnf_ap = args[0]
+        b, cnf_bp = args[1]
+        _, cnf_an = args[2]
+        _, cnf_bn = args[3]
+
+        k = self._key_var(formula)
+        not_a = self.mgr.Not(a).simplify()
+        not_b = self.mgr.Not(b).simplify()
+        not_k = self.mgr.Not(k)
+
+        return k, (cnf_ap | cnf_an | cnf_bp | cnf_bn
+                   | frozenset([frozenset([not_a, not_b, k]),
+                                frozenset([not_a, b, not_k]),
+                                frozenset([a, not_b, not_k]),
+                                frozenset([a, b, k])]))
+
+    def walk_ite(self, formula, args, pol=None, **kwargs):
+        if any(a == CNFizer.THEORY_PLACEHOLDER for a in args):
+            return CNFizer.THEORY_PLACEHOLDER
+        (i, cnf_ip), (_, cnf_in), (t, cnf_t), (e, cnf_e) = args
+        k = self._key_var(formula)
+        not_i = self.mgr.Not(i).simplify()
+        not_t = self.mgr.Not(t).simplify()
+        not_e = self.mgr.Not(e).simplify()
+        not_k = self.mgr.Not(k)
+
+        _cnf = []
+        if pol:
+            _cnf.extend([frozenset([not_i, t, not_k]), frozenset([i, e, not_k])])
+        else:
+            _cnf.extend([frozenset([not_i, not_t, k]), frozenset([i, not_e, k])])
+
+        return k, (cnf_ip | cnf_in | cnf_t | cnf_e | frozenset(_cnf))
+
+# EOC PolarityCNFizer
+
+
 class NNFizer(DagWalker):
     """Converts a formula into Negation Normal Form.
 

--- a/pysmt/rewritings.py
+++ b/pysmt/rewritings.py
@@ -312,12 +312,13 @@ class PolarityCNFizer(CNFizer):
     def walk_or(self, formula, args, pol=None, **kwargs):
         if len(args) == 1:
             return args[0]
+
         k = self._key_var(formula)
         _cnf = [clause for a, c in args for clause in c]
         if pol:
-            _cnf.extend(frozenset([k, self.mgr.Not(a).simplify()]) for a, c in args)
-        else:
             _cnf.extend([frozenset([self.mgr.Not(k)] + [a for a, _ in args])])
+        else:
+            _cnf.extend(frozenset([k, self.mgr.Not(a).simplify()]) for a, c in args)
 
         return k, frozenset(_cnf)
 

--- a/pysmt/rewritings.py
+++ b/pysmt/rewritings.py
@@ -245,7 +245,7 @@ class PolarityCNFizer(CNFizer):
             # theory atoms
             assert self.env.stc.get_type(formula).is_bool_type()
             i, t, e = formula.args()
-            return [(i, pol), (i, not pol), (t, pol), (e, not pol)]
+            return [(i, pol), (i, not pol), (t, pol), (e, pol)]
 
         else:
             assert formula.is_str_op() or \

--- a/pysmt/test/test_cnf.py
+++ b/pysmt/test/test_cnf.py
@@ -19,7 +19,7 @@ import os
 import pytest
 
 from pysmt.shortcuts import Implies, is_sat, is_valid, reset_env, Symbol, Iff, Select, ArrayType, INT, BOOL, And, get_env
-from pysmt.rewritings import CNFizer
+from pysmt.rewritings import CNFizer, PolarityCNFizer
 from pysmt.logics import QF_BOOL, QF_LRA, QF_LIA, QF_UFLIRA, QF_UFLRA, QF_ALIA
 from pysmt.test import TestCase, skipIfNoSolverForLogic, main
 from pysmt.test.examples import get_example_formulae
@@ -29,16 +29,16 @@ from pysmt.smtlib.parser import get_formula_fname
 class TestCnf(TestCase):
 
     def do_examples(self, logic):
-        conv = CNFizer()
-        for example in get_example_formulae():
-            if example.logic != logic:
-                continue
-            cnf = conv.convert_as_formula(example.expr)
+        for conv in (CNFizer(), PolarityCNFizer()):
+            for example in get_example_formulae():
+                if example.logic != logic:
+                    continue
+                cnf = conv.convert_as_formula(example.expr)
 
-            self.assertValid(Implies(cnf, example.expr), logic=logic)
+                self.assertValid(Implies(cnf, example.expr), logic=logic)
 
-            res = is_sat(cnf, logic=logic)
-            self.assertEqual(res, example.is_sat)
+                res = is_sat(cnf, logic=logic)
+                self.assertEqual(res, example.is_sat)
 
 
     @skipIfNoSolverForLogic(QF_BOOL)

--- a/pysmt/test/test_cnf.py
+++ b/pysmt/test/test_cnf.py
@@ -80,31 +80,30 @@ class TestCnf(TestCase):
 
     def _smtlib_cnf(self, filename, logic, res_is_sat):
         reset_env()
-        conv = CNFizer()
         smtfile = os.path.join(SMTLIB_DIR, filename)
         assert os.path.exists(smtfile)
 
         expr = get_formula_fname(smtfile)
-        if not logic.quantifier_free:
-            with self.assertRaises(NotImplementedError):
-                conv.convert_as_formula(expr)
-            return
+        for conv in (CNFizer(), PolarityCNFizer()):
+            if not logic.quantifier_free:
+                with self.assertRaises(NotImplementedError):
+                    conv.convert_as_formula(expr)
+                return
+            cnf = conv.convert_as_formula(expr)
+            self.assertValid(Implies(cnf, expr), logic=logic)
 
-        cnf = conv.convert_as_formula(expr)
-        self.assertTrue(is_valid(Implies(cnf, expr), logic=logic))
-
-        res = is_sat(cnf, logic=logic)
-        self.assertEqual(res, res_is_sat)
+            res = is_sat(cnf, logic=logic)
+            self.assertEqual(res, res_is_sat)
 
     @skipIfNoSolverForLogic(QF_BOOL)
     def test_implies(self):
         a,b,c,d = (Symbol(x) for x in "abcd")
         f = Implies(Iff(a, b), Iff(c, d))
 
-        conv = CNFizer()
-        cnf = conv.convert_as_formula(f)
+        for conv in [CNFizer(), PolarityCNFizer()]:
+            cnf = conv.convert_as_formula(f)
 
-        self.assertValid(Implies(cnf, f), logic=QF_BOOL)
+            self.assertValid(Implies(cnf, f), logic=QF_BOOL)
 
     @skipIfNoSolverForLogic(QF_ALIA)
     def test_CNFizer_bool_theory(self):

--- a/pysmt/test/test_cnf.py
+++ b/pysmt/test/test_cnf.py
@@ -90,7 +90,7 @@ class TestCnf(TestCase):
                     conv.convert_as_formula(expr)
                 return
             cnf = conv.convert_as_formula(expr)
-            self.assertValid(Implies(cnf, expr), logic=logic)
+            self.assertTrue(is_valid(Implies(cnf, expr), logic=logic))
 
             res = is_sat(cnf, logic=logic)
             self.assertEqual(res, res_is_sat)

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -258,7 +258,7 @@ class TestRegressions(TestCase):
 
     def test_cnf_as_set(self):
         r = cnf_as_set(Symbol("x"))
-        self.assertTrue(type(r) == frozenset)
+        self.assertEqual(type(r), frozenset)
 
     def test_substitute_to_real(self):
         p = Symbol("p", INT)


### PR DESCRIPTION
Resolves #743:
- Avoid redundant labeling in Labeling CNF. This also fixes #403.
- Add polarity-based CNF conversion [by Plaisted and Greenbaum](https://www.sciencedirect.com/science/article/pii/S0747717186800281). The polarity-based walk is inspired by https://github.com/pysmt/pysmt/commit/245993fcbd0d4091134c9f03805021f738b58b33 (not merged). 