### PR TITLE
Fix issue 801

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -31,4 +31,5 @@ Wael-Amine Boutglay <btwael@gmail.com> Wael Boutglay <btwael@gmail.com>
 Aryan Kumar <akumm2k@gmail.com> akumm2k <82381989+akumm2k@users.noreply.github.com>
 Anna Becchi <lanna.becchi@gmail.com> Anna Becchi <abecchi@fbk.eu>
 Anna Becchi <lanna.becchi@gmail.com> annabeks <lanna.becchi@gmail.com>
-Agustin Martinez Sune <agustin.martinez.sune@cs.ox.ac.uk> Agustín Martinez Suñé <4691852+aemartinez@users.noreply.github.com> 
+Agustin Martinez Sune <agustin.martinez.sune@cs.ox.ac.uk> Agustín Martinez Suñé <4691852+aemartinez@users.noreply.github.com>
+Luca Framba <framba@fbk.eu> Framba Luca <framba@fbk.eu>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,6 +24,7 @@ Kamyar Mohajerani <kammoh@gmail.com>
 Kangjing Huang
 Kino <cybao292261@163.com>
 Leonard Truong <lenny@stanford.edu>
+Luca Framba <framba@fbk.eu>
 Lukas Dresel <lukas.dresel@cs.ucsb.edu>
 Makai Mann <makaim@stanford.edu>
 M. Fareed Arif <fareed.arif@yahoo.com>

--- a/pysmt/rewritings.py
+++ b/pysmt/rewritings.py
@@ -162,7 +162,7 @@ class CNFizer(DagWalker):
             return CNFizer.THEORY_PLACEHOLDER
 
     def walk_function(self, formula, **kwargs):
-        ty = formula.function_symbol().symbol_type()
+        ty = formula.function_name().symbol_type()
         if ty.return_type.is_bool_type():
             return formula, CNFizer.TRUE_CNF
         else:

--- a/pysmt/test/test_cnf.py
+++ b/pysmt/test/test_cnf.py
@@ -20,7 +20,7 @@ import pytest
 
 from pysmt.shortcuts import Implies, is_sat, reset_env, Symbol, Iff
 from pysmt.rewritings import CNFizer
-from pysmt.logics import QF_BOOL, QF_LRA, QF_LIA, QF_UFLIRA
+from pysmt.logics import QF_BOOL, QF_LRA, QF_LIA, QF_UFLIRA, QF_UFLRA
 from pysmt.test import TestCase, skipIfNoSolverForLogic, main
 from pysmt.test.examples import get_example_formulae
 from pysmt.test.smtlib.parser_utils import SMTLIB_TEST_FILES, SMTLIB_DIR
@@ -53,6 +53,11 @@ class TestCnf(TestCase):
     def test_examples_solving_lia(self):
         self.do_examples(QF_LIA)
 
+    @skipIfNoSolverForLogic(QF_UFLRA)
+    def test_examples_solving_lia(self):
+        self.do_examples(QF_UFLRA)
+
+    @pytest.mark.slow
     @skipIfNoSolverForLogic(QF_LIA)
     def test_smtlib_cnf_small(self):
         cnt = 0


### PR DESCRIPTION
This PR fixes the `CNFizer` `walk_function` method, renaming `function_symbol` (deprecated name) with `function_name`

fixes #801 
