### PR TITLE
Fix Create node does not raise type error

### DIFF
--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -89,7 +89,9 @@ class FormulaManager(object):
     def create_node(self, node_type, args, payload=None):
         content = FNodeContent(node_type, args, payload)
         if content in self.formulae:
-            return self.formulae[content]
+            n = self.formulae[content]
+            self._do_type_check(n)
+            return n
         else:
             n = FNode(content, self._next_free_id)
             self._next_free_id += 1

--- a/pysmt/smtlib/parser/parser.py
+++ b/pysmt/smtlib/parser/parser.py
@@ -344,13 +344,15 @@ class SmtLibParser(object):
                 get_type = self.env.stc.get_type
                 get_free_variables = self.env.fvo.get_free_variables
                 new_args = []
+                changed = False
                 for x in args:
                     if get_type(x).is_int_type() and\
                        len(get_free_variables(x)) == 0:
                         new_args.append(mgr.ToReal(x))
+                        changed = True
                     else:
                         new_args.append(x)
-                if args == new_args:
+                if not changed:
                     raise
                 return op(*new_args)
 

--- a/pysmt/test/smtlib/test_smtlibscript.py
+++ b/pysmt/test/smtlib/test_smtlibscript.py
@@ -175,6 +175,17 @@ class TestSmtLibScript(TestCase):
         # No exceptions are thrown
         self.assertEqual(smtlib_script.replace('var', '__var0'), script.commands[0].serialize_to_string())
 
+    def test_twice_fix_real(self):
+        smtlib_script = "\n".join([
+            '(declare-fun r () Real)',
+            '(assert (< (* 1 r) 0))',
+            '(assert (< 2 (* 1 r)))'
+        ])
+        stream = StringIO(smtlib_script)
+        parser = SmtLibParser()
+        _ = parser.get_script(stream)
+        # No exceptions are thrown
+        self.assertTrue(True)
 
     def test_evaluate_command(self):
         class SmtLibIgnore(SmtLibIgnoreMixin):

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -456,12 +456,19 @@ class TestRegressions(TestCase):
             self.assertEqual(ex.pos_info[1], 19)
 
     def test_parse_bvconst_width(self):
-        smtlib_input = "(assert (> #x10 #x10))"
+        smtlib_input = "(assert (bvugt #x10 #x10))"
         parser = SmtLibParser()
         buffer_ = StringIO(smtlib_input)
         expr = parser.get_script(buffer_).get_last_formula()
         const = expr.args()[0]
         self.assertEqual(const.bv_width(), 8, const.bv_width())
+
+    def test_parse_bvconst_type_check(self):
+        smtlib_input = "(assert (> #x10 #x10))"
+        parser = SmtLibParser()
+        buffer_ = StringIO(smtlib_input)
+        with self.assertRaises(PysmtTypeError):
+            _ = parser.get_script(buffer_).get_last_formula()
 
     def test_equality_typing(self):
         x = Symbol('x', BOOL)

--- a/pysmt/test/test_typechecker.py
+++ b/pysmt/test/test_typechecker.py
@@ -212,6 +212,15 @@ class TestSimpleTypeChecker(TestCase):
         with self.assertRaises(PysmtTypeError):
             super_bad_function()
 
+    def test_multiple_creations(self):
+        def bad_formula():
+            return Times(self.p, self.r)
+        with self.assertRaises(PysmtTypeError):
+            bad_formula()
+        # When building the same formula a second time, should raise again.
+        with self.assertRaises(PysmtTypeError):
+            bad_formula()
+
     def test_examples(self):
         for (f, _, _, _) in get_example_formulae():
             self.assertIs(f.get_type(), BOOL, f)


### PR DESCRIPTION
Fixes: https://github.com/pysmt/pysmt/issues/784

This fixes the issue by type-checking every newly created node even when it is found in the `formulae` map.
No overhead should have been added as the type is cached.

This also fixes the tests where a type error in smtlib was not noticed, and adds new ones.

Minor: This also fixes the decision on retrying building a type-invalid node in the smtlib parser. Namely, if there are no integer constants within the arguments, there is nothing to change and an exception is directly raised.

<!--

- [ ] For bugs or new features, make sure there is a test showing the bug or demonstrating the use of the new feature
- [ ] Are all tests green?
- [ ] (First contribution only) You accepted the licensing terms by adding name and email to the CONTRIBUTORS file (see https://github.com/pysmt/pysmt/blob/master/docs/development.rst#licensing).

-->