### PR TITLE
Add to_int and is_int from the SMT-LIB Reals_Ints theory

### DIFF
--- a/pysmt/fnode.py
+++ b/pysmt/fnode.py
@@ -29,7 +29,7 @@ from pysmt.operators import (FORALL, EXISTS, AND, OR, NOT, IMPLIES, IFF,
                              PLUS, MINUS, TIMES, DIV,
                              LE, LT, EQUALS,
                              ITE,
-                             TOREAL,
+                             TOREAL, TOINT,
                              BV_CONSTANT, BV_NOT, BV_AND, BV_OR, BV_XOR,
                              BV_CONCAT, BV_EXTRACT,
                              BV_ULT, BV_ULE, BV_NEG, BV_ADD, BV_SUB,
@@ -255,6 +255,10 @@ class FNode(object):
     def is_toreal(self) -> bool:
         """Test whether the node is the ToReal operator."""
         return self.node_type() == TOREAL
+
+    def is_toint(self) -> bool:
+        """Test whether the node is the ToInt operator."""
+        return self.node_type() == TOINT
 
     def is_forall(self) -> bool:
         """Test whether the node is the ForAll operator."""

--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -493,6 +493,44 @@ class FormulaManager(object):
             raise PysmtTypeError("Argument is of type %s, but INT was "
                                  "expected!\n" % t)
 
+    def ToInt(self, formula: FNode) -> FNode:
+        """ Cast a formula to integer type.
+
+        This is the SMT-LIB to_int function, i.e. the floor: it rounds
+        towards minus infinity, hence ToInt(-3/2) is -2 and not -1.
+        """
+        t = self.env.stc.get_type(formula)
+        if t == types.INT:
+            # Ignore casting of an Int
+            return formula
+        elif t == types.REAL:
+            if formula.is_real_constant():
+                value = cast(fractions.Fraction, formula.constant_value())
+                # Floor division on the numerator/denominator, so that this
+                # also works for the gmpy2 mpq backend (see pysmt.constants)
+                return self.Int(value.numerator // value.denominator)
+            return self.create_node(node_type=op.TOINT,
+                                    args=(formula,))
+        else:
+            raise PysmtTypeError("Argument is of type %s, but REAL was "
+                                 "expected!\n" % t)
+
+    def IsInt(self, formula: FNode) -> FNode:
+        """ Returns whether the given real formula has an integer value.
+
+        This is the SMT-LIB is_int predicate, expanded into its SMT-LIB
+        definition: (is_int t) is (= t (to_real (to_int t))).
+        """
+        t = self.env.stc.get_type(formula)
+        if t == types.INT:
+            # An Int is always an integer
+            return self.TRUE()
+        elif t == types.REAL:
+            return self.Equals(formula, self.ToReal(self.ToInt(formula)))
+        else:
+            raise PysmtTypeError("Argument is of type %s, but REAL was "
+                                 "expected!\n" % t)
+
     def AtMostOne(self, *args: Union[FNode, Iterable[FNode]]) -> FNode:
         """ At most one of the bool expressions can be true at anytime.
 

--- a/pysmt/operators.py
+++ b/pysmt/operators.py
@@ -25,7 +25,7 @@ from itertools import chain
 from typing import List
 
 
-ALL_TYPES = list(range(0,66))
+ALL_TYPES = list(range(0,67))
 
 (
 FORALL, EXISTS, AND, OR, NOT, IMPLIES, IFF, # Boolean Logic (0-6)
@@ -79,6 +79,7 @@ DIV,                                        # Arithmetic Division (62)
 POW,                                        # Arithmetic Power (63)
 ALGEBRAIC_CONSTANT,                         # Algebraic Number (64)
 BV_TONATURAL,                               # BV to Natural Conversion (65)
+TOINT,                                      # LIRA to_int() function, i.e. floor (66)
 ) = ALL_TYPES
 
 QUANTIFIERS = frozenset([FORALL, EXISTS])
@@ -110,7 +111,8 @@ BV_OPERATORS = frozenset([BV_NOT, BV_AND, BV_OR, BV_XOR,
 STR_OPERATORS = frozenset([STR_LENGTH, STR_CONCAT, STR_INDEXOF, STR_REPLACE,
                            STR_SUBSTR, STR_CHARAT, STR_TO_INT, INT_TO_STR,])
 
-IRA_OPERATORS = frozenset([PLUS, MINUS, TIMES, TOREAL, DIV, POW, BV_TONATURAL])
+IRA_OPERATORS = frozenset([PLUS, MINUS, TIMES, TOREAL, TOINT, DIV, POW,
+                           BV_TONATURAL])
 
 ARRAY_OPERATORS = frozenset([ARRAY_SELECT, ARRAY_STORE, ARRAY_VALUE])
 
@@ -178,6 +180,7 @@ __OP_STR__ = {
     EQUALS : "EQUALS",
     ITE : "ITE",
     TOREAL : "TOREAL",
+    TOINT : "TOINT",
     BV_CONSTANT : "BV_CONSTANT",
     BV_NOT : "BV_NOT",
     BV_AND : "BV_AND",

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -246,6 +246,12 @@ class TheoryOracle(walkers.DagWalker):
         """Extends the Theory with LIRA."""
         theory_out = args[0].set_lira() # This makes a copy of args[0]
         return theory_out
+
+    def walk_toint(self, formula: FNode, args: List[Theory], **kwargs) -> Theory:
+        #pylint: disable=unused-argument
+        """Extends the Theory with LIRA."""
+        theory_out = args[0].set_lira() # This makes a copy of args[0]
+        return theory_out
         rtype = formula.symbol_name()
 
     @walkers.handles([op.STR_LENGTH, op.STR_INDEXOF, op.STR_TO_INT])

--- a/pysmt/parsing.py
+++ b/pysmt/parsing.py
@@ -199,6 +199,8 @@ class HRLexer(Lexer):
             "ZEXT": InfixOpAdapter(self.BVHack(self.mgr.BVZExt), 90),# BVZext
             "SEXT": InfixOpAdapter(self.BVHack(self.mgr.BVSExt), 90),# BVSext
             "ToReal": UnaryOpAdapter(self.mgr.ToReal, 100),#
+            "ToInt": UnaryOpAdapter(self.mgr.ToInt, 100),#
+            "IsInt": UnaryOpAdapter(self.mgr.IsInt, 100),#
             "Int": IntTypeTok(),# Int Type
             "Real": RealTypeTok(),# Real Type
             "Bool": BoolTypeTok(),# Bool Type

--- a/pysmt/printers.py
+++ b/pysmt/printers.py
@@ -177,6 +177,11 @@ class HRPrinter(TreeWalker):
         yield formula.arg(0)
         self.write(")")
 
+    def walk_toint(self, formula: FNode) -> Iterator[FNode]:
+        self.write("ToInt(")
+        yield formula.arg(0)
+        self.write(")")
+
     def walk_str_constant(self, formula: FNode):
         formula_value = formula.constant_value()
         assert isinstance(formula_value, str), \

--- a/pysmt/shortcuts.py
+++ b/pysmt/shortcuts.py
@@ -361,6 +361,19 @@ def ToReal(formula: FNode) -> FNode:
     return get_env().formula_manager.ToReal(formula)
 
 
+def ToInt(formula: FNode) -> FNode:
+    """Explicit cast of a term into an Int term.
+
+    This is the SMT-LIB to_int function, i.e. the floor.
+    """
+    return get_env().formula_manager.ToInt(formula)
+
+
+def IsInt(formula: FNode) -> FNode:
+    """Returns whether the given real term has an integer value."""
+    return get_env().formula_manager.IsInt(formula)
+
+
 def AtMostOne(*args: Union[FNode, Iterable[FNode]]) -> FNode:
     """At most one can be true at anytime.
 

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -463,6 +463,16 @@ class Simplifier(pysmt.walkers.DagWalker):
             return self.manager.Real(cast(int, args[0].constant_value()))
         return self.manager.ToReal(args[0])
 
+    def walk_toint(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
+        assert len(args) == 1
+        if args[0].is_toreal():
+            # to_int(to_real(x)) is x, since x is an integer.
+            # Note that the converse does not hold: to_real(to_int(y)) is
+            # y only when y happens to have an integer value.
+            return args[0].arg(0)
+        # Folding of real constants is done by the FormulaManager
+        return self.manager.ToInt(args[0])
+
     def walk_bv_and(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
         simplified = None
         width = formula.bv_width()

--- a/pysmt/smtlib/parser/parser.py
+++ b/pysmt/smtlib/parser/parser.py
@@ -392,6 +392,8 @@ class SmtLibParser(object):
             'ite': self._operator_adapter(self.Ite),
             'distinct': self._operator_adapter(self.AllDifferent),
             'to_real': self._operator_adapter(mgr.ToReal),
+            'to_int': self._operator_adapter(mgr.ToInt),
+            'is_int': self._operator_adapter(mgr.IsInt),
             'concat': self._operator_adapter(mgr.BVConcat),
             'bvnot': self._operator_adapter(mgr.BVNot),
             'bvand': self._operator_adapter(mgr.BVAnd),

--- a/pysmt/smtlib/printers.py
+++ b/pysmt/smtlib/printers.py
@@ -94,6 +94,7 @@ class SmtPrinter(TreeWalker):
     def walk_lt(self, formula): return self.walk_nary(formula, "<")
     def walk_ite(self, formula): return self.walk_nary(formula, "ite")
     def walk_toreal(self, formula): return self.walk_nary(formula, "to_real")
+    def walk_toint(self, formula): return self.walk_nary(formula, "to_int")
     def walk_div(self, formula): return self.walk_nary(formula, "/")
     def walk_pow(self, formula): return self.walk_nary(formula, "pow")
     def walk_bv_and(self, formula): return self.walk_nary(formula, "bvand")
@@ -421,6 +422,9 @@ class SmtDagPrinter(DagWalker):
 
     def walk_toreal(self, formula: FNode, args: List[str]) -> str:
         return self.walk_nary(formula, args, "to_real")
+
+    def walk_toint(self, formula: FNode, args: List[str]) -> str:
+        return self.walk_nary(formula, args, "to_int")
 
     def walk_div(self, formula: FNode, args: List[str]) -> str:
         return self.walk_nary(formula, args, "/")

--- a/pysmt/solvers/cvcfive.py
+++ b/pysmt/solvers/cvcfive.py
@@ -394,6 +394,9 @@ class CVC5Converter(Converter, DagWalker):
     def walk_toreal(self, formula, args, **kwargs):
         return self.cvc5_solver.mkTerm(Kind.TO_REAL, args[0])
 
+    def walk_toint(self, formula, args, **kwargs):
+        return self.cvc5_solver.mkTerm(Kind.TO_INTEGER, args[0])
+
     def walk_function(self, formula, args, **kwargs):
         name = formula.function_name()
         if name not in self.declared_vars:

--- a/pysmt/solvers/cvcfour.py
+++ b/pysmt/solvers/cvcfour.py
@@ -351,6 +351,9 @@ class CVC4Converter(Converter, DagWalker):
     def walk_toreal(self, formula, args, **kwargs):
         return self.mkExpr(CVC4.TO_REAL, args[0])
 
+    def walk_toint(self, formula, args, **kwargs):
+        return self.mkExpr(CVC4.TO_INTEGER, args[0])
+
     def walk_function(self, formula, args, **kwargs):
         name = formula.function_name()
         if name not in self.declared_vars:

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -427,6 +427,7 @@ class MSatConverter(Converter, DagWalker):
             self._msat_lib.MSAT_TAG_BV_LSHR: self._back_adapter(self.mgr.BVLShr),
             self._msat_lib.MSAT_TAG_BV_ASHR: self._back_adapter(self.mgr.BVAShr),
             self._msat_lib.MSAT_TAG_BV_COMP: self._back_adapter(self.mgr.BVComp),
+            self._msat_lib.MSAT_TAG_FLOOR: self._back_adapter(self.mgr.ToInt),
             self._msat_lib.MSAT_TAG_INT_FROM_UBV: self._back_adapter(self.mgr.BVToNatural),
             self._msat_lib.MSAT_TAG_ARRAY_READ: self._back_adapter(self.mgr.Select),
             self._msat_lib.MSAT_TAG_ARRAY_WRITE: self._back_adapter(self.mgr.Store),
@@ -461,6 +462,8 @@ class MSatConverter(Converter, DagWalker):
             self._msat_lib.MSAT_TAG_LEQ: self._sig_most_generic_bool_binary,
             self._msat_lib.MSAT_TAG_PLUS:  self._sig_most_generic_bool_binary,
             self._msat_lib.MSAT_TAG_TIMES: self._sig_most_generic_bool_binary,
+            self._msat_lib.MSAT_TAG_FLOOR: lambda term, args:\
+                types.FunctionType(types.INT, [types.REAL]),
             self._msat_lib.MSAT_TAG_BV_MUL: self._sig_binary,
             self._msat_lib.MSAT_TAG_BV_ADD: self._sig_binary,
             self._msat_lib.MSAT_TAG_BV_UDIV:self._sig_binary,
@@ -1003,6 +1006,9 @@ class MSatConverter(Converter, DagWalker):
     def walk_toreal(self, formula: FNode, args: List[Any], **kwargs) -> Any:
         # In mathsat toreal is implicit
         return args[0]
+
+    def walk_toint(self, formula: FNode, args: List[Any], **kwargs) -> Any:
+        return self._msat_lib.msat_make_floor(self.msat_env(), args[0])
 
     def walk_bv_tonatural(self, formula: FNode, args: List[Any], **kwargs) -> Any:
         return self._msat_lib.msat_make_int_from_ubv(self.msat_env(), args[0])

--- a/pysmt/solvers/yices.py
+++ b/pysmt/solvers/yices.py
@@ -470,6 +470,11 @@ class YicesConverter(Converter, DagWalker):
     def walk_toreal(self, formula: FNode, args, **kwargs):
         return args[0]
 
+    def walk_toint(self, formula: FNode, args, **kwargs):
+        res = yices_api.yices_floor(args[0])
+        self._check_term_result(res)
+        return res
+
     def walk_function(self, formula: FNode, args, **kwargs):
         name = formula.function_name()
         if name not in self.symbol_to_decl:

--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -340,6 +340,8 @@ class Z3Converter(Converter, DagWalker):
             z3.Z3_OP_IMPLIES: lambda args, expr: self.mgr.Implies(args[0], args[1]),
             z3.Z3_OP_ITE: lambda args, expr: self.mgr.Ite(args[0], args[1], args[2]),
             z3.Z3_OP_TO_REAL: lambda args, expr: self.mgr.ToReal(args[0]),
+            z3.Z3_OP_TO_INT: lambda args, expr: self.mgr.ToInt(args[0]),
+            z3.Z3_OP_IS_INT: lambda args, expr: self.mgr.IsInt(args[0]),
             z3.Z3_OP_BAND : lambda args, expr: self.mgr.BVAnd(args),
             z3.Z3_OP_BOR : lambda args, expr: self.mgr.BVOr(args),
             z3.Z3_OP_BXOR : lambda args, expr: self.mgr.BVXor(args[0], args[1]),
@@ -734,6 +736,11 @@ class Z3Converter(Converter, DagWalker):
 
     def walk_toreal(self, formula, args, **kwargs):
         z3term = z3.Z3_mk_int2real(self.ctx.ref(), args[0])
+        z3.Z3_inc_ref(self.ctx.ref(), z3term)
+        return z3term
+
+    def walk_toint(self, formula, args, **kwargs):
+        z3term = z3.Z3_mk_real2int(self.ctx.ref(), args[0])
         z3.Z3_inc_ref(self.ctx.ref(), z3term)
         return z3term
 

--- a/pysmt/test/examples.py
+++ b/pysmt/test/examples.py
@@ -23,7 +23,7 @@ from pysmt.shortcuts import (Symbol, Function,
                              Int, Real, FALSE, TRUE,
                              And, Iff, Or, Not, Implies, Ite,
                              LT, LE, GT, GE,
-                             Times, Pow, Equals, Plus, Minus, Div, ToReal,
+                             Times, Pow, Equals, Plus, Minus, Div, ToReal, ToInt,
                              ForAll, Exists,
                              BV, SBV, BVOne, BVZero,
                              BVNot, BVAnd, BVOr, BVXor,
@@ -697,6 +697,32 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     is_valid=False,
                     is_sat=False,
                     logic=pysmt.logics.QF_UFLIRA
+                ),
+
+            # ToInt is the floor, hence it rounds towards minus infinity
+            Example(hr="((r = -3/2) -> (ToInt(r) = -2))",
+                    expr=Implies(Equals(r, Real(Fraction(-3, 2))),
+                                 Equals(ToInt(r), Int(-2))),
+                    is_valid=True,
+                    is_sat=True,
+                    logic=pysmt.logics.QF_LIRA
+                ),
+
+            # ToInt must not truncate towards zero
+            Example(hr="((r = -3/2) & (ToInt(r) = -1))",
+                    expr=And(Equals(r, Real(Fraction(-3, 2))),
+                             Equals(ToInt(r), Int(-1))),
+                    is_valid=False,
+                    is_sat=False,
+                    logic=pysmt.logics.QF_LIRA
+                ),
+
+            Example(hr="((ToInt(r) = p) & (0.0 < r))",
+                    expr=And(Equals(ToInt(r), p),
+                             GT(r, Real(0))),
+                    is_valid=False,
+                    is_sat=True,
+                    logic=pysmt.logics.QF_LIRA
                 ),
             #
             # STR

--- a/pysmt/test/smtlib/test_parser_examples.py
+++ b/pysmt/test/smtlib/test_parser_examples.py
@@ -118,6 +118,7 @@ class TestSMTParseExamples(TestCase):
             logics.QF_BOOL: logics.QF_UF,
             logics.BOOL: logics.LRA,
             logics.QF_NIRA: logics.AUFNIRA,
+            logics.QF_LIRA: logics.QF_UFLIRA,
         }
         fs = get_example_formulae()
 

--- a/pysmt/test/test_lira.py
+++ b/pysmt/test/test_lira.py
@@ -16,9 +16,11 @@
 #   limitations under the License.
 #
 from pysmt.shortcuts import *
+from pysmt.constants import Fraction
+from pysmt.exceptions import PysmtTypeError
 from pysmt.typing import INT, REAL, FunctionType
 from pysmt.test import TestCase, main
-from pysmt.logics import QF_UFLIRA, UFLIRA
+from pysmt.logics import QF_LIRA, QF_UFLIRA, UFLIRA
 
 class TestLIRA(TestCase):
 
@@ -45,6 +47,80 @@ class TestLIRA(TestCase):
         self.assertEqual(ToReal(b), ToReal(ToReal(b)))
         self.assertEqual(ToReal(Plus(b, Int(1))),
                           ToReal(ToReal(Plus(b, Int(1)))))
+
+
+    def test_toint_is_floor(self):
+        # to_int rounds towards minus infinity, it does not truncate
+        self.assertEqual(ToInt(Real(Fraction(-3, 2))), Int(-2))
+        self.assertEqual(ToInt(Real(Fraction(3, 2))), Int(1))
+        self.assertEqual(ToInt(Real(Fraction(-1, 3))), Int(-1))
+        self.assertEqual(ToInt(Real(0)), Int(0))
+        self.assertEqual(ToInt(Real(-2)), Int(-2))
+
+
+    def test_toint(self):
+        a = Symbol("a", REAL)
+        b = Symbol("b", INT)
+
+        # Casting an Int is a no-op
+        self.assertEqual(b, ToInt(b))
+        self.assertEqual(Plus(b, Int(1)), ToInt(Plus(b, Int(1))))
+
+        self.assertTrue(ToInt(a).is_toint())
+        self.assertEqual(get_type(ToInt(a)), INT)
+
+        for bad in (TRUE(), Symbol("x"), BV(1, 8)):
+            with self.assertRaises(PysmtTypeError):
+                ToInt(bad)
+
+
+    def test_toint_simplify(self):
+        a = Symbol("a", REAL)
+        b = Symbol("b", INT)
+
+        # to_int(to_real(b)) is b, since b is an integer
+        self.assertEqual(b, ToInt(ToReal(b)).simplify())
+        self.assertEqual(Plus(b, Int(1)),
+                         ToInt(ToReal(Plus(b, Int(1)))).simplify())
+
+        # The converse does NOT hold: to_real(to_int(a)) is a only when a
+        # happens to have an integer value.
+        self.assertNotEqual(a, ToReal(ToInt(a)).simplify())
+
+
+    def test_isint(self):
+        a = Symbol("a", REAL)
+        b = Symbol("b", INT)
+
+        # is_int is expanded into its SMT-LIB definition
+        self.assertEqual(IsInt(a), Equals(a, ToReal(ToInt(a))))
+        # An Int is trivially an integer
+        self.assertEqual(IsInt(b), TRUE())
+
+        with self.assertRaises(PysmtTypeError):
+            IsInt(TRUE())
+
+
+    def test_toint_solving(self):
+        a = Symbol("a", REAL)
+
+        for sname in get_env().factory.all_solvers(logic=QF_LIRA):
+            # 7/2 floors to 3
+            self.assertSat(And(Equals(a, Real(Fraction(7, 2))),
+                               Equals(ToInt(a), Int(3))),
+                           solver_name=sname)
+            # -3/2 floors to -2, and in particular not to -1
+            self.assertSat(And(Equals(a, Real(Fraction(-3, 2))),
+                               Equals(ToInt(a), Int(-2))),
+                           solver_name=sname)
+            self.assertUnsat(And(Equals(a, Real(Fraction(-3, 2))),
+                                 Equals(ToInt(a), Int(-1))),
+                             solver_name=sname)
+            # 1/2 is not an integer
+            self.assertUnsat(And(IsInt(a), Equals(a, Real(Fraction(1, 2)))),
+                             solver_name=sname)
+            self.assertSat(And(IsInt(a), Equals(a, Real(Fraction(4, 2)))),
+                           solver_name=sname)
 
 
     def test_uflira(self):

--- a/pysmt/test/test_printing.py
+++ b/pysmt/test/test_printing.py
@@ -20,7 +20,7 @@ from io import StringIO
 from pysmt.shortcuts import Or, And, Not, Plus, Iff, Implies
 from pysmt.shortcuts import Exists, ForAll, Ite, ExactlyOne
 from pysmt.shortcuts import Bool, Real, Int, Symbol, Function
-from pysmt.shortcuts import Times, Minus, Equals, LE, LT, ToReal, FreshSymbol
+from pysmt.shortcuts import Times, Minus, Equals, LE, LT, ToReal, ToInt, FreshSymbol
 from pysmt.typing import REAL, INT, FunctionType
 from pysmt.smtlib.printers import SmtPrinter, SmtDagPrinter
 from pysmt.smtlib.annotations import Annotations
@@ -138,6 +138,14 @@ class TestPrinting(TestCase):
 
         self.assertEqual(rp.to_smtlib(daggify=False), "(to_real p)")
         self.assertEqual(rp.to_smtlib(daggify=True), "(let ((.def_0 (to_real p))) .def_0)")
+
+    def test_toint(self):
+        r = Symbol("r", REAL)
+        ir = ToInt(r)
+
+        self.assertEqual(ir.to_smtlib(daggify=False), "(to_int r)")
+        self.assertEqual(ir.to_smtlib(daggify=True), "(let ((.def_0 (to_int r))) .def_0)")
+        self.assertEqual(ir.serialize(), "ToInt(r)")
 
     def test_threshold_printing(self):
         x = Symbol("x")

--- a/pysmt/type_checker.py
+++ b/pysmt/type_checker.py
@@ -79,6 +79,11 @@ class SimpleTypeChecker(walkers.DagWalker):
         #pylint: disable=unused-argument
         return self.walk_type_to_type(formula, args, INT, REAL)
 
+    @walkers.handles(op.TOINT)
+    def walk_real_to_int(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
+        #pylint: disable=unused-argument
+        return self.walk_type_to_type(formula, args, REAL, INT)
+
     def walk_real_to_real(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
         #pylint: disable=unused-argument
         return self.walk_type_to_type(formula, args, REAL, REAL)

--- a/pysmt/walkers/identitydag.py
+++ b/pysmt/walkers/identitydag.py
@@ -114,6 +114,9 @@ class IdentityDagWalker(DagWalker):
     def walk_toreal(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
         return self.mgr.ToReal(args[0])
 
+    def walk_toint(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
+        return self.mgr.ToInt(args[0])
+
     def walk_bv_constant(self, formula: FNode, **kwargs) -> FNode:
         return self.mgr.BV(cast(int, formula.constant_value()), formula.bv_width())
 


### PR DESCRIPTION
Fixes #835.

## What

`to_int` and `is_int` from the [Reals_Ints](https://smt-lib.org/theories-Reals_Ints.shtml) theory were missing, although `to_real` has been supported for a long time and `QF_LIRA` is among the supported logics.

**`ToInt`** is a new operator (`TOINT`). It is the SMT-LIB `to_int`, i.e. the floor: it rounds towards minus infinity, so `ToInt(-3/2)` is `-2` and not `-1`. Like `ToReal`, casting a term that already has the target type is a no-op, and constants are folded eagerly. The floor is computed as a floor division of numerator and denominator, so that it is also correct under the gmpy2 `mpq` backend.

**`IsInt`** needs no new operator: it is expanded into its own SMT-LIB definition, `(is_int t)` is `(= t (to_real (to_int t)))`. An `Int` argument cannot use that expansion, since it would compare an `Int` with a `Real`, so it is mapped to `TRUE` instead. The consequence of expanding is that `is_int` read from an SMT-LIB file is printed back as the expansion; it is semantically identical but not textually a round-trip.

The simplifier rewrites `to_int(to_real(x))` into `x`. The converse does *not* hold, since `to_real(to_int(y))` is `y` only when `y` happens to have an integer value; there is a test pinning that down so the unsound rewrite does not get added later.

`TOINT` is appended as id 66 rather than inserted next to `TOREAL`, to avoid renumbering every BV/string/array operator (`new_node_type()` allocates custom ids from `ALL_TYPES[-1] + 1`). This follows `BV_TONATURAL`, which is an IRA operator sitting at id 65. Adding it to `IRA_OPERATORS` means the theory oracle reports LIRA and every walker handling `THEORY_OPERATORS` picks it up automatically.

## Solver support

| Solver | Forward | Back conversion |
|---|---|---|
| MathSAT | `msat_make_floor` | `MSAT_TAG_FLOOR` |
| Z3 | `Z3_mk_real2int` | `Z3_OP_TO_INT`, `Z3_OP_IS_INT` |
| CVC5 | `TO_INTEGER` | n/a |
| CVC4 | `TO_INTEGER` | n/a |
| Yices | `yices_floor` | n/a |

No logic declaration is changed. As is already the case for `Div` and `Pow` on Yices, a solver that cannot express `to_int` reports it at conversion time rather than having a hole carved into the logic lattice for a single operator.

For MathSAT, adding the tag to `back_fun` was not sufficient: `_get_signature` consults a separate `term_sig` table, so a `Real -> Int` signature entry was needed as well, otherwise back conversion raised `ConvertExpressionError`.

## Tests

Three entries in `pysmt/test/examples.py`, which covers the HR and SMT-LIB printers and parsers, the type checker, the simplifier, the walkers, the theory oracle and solver back conversion in one go. One is valid, one is unsatisfiable specifically to catch truncation instead of flooring, and one is satisfiable with a free `Int` variable to exercise model extraction.

`QF_LIRA` is not an SMT-LIB logic, so these are dumped with the closest one, `QF_UFLIRA`. These are the first examples using `QF_LIRA`, hence the new entry in the `rewrite` dict of `test_dumped_logic`, next to the existing `QF_NIRA` one.

Targeted tests in `test_lira.py` cover the floor semantics on negative values, the no-op cast, the type errors, the simplifier rewrite and its non-converse, the `IsInt` expansion, and the floor semantics *through* each available solver (so a solver kind that truncates rather than floors fails, not just a wrong function name). `test_printing.py` covers the daggified and non-daggified SMT-LIB output.

Verified against a clean `master` baseline: same pre-existing failures before and after, `+6` tests, under both the default and the `PYSMT_GMPY=true` backends. `mypy pysmt` stays clean.

The CVC4 line is untested, as CVC4 is not in the CI matrix.

`mod`, `divisible` and a first-class `abs` are still missing from Reals_Ints; those are a separate issue.