### PR TITLE
Added Abs shortcut as shorthand for Ite(x > 0, x, -x)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,4 @@
+Agustin Martinez Sune <agustin.martinez.sune@cs.ox.ac.uk>
 Ahmed Irfan <ahmed.irfan@alumni.unitn.it>
 Alastair Reid <alastair.d.reid@gmail.com>
 Alberto Griggio <griggio@fbk.eu>

--- a/pysmt/shortcuts.py
+++ b/pysmt/shortcuts.py
@@ -233,6 +233,31 @@ def Ite(iff, left, right):
     return get_env().formula_manager.Ite(iff, left, right)
 
 
+def Abs(formula):
+    r"""Returns the absolute value of the formula.
+    
+    This is implemented as If(formula > 0, formula, -formula).
+    Works for both integer and real values.
+    
+    :param formula: The formula to compute the absolute value of
+    :returns: The absolute value of the formula
+    :raises: ValueError if the formula type is not integer or real
+    """
+    # Get the type of the formula to determine the appropriate zero value
+    formula_type = get_type(formula)
+    
+    # Create a zero value of the same type as the formula
+    if formula_type == types.INT:
+        zero = Int(0)
+    elif formula_type == types.REAL:
+        zero = Real(0)
+    else:
+        # Raise an error for unsupported types
+        raise ValueError(f"Abs function only supports integer and real types, got {formula_type}")
+    
+    return Ite(GT(formula, zero), formula, Minus(zero, formula))
+
+
 def Symbol(name, typename=types.BOOL):
     """Returns a symbol with the given name and type.
 


### PR DESCRIPTION
I added `Abs` as a shortcut for Ite(x > 0, x, -x). 

I haven't yet added support for parsing the `abs` SMT-LIB function and simplifying it into Ite(x > 0, x, -x). Let me know if you think this would be a useful addition.

- [ x ] For bugs or new features, make sure there is a test showing the bug or demonstrating the use of the new feature
- [ x ] Are all tests green?
- [ x ] (First contribution only) You accepted the licensing terms by adding name and email to the CONTRIBUTORS file (see https://github.com/pysmt/pysmt/blob/master/docs/development.rst#licensing).
