### PR TITLE
Upgrade OptiMathSAT to 1.7.5

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -18,6 +18,7 @@ Daniel Ricardo dos Santos <danielricardo.santos@gmail.com>
 Enrico Magnago <en.magnago@gmail.com>
 Francesco Arrighi <arrighi.079@gmail.com>
 Francesco Contaldo <francio.194@gmail.com>
+Gabriele Masina <gabriele.masina@virgilio.it>
 Eric Kilmer <eric.d.kilmer@gmail.com>
 Gianluca Redondi <gianluca.redondi@gmail.com>
 Haozhong Zhang <hzzhan9@gmail.com>

--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -43,7 +43,7 @@ INSTALLERS = [
               {"pypicosat_minor_version" : "1708010052"}),
     Installer(CuddInstaller,    "2.0.3",
               {"git_version" : "ecb03d6d231273343178f566cc4d7258dcce52b4"}),
-    Installer(OptiMSatInstaller, "1.7.3", {})
+    Installer(OptiMSatInstaller, "1.7.5", {})
 ]
 
 

--- a/pysmt/cmd/installers/optimsat.py
+++ b/pysmt/cmd/installers/optimsat.py
@@ -24,18 +24,26 @@ class OptiMSatInstaller(SolverInstaller):
 
     def __init__(self, install_dir, bindings_dir, solver_version,
                  mirror_link=None):
-        # Getting the right archive name
-        os_name = self.os_name
-        arch = str(self.bits) + "-bit"
-        ext = "tar.gz"
-        if os_name == "windows":
-            ext = "zip"
-            arch += "-mingw"
-        elif os_name == "darwin":
-            os_name = "macos"
 
-        archive_name = "optimathsat-%s-%s-%s.%s" % (solver_version, os_name,
-                                                    arch, ext)
+        # Getting the right archive name
+        archive_name_template = "optimathsat-{version}-{os}-{arch}.{ext}"
+        format = {
+                "version": solver_version,
+                "os" : self.os_name,
+                "arch": self.architecture,
+                "ext": "tar.gz"
+        }
+        if self.os_name in ["windows", "darwin"]:
+            # Since version 1.7.5 the architecture is not included in the
+            # pkg name for the OSX and Win release as it is considered a "universal binary"
+            archive_name_template = "optimathsat-{version}-{os}.{ext}"
+        if self.os_name == "windows":
+            format["ext"] = "zip"
+            format["os"] = "win64" if self.architecture == "x86_64" else "win32"
+        elif self.os_name == "darwin":
+            format["os"] = "osx"
+
+        archive_name = archive_name_template.format(**format)
 
         native_link = "https://optimathsat.disi.unitn.it/releases/optimathsat-%s/{archive_name}" % solver_version
 

--- a/pysmt/optimization/optimsat.py
+++ b/pysmt/optimization/optimsat.py
@@ -144,9 +144,18 @@ class OptiMSATSolver(MathSAT5Solver, Optimizer):
         }
 
         while self.solve():
-            if all(self._check_unsat_unbound_infinitesimal(mo) for mo in msat_objs.values()):
-                model = self.get_model()
-                yield model, [model.get_value(goal.term()) for goal in goals]
+            all_ok = True
+            costs = []
+            model = None
+            for goal in goals:
+                result = self._get_goal_value(msat_objs[goal], goal)
+                if result is None:
+                    all_ok = False
+                    break
+                model, cost = result
+                costs.append(cost)
+            if all_ok and model is not None:
+                yield model, costs
             else:
                 break
         # set after the solve because the solve method has the clear_pending_pop decorator

