### PR TITLE
Release 0.9.6

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -1,6 +1,42 @@
 Change Log
 ==========
 
+0.9.6: 2022-06-24 -- CVC5 and upgraded solvers
+----------------------------------------------
+
+## What's Changed
+* Fixed issue #613 by @mikand in https://github.com/pysmt/pysmt/pull/710 - Thanks @ekiwi for reporting
+* Fix missing file in Manifest by @marcogario in https://github.com/pysmt/pysmt/pull/718
+* Upgrade MathSAT to 5.6.6 by @marcogario in https://github.com/pysmt/pysmt/pull/720
+* CI: Avoid running on PR branch push by @marcogario in https://github.com/pysmt/pysmt/pull/721
+* Upgrade MathSAT to 5.6.7 by @marcogario in https://github.com/pysmt/pysmt/pull/719
+* Fix misspellings by @jayvdb in https://github.com/pysmt/pysmt/pull/724
+* Upgrade Z3 to 4.8.17 by @marcogario in https://github.com/pysmt/pysmt/pull/723
+* make FormulaContextualizer singleton in FormulaManager. by @enmag in https://github.com/pysmt/pysmt/pull/698
+* README: Remove interpolants from Z3 by @marcogario in https://github.com/pysmt/pysmt/pull/727
+* Parse logic str in Portfolio by @marcogario in https://github.com/pysmt/pysmt/pull/726
+* Make sudoku.py Python3 compatible by @akumm2k in https://github.com/pysmt/pysmt/pull/734
+* Fix the definition of BVXnor by @YikeZhou in https://github.com/pysmt/pysmt/pull/748
+* Deterministic get_closer_logic by @marcogario in https://github.com/pysmt/pysmt/pull/733
+* Grammar correction by @quantik-git in https://github.com/pysmt/pysmt/pull/750
+* example/parallel.py: typo fix by @tias in https://github.com/pysmt/pysmt/pull/755
+* Fix for pyximport by @marcogario in https://github.com/pysmt/pysmt/pull/766
+* Remove deprecated distutils by @marcogario in https://github.com/pysmt/pysmt/pull/765
+* Fixed removed imp module in Python 3.12 by @cybaol in https://github.com/pysmt/pysmt/pull/770
+* [Boolector] Add support for const arrays and boolean indices/elements by @nbailluet in https://github.com/pysmt/pysmt/pull/771
+* Update of all solvers  by @mikand in https://github.com/pysmt/pysmt/pull/761
+
+## New Contributors
+* @jayvdb made their first contribution in https://github.com/pysmt/pysmt/pull/724
+* @akumm2k made their first contribution in https://github.com/pysmt/pysmt/pull/734
+* @YikeZhou made their first contribution in https://github.com/pysmt/pysmt/pull/748
+* @quantik-git made their first contribution in https://github.com/pysmt/pysmt/pull/750
+* @tias made their first contribution in https://github.com/pysmt/pysmt/pull/755
+* @cybaol made their first contribution in https://github.com/pysmt/pysmt/pull/770
+* @nbailluet made their first contribution in https://github.com/pysmt/pysmt/pull/771
+
+**Full Changelog**: https://github.com/pysmt/pysmt/compare/v0.9.5...v0.9.6
+
 0.9.5: 2022-05-28 -- 2 years of bugfixes
 ----------------------------------------
 

--- a/pysmt/__init__.py
+++ b/pysmt/__init__.py
@@ -16,7 +16,7 @@
 #   limitations under the License.
 #
 
-VERSION = (0, 9, 6, "dev", 1)
+VERSION = (0, 9, 6)
 
 # Try to provide human-readable version of latest commit for dev versions
 # E.g. v0.5.1-4-g49a49f2-wip


### PR DESCRIPTION
Relaese branch for 0.9.6. This used the release notes generated by GH to speed up things. In order to do so, we create a draft release using the release branch and auto-generate the release notes.
We than copy the notes to the changelog and commit the file.
We then change the target for the relase to be master again.

Note: I put the 24th as release date.

**Next steps:**
- [x] Test the distribution locally to ensure no file is missing.
- [ ] Merge the PR
- [ ] If CI succeeds, it will automatically publish to pypi
- [ ] Publish the [draft release](https://github.com/pysmt/pysmt/releases/edit/untagged-ff00d90664c79c510255)  NOTE: This will autotag the HEAD of master with the tag `v0.9.6`
- [ ] Bump the version to `VERSION = (0, 9, 7, "dev", 1)` in https://github.com/pysmt/pysmt/blob/master/pysmt/__init__.py directly on master.
- [ ] Post a message to the google group https://groups.google.com/forum/#!forum/pysmt