### PR TITLE
Fix for pyximport

### DIFF
--- a/pysmt/smtlib/parser/__init__.py
+++ b/pysmt/smtlib/parser/__init__.py
@@ -82,6 +82,14 @@ else:
     #
     import imp
 
+    if not hasattr(pyximport, "build_module"):
+        import sys
+        if sys.version_info < (3, 5):
+            # _pyximport3 module requires at least Python 3.5
+            import pyximport._pyximport2 as pyximport
+        else:
+            import pyximport._pyximport3 as pyximport
+
     pyx = pyximport.install()
     pyximport.uninstall(*pyx)
     build_dir = os.path.join(os.path.expanduser('~'), '.pyxbld')


### PR DESCRIPTION
Pick the fix for `pyximport` from https://github.com/pysmt/pysmt/pull/761 so CI can be green in master