### PR TITLE
Fix term conversion of important SMT-atoms in AllSMT

### DIFF
--- a/examples/allsat.py
+++ b/examples/allsat.py
@@ -1,15 +1,10 @@
 # This example requires MathSAT to be installed.
-#
-# This example shows how to use a solver converter to access
-# functionalities of the solver that are not wrapped by pySMT.
-#
-# Our goal is to call the method msat_all_sat from the MathSAT API.
-#
-import mathsat
-from pysmt.shortcuts import Or, Symbol, Solver, And
+
+from pysmt.shortcuts import And, Or, Solver, Symbol
+
 
 def callback(model, converter, result):
-    """Callback for msat_all_sat.
+    """Callback for msat.all_sat.
 
     This function is called by the MathSAT API everytime a new model
     is found. If the function returns 1, the search continues,
@@ -19,21 +14,17 @@ def callback(model, converter, result):
     # Converter.back() provides the pySMT representation of a solver term.
     py_model = [converter.back(v) for v in model]
     result.append(And(py_model))
-    return 1 # go on
+    return 1  # go on
+
 
 x, y = Symbol("x"), Symbol("y")
 f = Or(x, y)
 
+result = []
 with Solver(name="msat") as msat:
-    converter = msat.converter # .converter is a property implemented by all solvers
-    msat.add_assertion(f) # This is still at pySMT level
+    converter = msat.converter  # .converter is a property implemented by all solvers
+    msat.add_assertion(f)
+    msat.all_sat([x], lambda model: callback(model, converter, result))
 
-    result = []
-    # Directly invoke the mathsat API !!!
-    # The second term is a list of "important variables"
-    mathsat.msat_all_sat(msat.msat_env(),
-        [converter.convert(x)],      # Convert the pySMT term into a MathSAT term
-        lambda model : callback(model, converter, result))
-
-    print("'exists y . %s' is equivalent to '%s'" %(f, Or(result)))
-    #exists y . (x | y) is equivalent to ((! x) | x)
+    print("'exists y . %s' is equivalent to '%s'" % (f, Or(result)))
+    # exists y . (x | y) is equivalent to ((! x) | x)

--- a/examples/allsmt.py
+++ b/examples/allsmt.py
@@ -23,7 +23,8 @@ def all_smt(formula, important):
                 solver_options={
                     "dpll.allsat_minimize_model": "false",  # enumerate total models
                     "dpll.allsat_allow_duplicates": "false",  # enumerate disjoint models
-                    "preprocessor.toplevel_propagation": "false",  # necessary to avoid non-validity preserving steps
+                    "preprocessor.toplevel_propagation": "false",  # these two options are necessary
+                    "preprocessor.simplification": "0",  # to avoid non-validity-preserving simplifications
                 }
                 ) as msat:
         msat.add_assertion(formula)

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -322,7 +322,7 @@ class MathSAT5Solver(IncrementalTrackingSolver, UnsatCoreSolver, SmtLibBasicSolv
     def all_sat(self, important, callback):
         self.push()
         self._msat_lib.msat_all_sat(self.msat_env(),
-                             [self._var2term(x) for x in important],
+                             [self.converter.convert(x) for x in important],
                              callback)
         self.pop()
 
@@ -335,11 +335,6 @@ class MathSAT5Solver(IncrementalTrackingSolver, UnsatCoreSolver, SmtLibBasicSolv
     def _pop(self, levels: int=1):
         for _ in range(levels):
             self._msat_lib.msat_pop_backtrack_point(self.msat_env())
-
-    def _var2term(self, var):
-        decl = self._msat_lib.msat_find_decl(self.msat_env(), var.symbol_name())
-        titem = self._msat_lib.msat_make_term(self.msat_env(), decl, [])
-        return titem
 
     def set_preferred_var(self, var, val=None):
         tvar = self.converter.convert(var)

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -574,6 +574,40 @@ class TestRegressions(TestCase):
                 s.add_assertion(f)
                 self.assertFalse(s.solve())
 
+    @skipIfSolverNotAvailable("msat")
+    def test_msat_all_sat_theory_atoms(self):
+        # Regression test: MathSAT5Solver.all_sat must accept arbitrary
+        # SMT-atoms as "important" terms, not only Boolean symbols.
+        # Previously the "important" terms were converted with a helper
+        # (_var2term) that assumed each term was a declared symbol, so
+        # passing a theory atom raised an AssertionError.
+        x = Symbol("x", INT)
+        f = And(LE(Int(0), x), LE(x, Int(5)))
+        atom = LE(x, Int(2))  # a theory atom, not a Boolean symbol
+
+        result = []
+
+        def callback(model, converter, res):
+            res.append(And(converter.back(v) for v in model))
+            return 1  # continue enumeration
+
+        with Solver(name="msat",
+                    solver_options={
+                        "dpll.allsat_minimize_model": "false",
+                        "dpll.allsat_allow_duplicates": "false",
+                        "preprocessor.toplevel_propagation": "false",
+                        "preprocessor.simplification": "0",
+                    }) as msat:
+            msat.add_assertion(f)
+            # This call used to raise AssertionError on a theory atom.
+            msat.all_sat([atom], lambda m: callback(m, msat.converter, result))
+
+        # The atom can be both true (x in [0,2]) and false (x in [3,5]),
+        # so we expect exactly the two disjoint total assignments.
+        self.assertEqual(len(result), 2, result)
+        self.assertIn(atom, result)
+        self.assertIn(Not(atom), result)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The conversion of SMT atoms when used as important atoms in AllSMT was broken, because the conversion code only worked for (Boolean) variables, whereas SMT atoms as important symbols [are supported from MathSAT version 5.6.7](https://mathsat.fbk.eu/releasenotes.html). 

I fixed it by using similar code as [the allsat example](https://github.com/pysmt/pysmt/blob/8c79de2635936f980595f4a43ee20a7da7554844/examples/allsat.py#L35).
The private method `MathSAT5Solver._var2term` was not used anymore, so I deleted it.

Also, I refactored `examples/allsat.py` and `examples/allsmt.py` to use the `MathSAT5Solver.all_sat` method.
