### PR TITLE
Fix interpretations when substituting in quantifiers

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -22,6 +22,7 @@ Francesco Contaldo <francio.194@gmail.com>
 Gabriele Masina <gabriele.masina@virgilio.it>
 Eric Kilmer <eric.d.kilmer@gmail.com>
 Gianluca Redondi <gianluca.redondi@gmail.com>
+Gereon Kremer <gereon.kremer@gmail.com>
 Haozhong Zhang <hzzhan9@gmail.com>
 Ioannis Filippidis <jfilippidis@gmail.com>
 Jan Tomassi <tomassijan@gmail.com>

--- a/pysmt/substituter.py
+++ b/pysmt/substituter.py
@@ -151,7 +151,7 @@ class Substituter(pysmt.walkers.IdentityDagWalker):
             # 2. We apply the substitution on the quantifier body with
             #    the new 'reduced' map
             sub = self.__class__(self.env)
-            res_formula = sub.substitute(formula.arg(0), new_subs)
+            res_formula = sub.substitute(formula.arg(0), new_subs, kwargs['interpretations'])
 
             # 3. We invoke the relevant function (walk_exists or
             #    walk_forall) to compute the substitution

--- a/pysmt/substituter.py
+++ b/pysmt/substituter.py
@@ -151,7 +151,8 @@ class Substituter(pysmt.walkers.IdentityDagWalker):
             # 2. We apply the substitution on the quantifier body with
             #    the new 'reduced' map
             sub = self.__class__(self.env)
-            res_formula = sub.substitute(formula.arg(0), new_subs, kwargs['interpretations'])
+            res_formula = sub.substitute(formula.arg(0), subs=new_subs,
+                                         interpretations=kwargs.get('interpretations', None))
 
             # 3. We invoke the relevant function (walk_exists or
             #    walk_forall) to compute the substitution
@@ -304,8 +305,9 @@ class MSSubstituter(Substituter):
     def __init__(self, env):
         Substituter.__init__(self, env=env)
 
-    def substitute(self, formula, subs):
-        return Substituter.substitute(self, formula, subs)
+    def substitute(self, formula, subs=None, interpretations=None):
+        return Substituter.substitute(self, formula, subs,
+                                      interpretations=interpretations)
 
     def _substitute(self, formula, substitutions):
         """Returns the substitution for formula, if one is defined, otherwise

--- a/pysmt/test/test_walkers.py
+++ b/pysmt/test/test_walkers.py
@@ -77,20 +77,21 @@ class TestWalkers(TestCase):
 
         with self.assertRaisesRegex(PysmtTypeError, "substitute()"):
             substitute(f, {x:x})
-    
+
     def test_substituter_interpretations_in_quantifiers(self):
-        x = Symbol("x")
+        x = Symbol("x", INT)
         UF_XOR = Symbol('uf_xor', FunctionType(INT, [INT, INT]))
-        f = ForAll([x], Equals(Function(self.UF_XOR, [x, x]), Int(0)))
+        f = ForAll([x], Equals(Function(UF_XOR, [x, x]), Int(0)))
 
         class XORInterpreter(FunctionInterpretation):
+            def __init__(self): pass
             def interpret(self, env, args):
                 if args[0] == args[1]: return Int(0)
                 return Function(UF_XOR, args)
         
-        subs = f.substitute({UF_XOR: XORInterpreter()})
+        subs = f.substitute({}, interpretations={UF_XOR: XORInterpreter()})
 
-        self.assertEqual(subs, TRUE())
+        self.assertEqual(subs, ForAll([x], Equals(Int(0), Int(0))))
 
     def test_undefined_node(self):
         varA = Symbol("At", INT)

--- a/pysmt/test/test_walkers.py
+++ b/pysmt/test/test_walkers.py
@@ -26,7 +26,7 @@ from pysmt.test import TestCase, main
 from pysmt.formula import FormulaManager
 from pysmt.test.examples import get_example_formulae
 from pysmt.exceptions import UnsupportedOperatorError, PysmtTypeError
-from pysmt.substituter import MSSubstituter, MGSubstituter
+from pysmt.substituter import FunctionInterpretation, MSSubstituter, MGSubstituter
 
 
 class TestWalkers(TestCase):
@@ -77,6 +77,20 @@ class TestWalkers(TestCase):
 
         with self.assertRaisesRegex(PysmtTypeError, "substitute()"):
             substitute(f, {x:x})
+    
+    def test_substituter_interpretations_in_quantifiers(self):
+        x = Symbol("x")
+        UF_XOR = Symbol('uf_xor', FunctionType(INT, [INT, INT]))
+        f = ForAll([x], Equals(Function(self.UF_XOR, [x, x]), Int(0)))
+
+        class XORInterpreter(FunctionInterpretation):
+            def interpret(self, env, args):
+                if args[0] == args[1]: return Int(0)
+                return Function(UF_XOR, args)
+        
+        subs = f.substitute({UF_XOR: XORInterpreter()})
+
+        self.assertEqual(subs, TRUE())
 
     def test_undefined_node(self):
         varA = Symbol("At", INT)


### PR DESCRIPTION
The Substituter class dropped the interpretations when going inside a quantifier. This PR fixes this issue and adds a little test to exercise this code.