### PR TITLE
Support all the SMT-LIB n-ary operators in the parser

### DIFF
--- a/pysmt/smtlib/parser/parser.py
+++ b/pysmt/smtlib/parser/parser.py
@@ -304,6 +304,40 @@ class Tokenizer(object):
 # EOC Tokenizer
 
 
+#
+# Helpers to expand the SMT-LIB n-ary applications of operators that pySMT
+# only exposes as binary ones. The SMT-LIB standard attaches one of the
+# attributes :left-assoc, :right-assoc, :chainable or :pairwise to every such
+# operator; the three functions below implement the first three (:pairwise is
+# already covered by mgr.AllDifferent).
+#
+# In all cases a single argument is accepted and behaves as the identity (or
+# as `true` for the chainable operators, where the conjunction is empty).
+# The standard requires at least two arguments, but pySMT has always been
+# lenient about this for `and`, `or`, `+` and `*`, and we keep it uniform.
+#
+
+def _left_assoc(operator: Callable) -> Callable:
+    """(op a b c) is expanded to (op (op a b) c)"""
+    def res(*args):
+        return functools.reduce(operator, args)
+    return res
+
+
+def _right_assoc(operator: Callable) -> Callable:
+    """(op a b c) is expanded to (op a (op b c))"""
+    def res(*args):
+        return functools.reduce(lambda acc, x: operator(x, acc), reversed(args))
+    return res
+
+
+def _chainable(mgr: FormulaManager, operator: Callable) -> Callable:
+    """(op a b c) is expanded to (and (op a b) (op b c))"""
+    def res(*args):
+        return mgr.And([operator(l, r) for l, r in zip(args, args[1:])])
+    return res
+
+
 class SmtLibParser(object):
     """Parse an SmtLib file and builds an SmtLibScript object.
     The main function is get_script (and its wrapper
@@ -373,22 +407,27 @@ class SmtLibParser(object):
             "!": self._enter_annotation,
             "exists": self._enter_quantifier,
             "forall": self._enter_quantifier,
+            # '+' and '*' are :left-assoc, but pySMT builds them n-ary
+            # natively; the other n-ary operators are folded, see the
+            # _left_assoc/_right_assoc/_chainable helpers above.
             '+': self._operator_adapter(self.Plus),
             '-': self._operator_adapter(self._minus_or_uminus),
             '*': self._operator_adapter(self.Times),
-            '/': self._operator_adapter(self._division),
+            '/': self._operator_adapter(_left_assoc(self._division)),
+            'div': self._operator_adapter(_left_assoc(mgr.Div)),
             'pow': self._operator_adapter(mgr.Pow),
-            '>': self._operator_adapter(self.GT),
-            '<': self._operator_adapter(self.LT),
-            '>=': self._operator_adapter(self.GE),
-            '<=': self._operator_adapter(self.LE),
-            '=': self._operator_adapter(self._equals_or_iff),
+            '>': self._operator_adapter(_chainable(mgr, self.GT)),
+            '<': self._operator_adapter(_chainable(mgr, self.LT)),
+            '>=': self._operator_adapter(_chainable(mgr, self.GE)),
+            '<=': self._operator_adapter(_chainable(mgr, self.LE)),
+            '=': self._operator_adapter(_chainable(mgr, self._equals_or_iff)),
             'not': self._operator_adapter(mgr.Not),
             'and': self._operator_adapter(mgr.And),
             'or': self._operator_adapter(mgr.Or),
-            'xor': self._operator_adapter(mgr.Xor),
-            '=>': self._operator_adapter(mgr.Implies),
-            '<->': self._operator_adapter(mgr.Iff),
+            'xor': self._operator_adapter(_left_assoc(mgr.Xor)),
+            '=>': self._operator_adapter(_right_assoc(mgr.Implies)),
+            # '<->' is a pySMT extension: treated as :left-assoc, like 'xor'
+            '<->': self._operator_adapter(_left_assoc(mgr.Iff)),
             'ite': self._operator_adapter(self.Ite),
             'distinct': self._operator_adapter(self.AllDifferent),
             'to_real': self._operator_adapter(mgr.ToReal),
@@ -407,12 +446,12 @@ class SmtLibParser(object):
             'bvlshr': self._operator_adapter(mgr.BVLShr),
             'bvsub': self._operator_adapter(mgr.BVSub),
             'bvult': self._operator_adapter(mgr.BVULT),
-            'bvxor': self._operator_adapter(mgr.BVXor),
+            'bvxor': self._operator_adapter(_left_assoc(mgr.BVXor)),
             '_': self._smtlib_underscore,
             # Extended Functions
             'bvnand': self._operator_adapter(mgr.BVNand),
             'bvnor': self._operator_adapter(mgr.BVNor),
-            'bvxnor': self._operator_adapter(mgr.BVXnor),
+            'bvxnor': self._operator_adapter(_left_assoc(mgr.BVXnor)),
             'bvcomp': self._operator_adapter(mgr.BVComp),
             'bvsdiv': self._operator_adapter(mgr.BVSDiv),
             'bvsrem': self._operator_adapter(mgr.BVSRem),
@@ -492,7 +531,7 @@ class SmtLibParser(object):
         self.cache.update({'false': mgr.FALSE(), 'true': mgr.TRUE()})
 
     def _minus_or_uminus(self, *args) -> FNode:
-        """Utility function that handles both unary and binary minus"""
+        """Utility function that handles unary and n-ary minus"""
         mgr = self.env.formula_manager
         if len(args) == 1:
             lty = self.get_type(args[0])
@@ -506,9 +545,8 @@ class SmtLibParser(object):
                     return mgr.Real(-1 * args[0].constant_value())
                 mult = mgr.Real(-1)
             return mgr.Times(mult, args[0])
-        else:
-            assert len(args) == 2
-            return self.Minus(args[0], args[1])
+        # '-' is :left-assoc: (- a b c) is (- (- a b) c)
+        return functools.reduce(self.Minus, args)
 
     def _enter_smtlib_as(self, stack: List[List[Union[Callable, FNode, Any]]], tokens: Tokenizer, key: str):
         """Utility function that handles 'as' that is a special function in SMTLIB"""

--- a/pysmt/test/smtlib/test_parser_examples.py
+++ b/pysmt/test/smtlib/test_parser_examples.py
@@ -25,10 +25,12 @@ from pysmt.test import TestCase, skipIfNoSolverForLogic, main
 from pysmt.test.examples import get_example_formulae
 from pysmt.smtlib.parser import SmtLibParser, Tokenizer
 from pysmt.smtlib.script import smtlibscript_from_formula
-from pysmt.shortcuts import Iff
+from pysmt.shortcuts import Iff, Symbol, And, Implies, Xor, LT, GE, Equals, \
+    Plus, Minus, Times, Div, AllDifferent, BVXor, BVConcat
 from pysmt.shortcuts import read_smtlib, write_smtlib, get_env
 from pysmt.exceptions import PysmtSyntaxError
-from pysmt.typing import INT
+from pysmt.smtlib.commands import ASSERT
+from pysmt.typing import INT, REAL, BV8
 
 
 class TestSMTParseExamples(TestCase):
@@ -260,6 +262,75 @@ class TestSMTParseExamples(TestCase):
             self.assertEqual(self._parse_assertion(decls, nary),
                              self._parse_assertion(decls, expected),
                              "wrong expansion of %s" % nary)
+
+    def test_nary_operators_end_to_end(self):
+        """Parse a whole SMT-LIB2 script using the n-ary operators and check
+        the resulting formulae against the ones built with the pySMT API"""
+        script = """
+        ; no set-logic: no pySMT logic covers BV + non-linear Int/Real at once
+        (declare-fun a () Int)
+        (declare-fun b () Int)
+        (declare-fun c () Int)
+        (declare-fun r () Real)
+        (declare-fun s () Real)
+        (declare-fun t () Real)
+        (declare-fun p () Bool)
+        (declare-fun q () Bool)
+        (declare-fun u () Bool)
+        (declare-fun x () (_ BitVec 8))
+        (declare-fun y () (_ BitVec 8))
+        (declare-fun z () (_ BitVec 8))
+        (assert (< a b c))
+        (assert (>= a b c))
+        (assert (= a b c))
+        (assert (= p q u))
+        (assert (= (- a b c) (+ a b c)))
+        (assert (= (div a b c) (* a b c)))
+        (assert (= (/ r s t) r))
+        (assert (=> p q u))
+        (assert (xor p q u))
+        (assert (distinct a b c))
+        (assert (= (bvxor x y z) x))
+        (assert (= (concat x y z) (concat z y x)))
+        (check-sat)
+        """
+        a, b, c = (Symbol(name, INT) for name in "abc")
+        r, s, t = (Symbol(name, REAL) for name in "rst")
+        p, q, u = (Symbol(name) for name in "pqu")
+        x, y, z = (Symbol(name, BV8) for name in "xyz")
+
+        expected = [
+            # :chainable
+            And(LT(a, b), LT(b, c)),
+            And(GE(a, b), GE(b, c)),
+            And(Equals(a, b), Equals(b, c)),
+            And(Iff(p, q), Iff(q, u)),
+            # :left-assoc ('+' and '*' stay flat n-ary)
+            Equals(Minus(Minus(a, b), c), Plus(a, b, c)),
+            Equals(Div(Div(a, b), c), Times(a, b, c)),
+            Equals(Div(Div(r, s), t), r),
+            # :right-assoc
+            Implies(p, Implies(q, u)),
+            # :left-assoc
+            Xor(Xor(p, q), u),
+            # :pairwise
+            AllDifferent(a, b, c),
+            # bit-vectors
+            Equals(BVXor(BVXor(x, y), z), x),
+            Equals(BVConcat(BVConcat(x, y), z), BVConcat(BVConcat(z, y), x)),
+        ]
+
+        parser = SmtLibParser()
+        parsed = [cmd.args[0] for cmd in
+                  parser.get_script(StringIO(script)).filter_by_command_name(ASSERT)]
+
+        self.assertEqual(len(parsed), len(expected))
+        for got, exp in zip(parsed, expected):
+            self.assertEqual(got, exp)
+        # ...and the conjunction of all of them is what the script means
+        self.assertEqual(
+            SmtLibParser().get_script(StringIO(script)).get_last_formula(),
+            And(expected))
 
     def test_nary_div_is_integer_division(self):
         """'div' is the Ints division, so it must not be promoted to Real"""

--- a/pysmt/test/smtlib/test_parser_examples.py
+++ b/pysmt/test/smtlib/test_parser_examples.py
@@ -28,6 +28,7 @@ from pysmt.smtlib.script import smtlibscript_from_formula
 from pysmt.shortcuts import Iff
 from pysmt.shortcuts import read_smtlib, write_smtlib, get_env
 from pysmt.exceptions import PysmtSyntaxError
+from pysmt.typing import INT
 
 
 class TestSMTParseExamples(TestCase):
@@ -215,6 +216,61 @@ class TestSMTParseExamples(TestCase):
         get_type = get_env().stc.get_type
         for cmd in s:
             self.assertEqual(cmd.args[2], get_type(cmd.args[3]))
+
+    def test_nary_operators(self):
+        """All the SMT-LIB n-ary operators are expanded as the standard
+        prescribes: see https://github.com/pysmt/pysmt/issues/638"""
+        INT_DECLS = "(declare-fun a () Int)(declare-fun b () Int)" \
+                    "(declare-fun c () Int)(declare-fun d () Int)"
+        BOOL_DECLS = "(declare-fun p () Bool)(declare-fun q () Bool)" \
+                     "(declare-fun r () Bool)"
+        BV_DECLS = "(declare-fun x () (_ BitVec 8))(declare-fun y () (_ BitVec 8))" \
+                   "(declare-fun z () (_ BitVec 8))"
+
+        # (declarations, n-ary application, expected expansion)
+        cases = [
+            # :right-assoc
+            (BOOL_DECLS, "(=> p q r)", "(=> p (=> q r))"),
+            (BOOL_DECLS, "(=> p q r p)", "(=> p (=> q (=> r p)))"),
+            # :left-assoc
+            (BOOL_DECLS, "(xor p q r)", "(xor (xor p q) r)"),
+            (BOOL_DECLS, "(<-> p q r)", "(<-> (<-> p q) r)"),
+            (INT_DECLS, "(- a b c)", "(- (- a b) c)"),
+            (INT_DECLS, "(- a b c d)", "(- (- (- a b) c) d)"),
+            (INT_DECLS, "(/ a b c)", "(/ (/ a b) c)"),
+            (INT_DECLS, "(div a b c)", "(div (div a b) c)"),
+            (BV_DECLS, "(bvxor x y z)", "(bvxor (bvxor x y) z)"),
+            (BV_DECLS, "(bvxnor x y z)", "(bvxnor (bvxnor x y) z)"),
+            # :chainable
+            (INT_DECLS, "(> a b c)", "(and (> a b) (> b c))"),
+            (INT_DECLS, "(>= a b c d)", "(and (>= a b) (>= b c) (>= c d))"),
+            (INT_DECLS, "(< a b c)", "(and (< a b) (< b c))"),
+            (INT_DECLS, "(<= a b c)", "(and (<= a b) (<= b c))"),
+            (INT_DECLS, "(= a b c)", "(and (= a b) (= b c))"),
+            (BOOL_DECLS, "(= p q r)", "(and (<-> p q) (<-> q r))"),
+            # unary applications: identity for the associative operators,
+            # vacuously true for the chainable ones
+            (BOOL_DECLS, "(=> p)", "p"),
+            (BOOL_DECLS, "(xor p)", "p"),
+            (INT_DECLS, "(/ a)", "a"),
+            (INT_DECLS, "(= a)", "true"),
+            (INT_DECLS, "(< a)", "true"),
+        ]
+        for decls, nary, expected in cases:
+            self.assertEqual(self._parse_assertion(decls, nary),
+                             self._parse_assertion(decls, expected),
+                             "wrong expansion of %s" % nary)
+
+    def test_nary_div_is_integer_division(self):
+        """'div' is the Ints division, so it must not be promoted to Real"""
+        f = self._parse_assertion("(declare-fun a () Int)", "(div a 2 3)")
+        self.assertEqual(get_env().stc.get_type(f), INT)
+
+    @staticmethod
+    def _parse_assertion(declarations, expression):
+        script = "%s (assert %s)" % (declarations, expression)
+        parser = SmtLibParser()
+        return parser.get_script(StringIO(script)).get_last_formula()
 
     def test_typing_define_fun(self):
         script = """


### PR DESCRIPTION
Fixes #638. Thanks @jhoenicke for reporting.

## The problem

`SmtLibParser.get_expression` collects the parsed arguments of an
application and calls the pySMT constructor as `fun(*args)`. That works
only for the operators pySMT builds n-ary natively — `and`, `or`, `+`,
`*`, `distinct`, `concat`, `bvand`, `bvor`, `bvadd`, `bvmul`, `str.++`.

For every other operator the SMT-LIB standard marks as `:left-assoc`,
`:right-assoc` or `:chainable`, parsing a legal script failed:

```smtlib
(declare-fun a () Int)
(declare-fun b () Int)
(declare-fun c () Int)
(assert (< a b c))
```
```
TypeError: FormulaManager.LT() takes 3 positional arguments but 4 were given
```

`-` was slightly different, tripping `assert len(args) == 2` in
`_minus_or_uminus`, and `div` was not in the operator table at all.

## The fix

Three helpers in `pysmt/smtlib/parser/parser.py`, one per attribute, that
wrap the existing binary constructors and expand the application the way
the standard prescribes:

| Attribute | Expansion | Operators |
|---|---|---|
| `:left-assoc` | `(op a b c)` → `(op (op a b) c)` | `-`, `/`, `xor`, `<->`, `bvxor`, `bvxnor` |
| `:right-assoc` | `(op a b c)` → `(op a (op b c))` | `=>` |
| `:chainable` | `(op a b c)` → `(and (op a b) (op b c))` | `=`, `<`, `<=`, `>`, `>=` |
| `:pairwise` | — | `distinct`, already correct via `AllDifferent` |

`+` and `*` keep going straight to the n-ary `Plus`/`Times` so the tree
stays flat; same for `concat`, `bvand`, `bvor`, `bvadd`, `bvmul` and
`str.++`. `<->` is not standard SMT-LIB, but it is treated as
`:left-assoc` like `xor` for consistency.

`div` (the Ints division) is new: it maps to `mgr.Div`, which the type
checker already types `INT -> INT` and the simplifier already folds with
SMT-LIB floor/ceil integer-division semantics.

### The unary case

A single argument keeps working, as the issue notes it did for `and`,
`or`, `+` and `*`. It falls out of the implementation rather than being
special-cased: `functools.reduce` over one element returns that element,
so unary is the identity for the associative operators, and the chainable
ones produce an empty conjunction, i.e. `true`. The standard requires at
least two arguments, but pySMT has always been lenient here and this
keeps the behaviour uniform across all the operators instead of
tightening some and not others.

## Tests

Three tests in `pysmt/test/smtlib/test_parser_examples.py`:

- `test_nary_operators` — 21 cases checking each expansion against its
  hand-written equivalent, including the unary applications.
- `test_nary_operators_end_to_end` — parses one script exercising every
  attribute over Int, Real, Bool and BV, then compares each assertion,
  and their conjunction, against the formulae built with the pySMT API.
- `test_nary_div_is_integer_division` — `div` stays `INT`-typed.

The first two fail on the parent of the first commit here. Full suite is
green (the two `optimsat` failures I see locally are pre-existing on
`master` and unrelated).

Note that `op.DIV` is printed as `/` regardless of the sort of its
arguments, so a parsed `div` does not round-trip back to `div`. That is
pre-existing, independent of this PR and reachable from the Python API;
it is tracked separately in #838.
