### PR TITLE
Fixed issue #778

### DIFF
--- a/pysmt/smtlib/printers.py
+++ b/pysmt/smtlib/printers.py
@@ -143,7 +143,7 @@ class SmtPrinter(TreeWalker):
         (n,d) = abs(formula.constant_value().numerator), \
                     formula.constant_value().denominator
         if d != 1:
-            res = template % ( "(/ " + str(n) + " " + str(d) + ")" )
+            res = template % ( "(/ " + str(n) + ".0 " + str(d) + ".0)" )
         else:
             res = template % (str(n) + ".0")
 

--- a/pysmt/smtlib/printers.py
+++ b/pysmt/smtlib/printers.py
@@ -521,7 +521,7 @@ class SmtDagPrinter(DagWalker):
         (n,d) = abs(formula.constant_value().numerator), \
                     formula.constant_value().denominator
         if d != 1:
-            return template % ( "(/ " + str(n) + " " + str(d) + ")" )
+            return template % ( "(/ " + str(n) + ".0 " + str(d) + ".0)" )
         else:
             return template % (str(n) + ".0")
 

--- a/pysmt/test/test_printing.py
+++ b/pysmt/test/test_printing.py
@@ -98,9 +98,9 @@ class TestPrinting(TestCase):
         self.assertEqual(b1.to_smtlib(daggify=True), "true")
         self.assertEqual(b2.to_smtlib(daggify=True), "false")
 
-        self.assertEqual(r1.to_smtlib(daggify=True), "(/ 11 2)")
+        self.assertEqual(r1.to_smtlib(daggify=True), "(/ 11.0 2.0)")
         self.assertEqual(r2.to_smtlib(daggify=True), "5.0")
-        self.assertEqual(r3.to_smtlib(daggify=True), "(- (/ 11 2))")
+        self.assertEqual(r3.to_smtlib(daggify=True), "(- (/ 11.0 2.0))")
 
         self.assertEqual(i1.to_smtlib(daggify=True), "4")
         self.assertEqual(i2.to_smtlib(daggify=True), "(- 4)")
@@ -108,9 +108,9 @@ class TestPrinting(TestCase):
         self.assertEqual(b1.to_smtlib(daggify=False), "true")
         self.assertEqual(b2.to_smtlib(daggify=False), "false")
 
-        self.assertEqual(r1.to_smtlib(daggify=False), "(/ 11 2)")
+        self.assertEqual(r1.to_smtlib(daggify=False), "(/ 11.0 2.0)")
         self.assertEqual(r2.to_smtlib(daggify=False), "5.0")
-        self.assertEqual(r3.to_smtlib(daggify=False), "(- (/ 11 2))")
+        self.assertEqual(r3.to_smtlib(daggify=False), "(- (/ 11.0 2.0))")
 
         self.assertEqual(i1.to_smtlib(daggify=False), "4")
         self.assertEqual(i2.to_smtlib(daggify=False), "(- 4)")


### PR DESCRIPTION
When printing a real constant in SMTLib, we used a notation `(/ n d)` where `n` is the integer numerator  and `d` the integer denominator. 

This causes issues on more restrictive parsers, so we now print `(/ n.0 d.0)` to force a rational interpretation.