### PR TITLE
Fixed n-ary bit vector operations in Z3

### DIFF
--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -340,12 +340,12 @@ class Z3Converter(Converter, DagWalker):
             z3.Z3_OP_IMPLIES: lambda args, expr: self.mgr.Implies(args[0], args[1]),
             z3.Z3_OP_ITE: lambda args, expr: self.mgr.Ite(args[0], args[1], args[2]),
             z3.Z3_OP_TO_REAL: lambda args, expr: self.mgr.ToReal(args[0]),
-            z3.Z3_OP_BAND : lambda args, expr: self.mgr.BVAnd(args[0], args[1]),
-            z3.Z3_OP_BOR : lambda args, expr: self.mgr.BVOr(args[0], args[1]),
+            z3.Z3_OP_BAND : lambda args, expr: self.mgr.BVAnd(args),
+            z3.Z3_OP_BOR : lambda args, expr: self.mgr.BVOr(args),
             z3.Z3_OP_BXOR : lambda args, expr: self.mgr.BVXor(args[0], args[1]),
             z3.Z3_OP_BNOT : lambda args, expr: self.mgr.BVNot(args[0]),
             z3.Z3_OP_BNEG : lambda args, expr: self.mgr.BVNeg(args[0]),
-            z3.Z3_OP_CONCAT : lambda args, expr: self.mgr.BVConcat(args[0], args[1]),
+            z3.Z3_OP_CONCAT : lambda args, expr: self.mgr.BVConcat(args),
             z3.Z3_OP_ULT : lambda args, expr: self.mgr.BVULT(args[0], args[1]),
             z3.Z3_OP_ULEQ : lambda args, expr: self.mgr.BVULE(args[0], args[1]),
             z3.Z3_OP_SLT : lambda args, expr: self.mgr.BVSLT(args[0], args[1]),
@@ -354,8 +354,8 @@ class Z3Converter(Converter, DagWalker):
             z3.Z3_OP_UGEQ : lambda args, expr: self.mgr.BVUGE(args[0], args[1]),
             z3.Z3_OP_SGT : lambda args, expr: self.mgr.BVSGT(args[0], args[1]),
             z3.Z3_OP_SGEQ : lambda args, expr: self.mgr.BVSGE(args[0], args[1]),
-            z3.Z3_OP_BADD : lambda args, expr: self.mgr.BVAdd(args[0], args[1]),
-            z3.Z3_OP_BMUL : lambda args, expr: self.mgr.BVMul(args[0], args[1]),
+            z3.Z3_OP_BADD : lambda args, expr: self.mgr.BVAdd(args),
+            z3.Z3_OP_BMUL : lambda args, expr: self.mgr.BVMul(args),
             z3.Z3_OP_BUDIV : lambda args, expr: self.mgr.BVUDiv(args[0], args[1]),
             z3.Z3_OP_BSDIV : lambda args, expr: self.mgr.BVSDiv(args[0], args[1]),
             z3.Z3_OP_BUREM : lambda args, expr: self.mgr.BVURem(args[0], args[1]),
@@ -513,6 +513,9 @@ class Z3Converter(Converter, DagWalker):
         assert not len(args) > 2 or \
             (z3.is_and(expr) or z3.is_or(expr) or
              z3.is_add(expr) or z3.is_mul(expr) or
+             z3.is_app_of(expr, z3.Z3_OP_BAND) or z3.is_app_of(expr, z3.Z3_OP_BOR) or
+             z3.is_app_of(expr, z3.Z3_OP_BADD) or z3.is_app_of(expr, z3.Z3_OP_BMUL) or
+             z3.is_app_of(expr, z3.Z3_OP_CONCAT) or
              (len(args) == 3 and (z3.is_ite(expr) or z3.is_array_store(expr)))),\
             "Unexpected n-ary term: %s" % expr
 

--- a/pysmt/test/test_back.py
+++ b/pysmt/test/test_back.py
@@ -93,7 +93,7 @@ class TestBasic(TestCase):
         # Z3 simplification can produce n-ary (more than two arguments)
         # bit-vector operations. Back-converting them used to fail because
         # only the binary case was handled (unlike the integer operations).
-        import z3
+        import z3 # type: ignore[import]
 
         s = Solver(name="z3", logic=QF_BV)
         conv = s.converter

--- a/pysmt/test/test_back.py
+++ b/pysmt/test/test_back.py
@@ -16,11 +16,12 @@
 #   limitations under the License.
 #
 from pysmt.shortcuts import FreshSymbol, GT, And, Plus, Real, Int, LE, Iff
-from pysmt.shortcuts import Solver
-from pysmt.typing import REAL, INT
+from pysmt.shortcuts import Solver, Symbol, EqualsOrIff
+from pysmt.shortcuts import BVAdd, BVMul, BVAnd, BVOr, BVConcat
+from pysmt.typing import REAL, INT, BVType
 from pysmt.test import TestCase, skipIfSolverNotAvailable, main
 from pysmt.test.examples import get_example_formulae
-from pysmt.logics import QF_UFLIRA
+from pysmt.logics import QF_UFLIRA, QF_BV
 from pysmt.exceptions import NoSolverAvailableError
 
 
@@ -86,6 +87,31 @@ class TestBasic(TestCase):
     def test_z3_back_formulae(self):
         self.do_back("z3", via_smtlib=True)
         self.do_back("z3", via_smtlib=False)
+
+    @skipIfSolverNotAvailable("z3")
+    def test_z3_back_nary_bv(self):
+        # Z3 simplification can produce n-ary (more than two arguments)
+        # bit-vector operations. Back-converting them used to fail because
+        # only the binary case was handled (unlike the integer operations).
+        import z3
+
+        s = Solver(name="z3", logic=QF_BV)
+        conv = s.converter
+        a = Symbol("a", BVType(8))
+        b = Symbol("b", BVType(8))
+        c = Symbol("c", BVType(8))
+
+        for f in (BVAdd(BVAdd(a, b), c),
+                  BVMul(BVMul(a, b), c),
+                  BVAnd(BVAnd(a, b), c),
+                  BVOr(BVOr(a, b), c),
+                  BVConcat(BVConcat(a, b), c)):
+            # Simplify in Z3 to flatten the associative operators into a
+            # single n-ary application before converting back.
+            simplified = z3.simplify(conv.convert(f))
+            res = conv.back(simplified)
+            self.assertValid(EqualsOrIff(f, res), logic=QF_BV,
+                             solver_name="z3")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is an adaptation of #772 (the branch was too old to cleanly merge), thanks @nbailluet!
