### PR TITLE
Fix compatibility with Z3 4.14.1

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,6 +29,7 @@ M. Fareed Arif <fareed.arif@yahoo.com>
 Marco Gario <marco.gario@gmail.com>
 Mathias Preiner <mathias.preiner@gmail.com>
 Matthew Venn  <matt@mattvenn.net>
+Nguyễn Gia Phong <cnx@loang.net>
 Nicolas Bailluet <nicolas.bailluet@inria.fr>
 Nitish  <nkd.2195@gmail.com>
 Quantik <40385569+quantik-git@users.noreply.github.com>

--- a/pysmt/smtlib/parser/parser.py
+++ b/pysmt/smtlib/parser/parser.py
@@ -1438,6 +1438,7 @@ class SmtLibZ3Parser(SmtLibParser):
                                 self._operator_adapter(self._ext_rotate_right)
         mgr = self.env.formula_manager
         self.interpreted['bv2int'] = self._operator_adapter(mgr.BVToNatural)
+        self.interpreted['ubv_to_int'] = self._operator_adapter(mgr.BVToNatural)
 
     def _ext_rotate_left(self, x, y):
         return self.env.formula_manager.BVRol(x, y.simplify().constant_value())


### PR DESCRIPTION
Z3 4.14.1 introduces support for SMT-LIB 2.7's operators `ubv_to_int`, `sbv_to_int` and `int_to_bv`.  pySMT does not seem to support the latter to operation out of the box, so we alias `ubv_to_int` to `bv2int`/`bv2nat` here to at least get `pysmt/test/test_back.py::TestBasic::test_z3_back_formulae` to pass.

References: https://github.com/Z3Prover/z3/issues/7572
References: https://issues.guix.gnu.org/78007