--- a/pysmt/test/optimization_utils.py
+++ b/pysmt/test/optimization_utils.py
@@ -242,9 +242,8 @@ def check_pareto(optimizer: Optimizer, goals: Sequence[Goal], goals_values: Sequ
     raised_class = _get_expected_raised_class(goals_values[0])
     assert raised_class is None or len(goals_values) == 1, "test: %s, goals_values: %s" % (test_id_str, str(goals_values))
     if raised_class is None:
-        iterator_retval = optimizer.pareto_optimize(goals, **kwargs)
-        assert iterator_retval is not None, test_id_str
-        retval = list(iterator_retval)
+        retval = optimizer.pareto_optimize(goals, **kwargs)
+        assert retval is not None, test_id_str
 
         sorted_costs = sorted((costs for _, costs in retval), key=str)
         sorted_goals_values = sorted(goals_values, key=str)
@@ -257,7 +256,7 @@ def check_pareto(optimizer: Optimizer, goals: Sequence[Goal], goals_values: Sequ
                 assert isinstance(goal_value, FNode)
                 _check_oracle_goal(goal, goal_value, cost, test_id_str, **kwargs)
 
-        return retval
+        return None
     elif not optimizer.can_diverge_for_unbounded_cases():
         with pytest.raises(raised_class):
             return list(optimizer.pareto_optimize(goals, **kwargs))

--- a/pysmt/test/smtlib/test_omt_lib_solver.py
+++ b/pysmt/test/smtlib/test_omt_lib_solver.py
@@ -338,11 +338,8 @@ sat
         )
 
 
-test_to_skip = {
-        ("QF_LRA - smtlib2_boxed.smt2", OptimizationTypes.LEXICOGRAPHIC, "optimsat"), # error return wrong maximization of z (should be 24, returns 0); seems like a bug in optimsat; have to try optimsat alone; with integers instead of reals it works
-        ("QF_LIA - smtlib2_allsat.smt2", OptimizationTypes.PARETO, "optimsat"), # error that happens only if test_optimizing is done before this test
-        ("QF_LIA - smtlib2_load_objective_model.smt2", OptimizationTypes.PARETO, "optimsat"), # error that happens only if test_optimizing is done before this test
-}
+test_to_skip = {}
+
 @pytest.mark.parametrize(
     "optimization_example, solver_name",
     generate_examples_with_solvers(omt_test_cases_from_smtlib_test_set()),

--- a/pysmt/test/smtlib/test_omt_lib_solver.py
+++ b/pysmt/test/smtlib/test_omt_lib_solver.py
@@ -338,7 +338,7 @@ sat
         )
 
 
-test_to_skip = {}
+test_to_skip: dict = {}
 
 @pytest.mark.parametrize(
     "optimization_example, solver_name",

--- a/pysmt/test/test_optimizing.py
+++ b/pysmt/test/test_optimizing.py
@@ -20,10 +20,7 @@ import pytest
 from pysmt.test.omt_examples import get_full_example_omt_formuale
 from pysmt.test.optimization_utils import generate_examples_with_solvers, solve_given_example, OptimizationTypes
 
-test_to_skip = {
-    ("QF_LIA 2 int 2 bools multiple objective", OptimizationTypes.PARETO, "optimsat"), # weird error, this test fails only if executed test_omt_lib_solver (skipping ("QF_LIA - smtlib2_load_objective_model.smt2", OptimizationTypes.PARETO, "optimsat") this skip becomes necessary, otherwise not). The cost returned is 0 when it should be 1
-    ("QF_LIA 2 variables multiple objective", OptimizationTypes.PARETO, "optimsat"), # weird error, this test fails only if executed after test_optimization, while it works on it's own
-}
+test_to_skip = {}
 
 @pytest.mark.parametrize(
     "optimization_example, solver_name",

--- a/pysmt/test/test_optimizing.py
+++ b/pysmt/test/test_optimizing.py
@@ -20,7 +20,7 @@ import pytest
 from pysmt.test.omt_examples import get_full_example_omt_formuale
 from pysmt.test.optimization_utils import generate_examples_with_solvers, solve_given_example, OptimizationTypes
 
-test_to_skip = {}
+test_to_skip: dict = {}
 
 @pytest.mark.parametrize(
     "optimization_example, solver_name",


### PR DESCRIPTION
Fix #810.

Hi, we released a new version of OptiMathSAT. The broken tests are now fixed.

I tested it on Linux and MacOS (I compiled it for arm64 only, I hope this is not a problem).
Bindings generation on Windows is still broken, but it was also broken with the previous version:
```
warning: I don't know what to do with 'runtime_library_dirs': ['$ORIGIN']
error: don't know how to set runtime library search path for MSVC
Traceback (most recent call last):
  File "C:\Users\sebad\Desktop\test\toRemove\Scripts\pysmt-install-script.py", line 33, in <module>
    sys.exit(load_entry_point('PySMT==0.9.7.dev334', 'console_scripts', 'pysmt-install')())
  File "c:\users\sebad\desktop\test\toremove\lib\site-packages\pysmt\cmd\install.py", line 261, in main
    installer.install(force_redo=options.force_redo)
  File "c:\users\sebad\desktop\test\toremove\lib\site-packages\pysmt\cmd\installers\base.py", line 147, in install
    self.compile()
  File "c:\users\sebad\desktop\test\toremove\lib\site-packages\pysmt\cmd\installers\optimsat.py", line 67, in compile
    SolverInstaller.run_python("./setup.py build_ext -R $ORIGIN", self.python_bindings_dir)
  File "c:\users\sebad\desktop\test\toremove\lib\site-packages\pysmt\cmd\installers\base.py", line 201, in run_python
    return SolverInstaller.run(cmd, directory=directory,
  File "c:\users\sebad\desktop\test\toremove\lib\site-packages\pysmt\cmd\installers\base.py", line 228, in run
    subprocess.check_call(program, env=environment,
  File "C:\Users\sebad\AppData\Local\Programs\Python\Python39\lib\subprocess.py", line 373, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['c:\\users\\sebad\\desktop\\test\\toremove\\scripts\\python.exe', './setup.py', 'build_ext', '-R', '$ORIGIN']' returned non-zero exit status 1.
```