### PR TITLE
Fix the definition of BVXnor

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -19,6 +19,7 @@ Marco Gario <marco.gario@gmail.com>  marcogario <marco.gario@email.it>
 Marco Gario <marco.gario@gmail.com>  Marco Gario <marco.gario@email.it>
 Marco Gario <marco.gario@gmail.com>  Marco Gario <marcogario@github.com>
 Radomir Stevanovic <radomir.stevanovic@gmail.com>  Radomir Stevanovic <radomir@dwavesys.com>
+Yike Zhou <yikezhou@outlook.com>  Yike Zhou <43945722+YikeZhou@users.noreply.github.com>
 Yoni Zohar <yoni206@gmail.com>  yoni206 <yoni206@users.noreply.github.com>
 Yuri Malheiros <yurimalheiros@gmail.com>  yurimalheiros <yurimalheiros@gmail.com>
 Enrico Magnago <en.magnago@gmail.com> Enrico Magnago <EnricoMagnago@users.noreply.github.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -35,6 +35,7 @@ Taylor Hodge <j.taylor.hodge@gmail.com>
 Varun Patro <varun.kumar.patro@gmail.com>
 Vijay Raghavan <vijaysgr8@gmail.com>
 Wael-Amine Boutglay <btwael@gmail.com>
+Yike Zhou <yikezhou@outlook.com>
 Yoni Zohar <yoni206@gmail.com>
 Yuri Malheiros <yurimalheiros@gmail.com>
 

--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -893,8 +893,7 @@ class FormulaManager(object):
 
     def BVXnor(self, left, right):
         """Returns the XNOR composition of left and right."""
-        return self.BVOr(self.BVAnd(left, self.BVNot(right)),
-                         self.BVAnd(self.BVNot(left), right))
+        return self.BVNot(self.BVXor(left, right))
 
     def BVSGT(self, left, right):
         """Returns the SIGNED GREATER-THAN comparison for BV."""


### PR DESCRIPTION
- [x] This should fix #747 
- [x] Are all tests green? - I tried `run_all_tests.sh`. It says `480 passed, 88 skipped, 59 warnings`.
- [x] (First contribution only) I have accepted the licensing terms by adding name and email to the CONTRIBUTORS file.

Also, I tried this quick-and-dirty differential testing script and it looks good to me:)
```python
import subprocess
from pysmt.shortcuts import simplify, BV

WIDTH = 5  # Do not set to a multiple of 4

for i in range(2**WIDTH):
    a = BV(i, WIDTH)

    for j in range(i):
        b = BV(j, WIDTH)

        pysmt_output = simplify(a.BVXnor(b)).to_smtlib()

        z3_input = f'(simplify (bvxnor {a.to_smtlib()} {b.to_smtlib()}))'
        cmd = f'echo "{z3_input}" | z3 -in'
        z3_output = subprocess.check_output(cmd, shell=True).decode('utf-8').strip()

        if pysmt_output != z3_output:
            raise RuntimeError(f'expected {z3_output}, got {pysmt_output}')

```

