### PR TITLE
Fixed issue #767

### DIFF
--- a/pysmt/substituter.py
+++ b/pysmt/substituter.py
@@ -259,7 +259,7 @@ class MGSubstituter(Substituter):
     def __init__(self, env):
         Substituter.__init__(self, env=env)
 
-    @handles(set(op.ALL_TYPES) - op.QUANTIFIERS - {op.FUNCTION})
+    @handles(set(op.ALL_TYPES) - op.QUANTIFIERS)
     def walk_identity_or_replace(self, formula, args, **kwargs):
         """
         If the formula appears in the substitution, return the substitution.
@@ -314,7 +314,7 @@ class MSSubstituter(Substituter):
         """
         return substitutions.get(formula, formula)
 
-    @handles(set(op.ALL_TYPES) - op.QUANTIFIERS - {op.FUNCTION})
+    @handles(set(op.ALL_TYPES) - op.QUANTIFIERS)
     def walk_replace(self, formula, args, **kwargs):
         new_f =  Substituter.super(self, formula, args=args, **kwargs)
         return self._substitute(new_f, kwargs['substitutions'])

--- a/pysmt/test/test_formula.py
+++ b/pysmt/test/test_formula.py
@@ -1085,6 +1085,20 @@ class TestFormulaManager(TestCase):
         self.assertRaises(PysmtValueError,
             lambda: self.mgr.BVMul([]))
 
+    def test_function_substitute(self):
+        FunTy = FunctionType(BOOL, [INT])
+        f = self.mgr.Symbol(f"myf", FunTy)
+        g = self.mgr.Symbol(f"myg", FunTy)
+        v = self.mgr.Symbol("v", INT)
+        w = self.mgr.Symbol("w", INT)
+
+        f_v = self.mgr.Function(f, [v])
+        f_w = self.mgr.Function(f, [w])
+        g_v = self.mgr.Function(g, [v])
+
+        phi = Iff(f_v, f_w)
+        self.assertEqual(phi.substitute({f_w: g_v}), Iff(f_v, g_v))
+
 class TestShortcuts(TestCase):
 
     def test_shortcut_is_using_global_env(self):


### PR DESCRIPTION
The test reported in issue #767 highlighted an issue in the substituter which was unable to correctly handle the case of a function application.

The base case for the `walk_function` is implemented in the `Substituter` class, but this function does not handle substitutions, only interpretations, hence I forced the code to pass through the `MGSubstituter` or the `MSSubstituter` before calling the `Substituter.walk_function`.

I believe this should be the correct path.