### PR TITLE
[Boolector] Add support for const arrays and boolean indices/elements

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -27,6 +27,7 @@ M. Fareed Arif <fareed.arif@yahoo.com>
 Marco Gario <marco.gario@gmail.com>
 Mathias Preiner <mathias.preiner@gmail.com>
 Matthew Venn  <matt@mattvenn.net>
+Nicolas Bailluet <nicolas.bailluet@inria.fr>
 Nitish  <nkd.2195@gmail.com>
 Quantik <40385569+quantik-git@users.noreply.github.com>
 Radomir Stevanovic <radomir.stevanovic@gmail.com>

--- a/pysmt/solvers/btor.py
+++ b/pysmt/solvers/btor.py
@@ -140,22 +140,20 @@ class BoolectorOptions(SolverOptions):
                                  pyboolector.BTOR_OPT_RW_ZERO_LOWER_SLICE,
                                  pyboolector.BTOR_OPT_NONDESTR_SUBST]
 
-
-
     def _set_option(self, btor, name, value):
-        available_options = {pyboolector.BoolectorOpt(btor, io).lng : io
+        available_options = {pyboolector.BoolectorOpt(btor, io).lng: io
                              for io in self.internal_options}
         try:
             btor.Set_opt(available_options[name], value)
         except TypeError:
-            raise PysmtValueError("Error setting the option '%s=%s'" \
-                                  % (name,value))
+            raise PysmtValueError("Error setting the option '%s=%s'"
+                                  % (name, value))
         except pyboolector.BoolectorException:
-            raise PysmtValueError("Error setting the option '%s=%s'" \
-                                  % (name,value))
+            raise PysmtValueError("Error setting the option '%s=%s'"
+                                  % (name, value))
         except KeyError:
             raise PysmtValueError("Unable to set non-existing option '%s'. "
-                                  "The accepted options options are: %s" \
+                                  "The accepted options options are: %s"
                                   % (name, ", ".join(pyboolector.BoolectorOpt(btor, io).lng
                                                      for io in self.internal_options)))
 
@@ -167,7 +165,7 @@ class BoolectorOptions(SolverOptions):
         if self.incrementality:
             self._set_option(solver.btor, "incremental", 1)
 
-        for k,v in self.solver_options.items():
+        for k, v in self.solver_options.items():
             # Note: Options values in btor are mostly integers
             self._set_option(solver.btor, str(k), v)
 
@@ -177,7 +175,9 @@ class BoolectorOptions(SolverOptions):
 class BoolectorSolver(IncrementalTrackingSolver, UnsatCoreSolver,
                       SmtLibBasicSolver, SmtLibIgnoreMixin):
 
-    LOGICS = [QF_BV, QF_UFBV, QF_ABV, QF_AUFBV, QF_AX] + list(filter(lambda l: l.name in {'QF_ABV*', 'QF_AUFBV*', 'QF_AX*'}, ARRAYS_CONST_LOGICS))
+    LOGICS = [QF_BV, QF_UFBV, QF_ABV, QF_AUFBV, QF_AX] + \
+        list(filter(lambda l: l.name in {
+             'QF_ABV*', 'QF_AUFBV*', 'QF_AX*'}, ARRAYS_CONST_LOGICS))
     OptionsClass = BoolectorOptions
 
     def __init__(self, environment, logic, **options):
@@ -258,7 +258,8 @@ class BoolectorSolver(IncrementalTrackingSolver, UnsatCoreSolver,
             unsat_core = set()
             # relies on this assertion stack being ordered
             assert isinstance(self._assertion_stack, list)
-            btor_assertions = [self.converter.convert(a) for a in self._assertion_stack]
+            btor_assertions = [self.converter.convert(
+                a) for a in self._assertion_stack]
             in_unsat_core = self.btor.Failed(*btor_assertions)
             for a, in_core in zip(self._assertion_stack, in_unsat_core):
                 if in_core:
@@ -276,7 +277,8 @@ class BoolectorSolver(IncrementalTrackingSolver, UnsatCoreSolver,
             unsat_core = {}
             # relies on this assertion stack being ordered
             assert isinstance(self._assertion_stack, list)
-            btor_named_assertions = [self.converter.convert(a) for a in self._named_assertions.keys()]
+            btor_named_assertions = [self.converter.convert(
+                a) for a in self._named_assertions.keys()]
             in_unsat_core = self.btor.Failed(*btor_named_assertions)
             for a, in_core in zip(self._assertion_stack, in_unsat_core):
                 if in_core:
@@ -304,22 +306,46 @@ class BoolectorSolver(IncrementalTrackingSolver, UnsatCoreSolver,
         self._assert_no_function_type(item)
         itype = item.get_type()
         titem = self.converter.convert(item)
+
+        def _back_bv_func(width):
+            def _back_bv(assignment):
+                return self.mgr.BV(assignment, width)
+            return _back_bv
+
+        def _back_bool(assignment):
+            return self.mgr.Bool(bool(int(assignment)))
+
         if itype.is_bv_type():
-            return self.mgr.BV(titem.assignment, item.bv_width())
+            return _back_bv_func(item.bv_width())(titem.assignment)
         elif itype.is_bool_type():
-            return self.mgr.Bool(bool(int(titem.assignment)))
+            return _back_bool(titem.assignment)
         else:
             assert itype.is_array_type()
-            assert itype.index_type.is_bv_type()
-            assert itype.elem_type.is_bv_type()
+            assert itype.index_type.is_bv_type() or itype.index_type.is_bool_type()
+            assert itype.elem_type.is_bv_type() or itype.index_type.is_bool_type()
 
-            idx_width = itype.index_type.width
-            val_width = itype.elem_type.width
+            if itype.index_type.is_bv_type():
+                _back_index = _back_bv_func(itype.index_type.width)
+            else:
+                _back_index = _back_bool
+
+            if itype.elem_type.is_bv_type():
+                _back_elem = _back_bv_func(itype.elem_type.width)
+                default_elem = self.mgr.BV(0, itype.elem_type.width)
+            else:
+                _back_elem = _back_bool
+                default_elem = self.mgr.Bool(False)
+
             assign = {}
             for (idx, val) in titem.assignment:
-                assign[self.mgr.BV(idx, idx_width)] = self.mgr.BV(val, val_width)
+                elem_value = _back_elem(val)
+                if idx == '*':
+                    default_elem = elem_value
+                else:
+                    assign[_back_index(idx)] = elem_value
+
             return self.mgr.Array(itype.index_type,
-                                  self.mgr.BV(0, val_width), assign)
+                                  default_elem, assign)
 
     def _exit(self):
         del self.btor
@@ -374,7 +400,8 @@ class BTORConverter(Converter, DagWalker):
     def walk_symbol(self, formula, **kwargs):
         symbol_type = formula.symbol_type()
         if symbol_type.is_bool_type():
-            res = self._btor.Var(self._btor.BitVecSort(1), formula.symbol_name())
+            res = self._btor.Var(self._btor.BitVecSort(1),
+                                 formula.symbol_name())
         elif symbol_type.is_real_type():
             raise ConvertExpressionError
         elif symbol_type.is_int_type():
@@ -383,11 +410,13 @@ class BTORConverter(Converter, DagWalker):
             # BTOR supports only Arrays of Type (BV, BV)
             index_type = symbol_type.index_type
             elem_type = symbol_type.elem_type
-            if not (index_type.is_bv_type() and elem_type.is_bv_type()):
-                raise ConvertExpressionError("BTOR supports only Array(BV,BV). "\
+            if not (index_type.is_bv_type() or index_type.is_bool_type()) or not (elem_type.is_bv_type() or elem_type.is_bool_type()):
+                raise ConvertExpressionError("BTOR supports only Array(BV,BV). "
                                              "Type '%s' was given." % str(symbol_type))
-            res = self._btor.Array(self._btor.ArraySort(self._btor.BitVecSort(index_type.width),
-                                                        self._btor.BitVecSort(elem_type.width)),
+            index_width = index_type.width if index_type.is_bv_type() else 1
+            elem_width = elem_type.width if elem_type.is_bv_type() else 1
+            res = self._btor.Array(self._btor.ArraySort(self._btor.BitVecSort(index_width),
+                                                        self._btor.BitVecSort(elem_width)),
                                    formula.symbol_name())
         elif symbol_type.is_bv_type():
             res = self._btor.Var(self._btor.BitVecSort(formula.bv_width()),
@@ -474,11 +503,11 @@ class BTORConverter(Converter, DagWalker):
 
     def walk_bv_rol(self, formula, args, **kwargs):
         return self._btor.Rol(args[0],
-                             formula.bv_rotation_step())
+                              formula.bv_rotation_step())
 
     def walk_bv_ror(self, formula, args, **kwargs):
         return self._btor.Ror(args[0],
-                             formula.bv_rotation_step())
+                              formula.bv_rotation_step())
 
     def walk_bv_zext(self, formula, args, **kwargs):
         return self._btor.Uext(args[0], formula.bv_extend_step())
@@ -501,7 +530,7 @@ class BTORConverter(Converter, DagWalker):
     def walk_bv_srem(self, formula, args, **kwargs):
         return self._btor.Srem(args[0], args[1])
 
-    def walk_bv_ashr (self, formula, args, **kwargs):
+    def walk_bv_ashr(self, formula, args, **kwargs):
         return self._btor.Sra(args[0], args[1])
 
     def walk_array_store(self, formula, args, **kwargs):
@@ -531,9 +560,9 @@ class BTORConverter(Converter, DagWalker):
             return self._btor.BitVecSort(tp.width)
         elif tp.is_array_type():
             return self._btor.ArraySort(self._type_to_btor(tp.index_type),
-                                   self._type_to_btor(tp.elem_type))
+                                        self._type_to_btor(tp.elem_type))
         else:
-            assert tp.is_function_type() , "Unsupported type '%s'" % tp
+            assert tp.is_function_type(), "Unsupported type '%s'" % tp
             stps = [self._type_to_btor(x) for x in tp.param_types]
             rtp = self._type_to_btor(tp.return_type)
             return self._btor.FunSort(stps, rtp)

--- a/pysmt/solvers/btor.py
+++ b/pysmt/solvers/btor.py
@@ -322,7 +322,7 @@ class BoolectorSolver(IncrementalTrackingSolver, UnsatCoreSolver,
         else:
             assert itype.is_array_type()
             assert itype.index_type.is_bv_type() or itype.index_type.is_bool_type()
-            assert itype.elem_type.is_bv_type() or itype.index_type.is_bool_type()
+            assert itype.elem_type.is_bv_type() or itype.elem_type.is_bool_type()
 
             if itype.index_type.is_bv_type():
                 _back_index = _back_bv_func(itype.index_type.width)

--- a/pysmt/test/examples.py
+++ b/pysmt/test/examples.py
@@ -864,6 +864,12 @@ def get_full_example_formulae(environment=None):
                     logic=pysmt.logics.get_logic_by_name("QF_AUFBVLIRA*")
                 ),
 
+            Example(hr="((Array{BV{8}, BV{8}}(0_8)[1_8 := 42_8] = abb) & (abb[1_8] = 42_8))",
+                    expr=And(Equals(Array(BV8, BV(0, 8), {BV(1, 8) : BV(42, 8)}), abb), Equals(Select(abb, BV(1, 8)), BV(42, 8))),
+                    is_valid=False,
+                    is_sat=True,
+                    logic=pysmt.logics.get_logic_by_name("QF_ABV*")
+                ),
 
             Example(hr="((a_arb_aii = Array{Array{Real, BV{8}}, Array{Int, Int}}(Array{Int, Int}(7))) -> (a_arb_aii[arb][42] = 7))",
                     expr=Implies(Equals(nested_a, Array(ArrayType(REAL, BV8),

--- a/pysmt/test/test_array.py
+++ b/pysmt/test/test_array.py
@@ -19,10 +19,10 @@
 from pysmt.test import TestCase, main
 from pysmt.test import skipIfNoSolverForLogic, skipIfSolverNotAvailable
 from pysmt.logics import QF_AUFLIA, QF_AUFBV
-from pysmt.typing import ARRAY_INT_INT, ArrayType, INT, REAL, BV8
+from pysmt.typing import ARRAY_INT_INT, ArrayType, INT, REAL, BV8, BOOL
 from pysmt.shortcuts import (Solver,
                              Symbol, Not, Equals, Int, BV, Real, FreshSymbol,
-                             Select, Store, Array)
+                             Select, Store, Array, TRUE)
 from pysmt.exceptions import ConvertExpressionError, PysmtTypeError, PysmtValueError
 
 
@@ -80,6 +80,16 @@ class TestArray(TestCase):
     def test_btor_supports_const_arrays(self):
         formula = Equals(Array(BV8, BV(0, 8)),
                                     FreshSymbol(ArrayType(BV8, BV8)))
+        self.assertSat(formula, logic=QF_AUFBV, solver_name="btor")
+
+    @skipIfSolverNotAvailable("btor")
+    def test_btor_support_bool_as_array_indices(self):
+        formula = Equals(Array(BOOL, BV(0, 8)), FreshSymbol(ArrayType(BOOL, BV8)))
+        self.assertSat(formula, logic=QF_AUFBV, solver_name="btor")
+
+    @skipIfSolverNotAvailable("btor")
+    def test_btor_support_bool_as_array_elements(self):
+        formula = Equals(Array(BV8, TRUE()), FreshSymbol(ArrayType(BV8, BOOL)))
         self.assertSat(formula, logic=QF_AUFBV, solver_name="btor")
 
     def test_complex_types(self):

--- a/pysmt/test/test_array.py
+++ b/pysmt/test/test_array.py
@@ -77,11 +77,10 @@ class TestArray(TestCase):
             btor.add_assertion(formula)
 
     @skipIfSolverNotAvailable("btor")
-    def test_btor_does_not_support_const_arryas(self):
-        with self.assertRaises(ConvertExpressionError):
-            btor = Solver(name="btor")
-            btor.add_assertion(Equals(Array(BV8, BV(0, 8)),
-                                      FreshSymbol(ArrayType(BV8, BV8))))
+    def test_btor_supports_const_arryas(self):
+        formula = Equals(Array(BV8, BV(0, 8)),
+                                    FreshSymbol(ArrayType(BV8, BV8)))
+        self.assertSat(formula, logic=QF_AUFBV, solver_name="btor")
 
     def test_complex_types(self):
         with self.assertRaises(PysmtTypeError):

--- a/pysmt/test/test_array.py
+++ b/pysmt/test/test_array.py
@@ -77,7 +77,7 @@ class TestArray(TestCase):
             btor.add_assertion(formula)
 
     @skipIfSolverNotAvailable("btor")
-    def test_btor_supports_const_arryas(self):
+    def test_btor_supports_const_arrays(self):
         formula = Equals(Array(BV8, BV(0, 8)),
                                     FreshSymbol(ArrayType(BV8, BV8)))
         self.assertSat(formula, logic=QF_AUFBV, solver_name="btor")

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -287,6 +287,10 @@ class TestBasic(TestCase):
     def test_model_picosat(self):
         self.do_model("picosat")
 
+    @skipIfSolverNotAvailable("btor")
+    def test_model_btor(self):
+        self.do_model("btor")
+
     @skipIfSolverNotAvailable("z3")
     def test_tactics_z3(self):
         from z3 import Tactic, Then


### PR DESCRIPTION
The conversion of "const array" terms was not yet implemented for Boolector.
This PR implements the conversion of pysmt array types into btor array sorts:
https://github.com/pysmt/pysmt/blob/743ff01f994b57437db6251866dbc39074f494de/pysmt/solvers/btor.py#L532-L534

and add support for building `ConstArray` instances with associated array stores (inpired from both msat and z3 converters):
https://github.com/pysmt/pysmt/blob/743ff01f994b57437db6251866dbc39074f494de/pysmt/solvers/btor.py#L513-L521

It also removes the `test_btor_does_not_support_const_arrays` and replace it with a test to ensure nothing breaks when building a const array with Boolector:
https://github.com/pysmt/pysmt/blob/743ff01f994b57437db6251866dbc39074f494de/pysmt/test/test_array.py#L79-L83
