### PR TITLE
Use the given environment instead of the global one

### DIFF
--- a/pysmt/factory.py
+++ b/pysmt/factory.py
@@ -615,7 +615,7 @@ class Factory(object):
                 atoms = formula.get_atoms()
                 res = []
                 for a in atoms:
-                    fv = a.get_free_variables()
+                    fv = self.environment.fvo.get_free_variables(a)
                     if any(v in model for v in fv):
                         if solver.get_value(a).is_true():
                             res.append(a)

--- a/pysmt/optimization/goal.py
+++ b/pysmt/optimization/goal.py
@@ -16,12 +16,12 @@
 #   limitations under the License.
 #
 
-from pysmt.environment import get_env
+from pysmt.environment import Environment, get_env
 from pysmt.exceptions import PysmtValueError
 from pysmt.oracles import get_logic
 from pysmt.logics import Logic, LIA, LRA, BV
 from pysmt.fnode import FNode
-from typing import List, Tuple, Type, cast
+from typing import List, Optional, Tuple, Type, cast
 
 
 class Goal(object):
@@ -51,6 +51,23 @@ class Goal(object):
         ```
     """
 
+    # The class-level default keeps subclasses that do not call Goal.__init__
+    # working against the global environment, as they did before.
+    _env: Optional[Environment] = None
+
+    def __init__(self, env: Optional[Environment]=None):
+        """
+        :param env: The environment the goal lives in; the global one if None
+        """
+        self._env = env if env is not None else get_env()
+
+    @property
+    def env(self) -> Environment:
+        """The environment this goal lives in."""
+        if self._env is None:
+            self._env = get_env()
+        return self._env
+
     def is_maximization_goal(self) -> bool:
         return False
 
@@ -67,7 +84,7 @@ class Goal(object):
         return False
 
     def get_logic(self) -> Logic:
-        logic = get_logic(self.term())
+        logic = get_logic(self.term(), env=self.env)
         if logic <= LIA:
             return LIA
         elif logic <= LRA:
@@ -99,11 +116,14 @@ class MaximizationGoal(Goal):
     Warning: some Optimizer may not support this goal
     """
 
-    def __init__(self, formula: FNode, signed: bool = False):
+    def __init__(self, formula: FNode, signed: bool = False,
+                 env: Optional[Environment]=None):
         """
         :param formula: The target formula
         :type  formula: FNode
+        :param env: The environment the goal lives in; the global one if None
         """
+        Goal.__init__(self, env)
         self.formula = formula
         self._bv_signed = signed
 
@@ -127,11 +147,14 @@ class MinimizationGoal(Goal):
     Warning: some Optimizer may not support this goal
     """
 
-    def __init__(self, formula: FNode, sign: bool = False):
+    def __init__(self, formula: FNode, sign: bool = False,
+                 env: Optional[Environment]=None):
         """
         :param formula: The target formula
         :type  formula: FNode
+        :param env: The environment the goal lives in; the global one if None
         """
+        Goal.__init__(self, env)
         self.formula = formula
         self._bv_signed = sign
 
@@ -156,19 +179,22 @@ class MinMaxGoal(MinimizationGoal):
     Warning: some Optimizer may not support this goal
     """
 
-    def __init__(self, terms: List[FNode], sign: bool = False):
+    def __init__(self, terms: List[FNode], sign: bool = False,
+                 env: Optional[Environment]=None):
         """
         :param terms: List of FNode
+        :param env: The environment the goal lives in; the global one if None
         """
+        if env is None:
+            env = get_env()
         if len(terms) == 0:
             raise PysmtValueError("MinMaxGoal requires at least one term")
-        elif terms[0].get_type().is_bv_type():
-            formula = get_env().formula_manager.MaxBV(sign, terms)
+        elif env.stc.get_type(terms[0]).is_bv_type():
+            formula = env.formula_manager.MaxBV(sign, terms)
         else:
-            formula = get_env().formula_manager.Max(terms)
-        MinimizationGoal.__init__(self, formula)
+            formula = env.formula_manager.Max(terms)
+        MinimizationGoal.__init__(self, formula, sign, env=env)
         self.terms = terms
-        self._bv_signed = sign
 
     def is_minmax_goal(self) -> bool:
         return True
@@ -185,19 +211,22 @@ class MaxMinGoal(MaximizationGoal):
     Warning: some Optimizer may not support this goal
     """
 
-    def __init__(self, terms: List[FNode], sign: bool = False):
+    def __init__(self, terms: List[FNode], sign: bool = False,
+                 env: Optional[Environment]=None):
         """
         :param terms: List of FNode
+        :param env: The environment the goal lives in; the global one if None
         """
+        if env is None:
+            env = get_env()
         if len(terms) == 0:
             raise PysmtValueError("MaxMinGoal requires at least one term")
-        elif terms[0].get_type().is_bv_type():
-            formula = get_env().formula_manager.MinBV(sign, terms)
+        elif env.stc.get_type(terms[0]).is_bv_type():
+            formula = env.formula_manager.MinBV(sign, terms)
         else:
-            formula = get_env().formula_manager.Min(terms)
-        MaximizationGoal.__init__(self, formula)
+            formula = env.formula_manager.Min(terms)
+        MaximizationGoal.__init__(self, formula, sign, env=env)
         self.terms = terms
-        self._bv_signed = sign
 
     def is_maxmin_goal(self) -> bool:
         return True
@@ -211,27 +240,33 @@ class MaxSMTGoal(Goal):
     MaxSMT goal common to all solvers.
     """
 
-    def __init__(self, real_weights: bool=True):
-        """Accepts soft clauses and the relative weights"""
+    def __init__(self, real_weights: bool=True,
+                 env: Optional[Environment]=None):
+        """Accepts soft clauses and the relative weights
+
+        :param env: The environment the goal lives in; the global one if None
+        """
+        Goal.__init__(self, env)
         self.soft: List[Tuple[FNode, FNode]] = []
         self._bv_signed = False
         self._real_weights = real_weights
 
     def add_soft_clause(self, clause: FNode, weight: FNode):
         """Accepts soft clauses and the relative weights"""
-        mgr = get_env().formula_manager
-        if not clause.get_type().is_bool_type():
+        mgr = self.env.formula_manager
+        get_type = self.env.stc.get_type
+        if not get_type(clause).is_bool_type():
             raise PysmtValueError(
                 "Clause '%s' has to be a boolean formula; given type is: '%s'" %
-                (str(clause), str(clause.get_type()))
+                (str(clause), str(get_type(clause)))
             )
         if isinstance(weight, FNode):
             if not weight.is_constant():
                 raise PysmtValueError(
                     "Weight '%s' has to be a constant; given type is: '%s'" %
-                    (str(weight), str(weight.get_type()))
+                    (str(weight), str(get_type(weight)))
                 )
-            weight_type = weight.get_type()
+            weight_type = get_type(weight)
             if not weight_type.is_real_type() and not weight_type.is_int_type():
                 raise PysmtValueError(
                     "Weight '%s' has to be a real or integer type; given type is: '%s'" %
@@ -240,7 +275,7 @@ class MaxSMTGoal(Goal):
             if weight_type.is_real_type() and not self._real_weights:
                 raise PysmtValueError(
                     "Weight '%s' has to be an integer because the flag 'real_weights' is set to 'False'; given type is: '%s'" %
-                    (str(weight), str(weight.get_type()))
+                    (str(weight), str(weight_type))
                 )
             if weight_type.is_int_type() and self._real_weights:
                 weight = mgr.Real(cast(int, weight.constant_value()))
@@ -260,7 +295,7 @@ class MaxSMTGoal(Goal):
 
     def term(self) -> FNode:
         formula = None
-        mgr = get_env().formula_manager
+        mgr = self.env.formula_manager
         zero = mgr.Real(0) if self.real_weights() else mgr.Int(0)
         for (c, w) in self.soft:
             if formula is not None:

--- a/pysmt/optimization/optimizer.py
+++ b/pysmt/optimization/optimizer.py
@@ -491,7 +491,7 @@ class ExternalOptimizerMixin(Optimizer):
         Based on the strategy, it will either perform a linear or binary search"""
         _warn_diverge_real_goal(goal, self.environment)
         if goal.is_maxsmt_goal():
-            goal = MaximizationGoal(goal.term())
+            goal = MaximizationGoal(goal.term(), env=self.environment)
         model = None
         client_data = self._setup()
 

--- a/pysmt/optimization/optimizer.py
+++ b/pysmt/optimization/optimizer.py
@@ -21,7 +21,7 @@ import warnings
 from pysmt.solvers.solver import Solver
 from pysmt.exceptions import PysmtValueError, GoalNotSupportedError
 from pysmt.optimization.goal import Goal, MaxSMTGoal, MinimizationGoal, MaximizationGoal
-from pysmt.typing import INT, REAL, BVType, _BVType
+from pysmt.typing import INT, REAL, _BVType
 from pysmt.logics import LIA, LRA, BV, QF_LIRA, Logic
 from pysmt.environment import Environment
 from pysmt.fnode import FNode
@@ -118,7 +118,7 @@ class Optimizer(Solver):
         elif otype.is_real_type():
             return REAL
         elif otype.is_bv_type():
-            return BVType(otype.width)
+            return self.environment.type_manager.BVType(otype.width)
         else:
             raise PysmtValueError("Invalid optimization function type: %s" % otype)
 
@@ -263,7 +263,7 @@ class OptSearchInterval(OptComparationFunctions):
 
         lower, upper = None, None
         if not goal.is_maxsmt_goal():
-            term_type = goal.term().get_type()
+            term_type = environment.stc.get_type(goal.term())
             # For bit-vectors, start lower and upper bounds to their width limit
             if term_type.is_bv_type():
                 assert isinstance(term_type, _BVType)
@@ -320,7 +320,7 @@ class OptSearchInterval(OptComparationFunctions):
             l = self._upper - (cast(Union[int, Fraction], abs(self._upper)) + 1)
         elif self._lower is not None and self._upper is None:
             u = self._lower + cast(Union[int, Fraction], abs(self._lower)) + 1
-        term_type = self._obj.term().get_type()
+        term_type = self.environment.stc.get_type(self._obj.term())
         assert l is not None and u is not None
         if term_type.is_int_type() or term_type.is_bv_type():
             pivot = (l + u) // 2
@@ -417,8 +417,9 @@ class OptPareto(OptComparationFunctions):
         return correct_operator(self.goal.term(), self.val)
 
 
-def _warn_diverge_real_goal(goal: Goal):
-    if (goal.is_maximization_goal() or goal.is_minimization_goal()) and goal.term().get_type().is_real_type():
+def _warn_diverge_real_goal(goal: Goal, env: Environment):
+    if (goal.is_maximization_goal() or goal.is_minimization_goal()) and \
+       env.stc.get_type(goal.term()).is_real_type():
         warnings.warn("Algorithm might diverge on Real minimization/maximization objectives.")
 
 
@@ -488,7 +489,7 @@ class ExternalOptimizerMixin(Optimizer):
         """
         Core algorithm for the optimization process.
         Based on the strategy, it will either perform a linear or binary search"""
-        _warn_diverge_real_goal(goal)
+        _warn_diverge_real_goal(goal, self.environment)
         if goal.is_maxsmt_goal():
             goal = MaximizationGoal(goal.term())
         model = None
@@ -528,7 +529,7 @@ class ExternalOptimizerMixin(Optimizer):
         objs = [OptPareto(goal, self.environment) for goal in goals]
 
         for g in goals:
-            _warn_diverge_real_goal(g)
+            _warn_diverge_real_goal(g, self.environment)
 
         terminated = False
         client_data = self._setup()

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -276,7 +276,8 @@ class TheoryOracle(walkers.DagWalker):
             theory_out = theory_out.combine(t)
         # Check for non-linear counting the arguments having at least
         # one free variable
-        if sum(1 for x in formula.args() if x.get_free_variables()) > 1:
+        if sum(1 for x in formula.args()
+               if self.env.fvo.get_free_variables(x)) > 1:
             theory_out = theory_out.set_linear(False)
         # This is  not in DL anymore
         theory_out = theory_out.set_difference_logic(False)
@@ -324,9 +325,10 @@ class TheoryOracle(walkers.DagWalker):
         for t in args[1:]:
             theory_out = theory_out.combine(t)
         # Check for non-linear
+        get_free_vars = self.env.fvo.get_free_variables
         left, right = formula.args()
-        if len(left.get_free_variables()) != 0 and \
-           len(right.get_free_variables()) != 0:
+        if len(get_free_vars(left)) != 0 and \
+           len(get_free_vars(right)) != 0:
             theory_out = theory_out.set_linear(False)
         elif formula.arg(1).is_zero():
             # DivBy0 is non-linear

--- a/pysmt/parsing.py
+++ b/pysmt/parsing.py
@@ -306,7 +306,7 @@ class BVTypeTok(GrammarSymbol):
         self.width = width
 
     def nud(self, parser):
-        return types.BVType(self.width)
+        return parser.env.type_manager.BVType(self.width)
 
 class IntTypeTok(GrammarSymbol):
     def nud(self, parser):
@@ -369,7 +369,7 @@ class OpenArrayTypeTok(GrammarSymbol):
             parser.expect(ClosePar, ")")
             return parser.mgr.Array(idx_type, default)
         else:
-            return types.ArrayType(idx_type, el_type)
+            return parser.env.type_manager.ArrayType(idx_type, el_type)
 
 
 class OpenPar(GrammarSymbol):

--- a/pysmt/rewritings.py
+++ b/pysmt/rewritings.py
@@ -40,6 +40,7 @@ class CNFizer(DagWalker):
         DagWalker.__init__(self, environment)
 
         self.mgr = self.env.formula_manager
+        self.simplify = self.env.simplifier.simplify
         self._introduced_variables: Dict[FNode, FNode] = {}
 
     def _key_var(self, formula: FNode) -> FNode:
@@ -72,7 +73,7 @@ class CNFizer(DagWalker):
                     # Prune clauses as ~tl -> l1 v ... v lk
                     simp = None
                     break
-                elif lit == self.mgr.Not(tl).simplify():
+                elif lit == self.simplify(self.mgr.Not(tl)):
                     # Simplify tl -> l1 v ... v lk
                     # into l1 v ... v lk
                     continue
@@ -111,7 +112,7 @@ class CNFizer(DagWalker):
             return args[0]
 
         k = self._key_var(formula)
-        _cnf = [frozenset([k] + [self.mgr.Not(a).simplify() for a,_ in args])]
+        _cnf = [frozenset([k] + [self.simplify(self.mgr.Not(a)) for a,_ in args])]
         for a,c in args:
             _cnf.append(frozenset([a, self.mgr.Not(k)]))
             for clause in c:
@@ -136,15 +137,15 @@ class CNFizer(DagWalker):
         elif a.is_false():
             return self.mgr.TRUE(), CNFizer.TRUE_CNF
         else:
-            return self.mgr.Not(a).simplify(), _cnf
+            return self.simplify(self.mgr.Not(a)), _cnf
 
     def walk_implies(self, formula,  args, **kwargs):
         a, cnf_a = args[0]
         b, cnf_b = args[1]
 
         k = self._key_var(formula)
-        not_a = self.mgr.Not(a).simplify()
-        not_b = self.mgr.Not(b).simplify()
+        not_a = self.simplify(self.mgr.Not(a))
+        not_b = self.simplify(self.mgr.Not(b))
         not_k = self.mgr.Not(k)
 
         return k, (cnf_a | cnf_b | frozenset([frozenset([not_a, b, not_k]),
@@ -156,8 +157,8 @@ class CNFizer(DagWalker):
         b, cnf_b = args[1]
 
         k = self._key_var(formula)
-        not_a = self.mgr.Not(a).simplify()
-        not_b = self.mgr.Not(b).simplify()
+        not_a = self.simplify(self.mgr.Not(a))
+        not_b = self.simplify(self.mgr.Not(b))
         not_k = self.mgr.Not(k)
 
         return k, (cnf_a | cnf_b | frozenset([frozenset([not_a, not_b, k]),
@@ -184,9 +185,9 @@ class CNFizer(DagWalker):
         else:
             (i,cnf_i),(t,cnf_t),(e,cnf_e) = args
             k = self._key_var(formula)
-            not_i = self.mgr.Not(i).simplify()
-            not_t = self.mgr.Not(t).simplify()
-            not_e = self.mgr.Not(e).simplify()
+            not_i = self.simplify(self.mgr.Not(i))
+            not_t = self.simplify(self.mgr.Not(t))
+            not_e = self.simplify(self.mgr.Not(e))
             not_k = self.mgr.Not(k)
 
             return k, (cnf_i | cnf_t | cnf_e |
@@ -198,7 +199,7 @@ class CNFizer(DagWalker):
     @handles(op.THEORY_OPERATORS)
     def walk_theory_op(self, formula, **kwargs):
         #pylint: disable=unused-argument
-        if formula.get_type().is_bool_type():
+        if self.env.stc.get_type(formula).is_bool_type():
             return formula, CNFizer.TRUE_CNF
         return CNFizer.THEORY_PLACEHOLDER
 
@@ -305,7 +306,7 @@ class PolarityCNFizer(CNFizer):
         if pol:
             _cnf.extend(frozenset([a, self.mgr.Not(k)]) for a, _ in args)
         else:
-            _cnf.extend([frozenset([k] + [self.mgr.Not(a).simplify() for a, _ in args])])
+            _cnf.extend([frozenset([k] + [self.simplify(self.mgr.Not(a)) for a, _ in args])])
 
         return k, frozenset(_cnf)
 
@@ -318,7 +319,7 @@ class PolarityCNFizer(CNFizer):
         if pol:
             _cnf.extend([frozenset([self.mgr.Not(k)] + [a for a, _ in args])])
         else:
-            _cnf.extend(frozenset([k, self.mgr.Not(a).simplify()]) for a, c in args)
+            _cnf.extend(frozenset([k, self.simplify(self.mgr.Not(a))]) for a, c in args)
 
         return k, frozenset(_cnf)
 
@@ -327,8 +328,8 @@ class PolarityCNFizer(CNFizer):
         b, cnf_b = args[1]
 
         k = self._key_var(formula)
-        not_a = self.mgr.Not(a).simplify()
-        not_b = self.mgr.Not(b).simplify()
+        not_a = self.simplify(self.mgr.Not(a))
+        not_b = self.simplify(self.mgr.Not(b))
         not_k = self.mgr.Not(k)
         _cnf = []
         if pol:
@@ -345,8 +346,8 @@ class PolarityCNFizer(CNFizer):
         _, cnf_bn = args[3]
 
         k = self._key_var(formula)
-        not_a = self.mgr.Not(a).simplify()
-        not_b = self.mgr.Not(b).simplify()
+        not_a = self.simplify(self.mgr.Not(a))
+        not_b = self.simplify(self.mgr.Not(b))
         not_k = self.mgr.Not(k)
 
         return k, (cnf_ap | cnf_an | cnf_bp | cnf_bn
@@ -360,9 +361,9 @@ class PolarityCNFizer(CNFizer):
             return CNFizer.THEORY_PLACEHOLDER
         (i, cnf_ip), (_, cnf_in), (t, cnf_t), (e, cnf_e) = args
         k = self._key_var(formula)
-        not_i = self.mgr.Not(i).simplify()
-        not_t = self.mgr.Not(t).simplify()
-        not_e = self.mgr.Not(e).simplify()
+        not_i = self.simplify(self.mgr.Not(i))
+        not_t = self.simplify(self.mgr.Not(t))
+        not_e = self.simplify(self.mgr.Not(e))
         not_k = self.mgr.Not(k)
 
         _cnf = []
@@ -590,7 +591,7 @@ class PrenexNormalizer(DagWalker):
         # matrix. If we find a quantifier over a variable in this set
         # we need to alpha-rename before adding the quantifier to the
         # final list and accumulate the matrix.
-        reserved = formula.get_free_variables()
+        reserved = self.env.fvo.get_free_variables(formula)
 
         # We iterate to each argument, each could have a sequence of
         # quantifiers that we need to merge
@@ -603,7 +604,7 @@ class PrenexNormalizer(DagWalker):
                     # we need alpha-renaming: prepare the substitution map
                     sub = dict((v,self.mgr.FreshSymbol(v.symbol_type()))
                                for v in needs_rename)
-                    sub_matrix = sub_matrix.substitute(sub)
+                    sub_matrix = self.env.substituter.substitute(sub_matrix, sub)
 
                     # The new variables for this quantifiers will be
                     # its old variables, minus the one needing
@@ -1109,7 +1110,7 @@ def propagate_toplevel(formula: FNode, env: Optional["pysmt.environment.Environm
             else:
                 sigma[k] = v
 
-    res = formula.substitute(sigma)
+    res = env.substituter.substitute(formula, sigma)
     if preserve_equivalence:
         res = mgr.And(res, mgr.And([mgr.Equals(k, sigma[k]) for k in sigma]))
-    return res.simplify() if do_simplify else res
+    return env.simplifier.simplify(res) if do_simplify else res

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -265,7 +265,8 @@ class Simplifier(pysmt.walkers.DagWalker):
         assert len(args) == 1
         sf = args[0]
 
-        varset = set(formula.quantifier_vars()).intersection(sf.get_free_variables())
+        varset = set(formula.quantifier_vars()).intersection(
+            self.env.fvo.get_free_variables(sf))
 
         if len(varset) == 0:
             return sf
@@ -276,7 +277,8 @@ class Simplifier(pysmt.walkers.DagWalker):
         assert len(args) == 1
         sf = args[0]
 
-        varset = set(formula.quantifier_vars()).intersection(sf.get_free_variables())
+        varset = set(formula.quantifier_vars()).intersection(
+            self.env.fvo.get_free_variables(sf))
 
         if len(varset) == 0:
             return sf
@@ -1151,7 +1153,7 @@ class BddSimplifier(Simplifier):
     def abstract_and_simplify(self, formula: FNode) -> FNode:
         abs_formula = self.walk(formula)
         abs_res = self.back(self.convert(abs_formula))
-        res = abs_res.substitute(self.ba_map)
+        res = self.env.substituter.substitute(abs_res, self.ba_map)
         return res
 
     @handles(op.RELATIONS)

--- a/pysmt/smtlib/parser/parser.py
+++ b/pysmt/smtlib/parser/parser.py
@@ -1619,9 +1619,11 @@ class SmtLibZ3Parser(SmtLibParser):
         self.interpreted['ubv_to_int'] = self._operator_adapter(mgr.BVToNatural)
 
     def _ext_rotate_left(self, x, y):
-        return self.env.formula_manager.BVRol(x, y.simplify().constant_value())
+        amount = self.env.simplifier.simplify(y).constant_value()
+        return self.env.formula_manager.BVRol(x, amount)
 
     def _ext_rotate_right(self, x, y):
-        return self.env.formula_manager.BVRor(x, y.simplify().constant_value())
+        amount = self.env.simplifier.simplify(y).constant_value()
+        return self.env.formula_manager.BVRor(x, amount)
 
 # EOC SmtLibZ3Parser

--- a/pysmt/smtlib/printers.py
+++ b/pysmt/smtlib/printers.py
@@ -19,7 +19,6 @@ from io import StringIO
 from typing import Callable, List, Optional, Set, TextIO, Union
 
 import pysmt.operators as op
-from pysmt.environment import get_env
 from pysmt.walkers import TreeWalker, DagWalker, handles
 from pysmt.utils import quote
 from pysmt.fnode import FNode
@@ -59,11 +58,11 @@ def write_annotations_dag(f: Callable) -> Callable:
 
 class SmtPrinter(TreeWalker):
 
-    def __init__(self, stream: TextIO, annotations=None):
-        TreeWalker.__init__(self)
+    def __init__(self, stream: TextIO, annotations=None, env=None):
+        TreeWalker.__init__(self, env=env)
         self.stream = stream
         self.write = self.stream.write
-        self.mgr = get_env().formula_manager
+        self.mgr = self.env.formula_manager
         self.annotations = annotations
 
     def printer(self, f):
@@ -314,7 +313,8 @@ class SmtPrinter(TreeWalker):
         for _ in range(len(assign)):
             self.write("(store ")
 
-        self.write("((as const %s) " % formula.get_type().as_smtlib(False))
+        self.write("((as const %s) " %
+                   self.env.stc.get_type(formula).as_smtlib(False))
         yield formula.array_value_default()
         self.write(")")
 
@@ -328,15 +328,15 @@ class SmtPrinter(TreeWalker):
 
 class SmtDagPrinter(DagWalker):
 
-    def __init__(self, stream: TextIO, template: str=".def_%d", annotations: Optional[Annotations]=None):
-        DagWalker.__init__(self, invalidate_memoization=True)
+    def __init__(self, stream: TextIO, template: str=".def_%d", annotations: Optional[Annotations]=None, env=None):
+        DagWalker.__init__(self, env=env, invalidate_memoization=True)
         self.stream = stream
         self.write = self.stream.write
         self.openings = 0
         self.name_seed = 0
         self.template = template
         self.names: Optional[Set[str]] = None
-        self.mgr = get_env().formula_manager
+        self.mgr = self.env.formula_manager
         self.annotations = annotations
 
     def _push_with_children_to_stack(self, formula: FNode, **kwargs):
@@ -358,7 +358,8 @@ class SmtDagPrinter(DagWalker):
     def printer(self, f: FNode):
         self.openings = 0
         self.name_seed = 0
-        self.names = set(quote(x.symbol_name()) for x in f.get_free_variables())
+        self.names = set(quote(x.symbol_name())
+                         for x in self.env.fvo.get_free_variables(f))
 
         key = self.walk(f)
         self.write(key)
@@ -575,7 +576,7 @@ class SmtDagPrinter(DagWalker):
             self.write(" %s)" % s.symbol_type().as_smtlib(False))
         self.write(") ")
 
-        subprinter = SmtDagPrinter(self.stream)
+        subprinter = SmtDagPrinter(self.stream, env=self.env)
         subprinter.printer(formula.arg(0))
 
         self.write(")))")
@@ -695,7 +696,8 @@ class SmtDagPrinter(DagWalker):
         for _ in range((len(args) - 1) // 2):
             self.write("(store ")
 
-        self.write("((as const %s) " % formula.get_type().as_smtlib(False))
+        self.write("((as const %s) " %
+                   self.env.stc.get_type(formula).as_smtlib(False))
         self.write(args[0])
         self.write(")")
 
@@ -709,7 +711,7 @@ class SmtDagPrinter(DagWalker):
         return sym
 
 
-def to_smtlib(formula: FNode, daggify: bool=True) -> str:
+def to_smtlib(formula: FNode, daggify: bool=True, env=None) -> str:
     """Returns a Smt-Lib string representation of the formula.
 
     The daggify parameter can be used to switch from a linear-size
@@ -722,9 +724,9 @@ def to_smtlib(formula: FNode, daggify: bool=True) -> str:
     buf = StringIO()
     p: Union[SmtDagPrinter, SmtPrinter]
     if daggify:
-        p = SmtDagPrinter(buf)
+        p = SmtDagPrinter(buf, env=env)
     else:
-        p = SmtPrinter(buf)
+        p = SmtPrinter(buf, env=env)
     p.printer(formula)
     res = buf.getvalue()
     buf.close()

--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -54,7 +54,7 @@ def check_sat_filter(log: List[Tuple[str, Optional[Union[Model, bool, Goal, List
 
 
 class SmtLibCommand(namedtuple('SmtLibCommand', ['name', 'args'])):
-    def serialize(self, outstream: Optional[TextIO]=None, printer: Optional[PrinterType]=None, daggify: bool=True):
+    def serialize(self, outstream: Optional[TextIO]=None, printer: Optional[PrinterType]=None, daggify: bool=True, env=None):
         """Serializes the SmtLibCommand into outstream using the given printer.
 
         Exactly one of outstream or printer must be specified. When
@@ -69,9 +69,9 @@ class SmtLibCommand(namedtuple('SmtLibCommand', ['name', 'args'])):
             outstream = printer.stream
         elif (outstream is not None) and (printer is None):
             if daggify:
-                printer = SmtDagPrinter(outstream)
+                printer = SmtDagPrinter(outstream, env=env)
             else:
-                printer = SmtPrinter(outstream)
+                printer = SmtPrinter(outstream, env=env)
         else:
             assert (outstream is not None and printer is not None) or \
                    (outstream is None and printer is None), \
@@ -197,9 +197,9 @@ class SmtLibCommand(namedtuple('SmtLibCommand', ['name', 'args'])):
         else:
             raise UnknownSmtLibCommandError(self.name)
 
-    def serialize_to_string(self, daggify: bool=True) -> str:
+    def serialize_to_string(self, daggify: bool=True, env=None) -> str:
         buf = StringIO()
-        self.serialize(buf, daggify=daggify)
+        self.serialize(buf, daggify=daggify, env=env)
         return buf.getvalue()
 
 
@@ -336,19 +336,19 @@ class SmtLibScript(object):
             return mgr.And(stack), tuple(goals)
         return mgr.And(stack)
 
-    def to_file(self, fname, daggify=True):
+    def to_file(self, fname, daggify=True, env=None):
         with open(fname, "w") as outstream:
-            self.serialize(outstream, daggify=daggify)
+            self.serialize(outstream, daggify=daggify, env=env)
 
-    def serialize(self, outstream: Union[TextIOWrapper, StringIO], daggify: bool=True):
+    def serialize(self, outstream: Union[TextIOWrapper, StringIO], daggify: bool=True, env=None):
         """Serializes the SmtLibScript expanding commands"""
         if daggify:
-            printer: PrinterType = SmtDagPrinter(outstream, annotations=self.annotations)
+            printer: PrinterType = SmtDagPrinter(outstream, env=env, annotations=self.annotations)
         else:
-            printer = SmtPrinter(outstream, annotations=self.annotations)
+            printer = SmtPrinter(outstream, env=env, annotations=self.annotations)
 
         for cmd in self.commands:
-            cmd.serialize(printer=printer)
+            cmd.serialize(printer=printer, env=env)
             outstream.write("\n")
 
     def __len__(self) -> int:
@@ -375,12 +375,14 @@ def _command_is_signed(command: SmtLibCommand) -> bool:
     return singed
 
 
-def smtlibscript_from_formula(formula: FNode, logic: Optional[Union[str, int, Logic]]=None) -> SmtLibScript:
+def smtlibscript_from_formula(formula: FNode, logic: Optional[Union[str, int, Logic]]=None, env=None) -> SmtLibScript:
     script = SmtLibScript()
+    if env is None:
+        env = get_env()
 
     if logic is None:
         # Get the simplest SmtLib logic that contains the formula
-        f_logic = get_logic(formula)
+        f_logic = get_logic(formula, env=env)
 
         smt_logic: Optional[Union[Logic, str]] = None
         try:
@@ -405,11 +407,11 @@ def smtlibscript_from_formula(formula: FNode, logic: Optional[Union[str, int, Lo
                args=[smt_logic])
 
     # Declare all types
-    types = get_env().typeso.get_types(formula, custom_only=True)
+    types = env.typeso.get_types(formula, custom_only=True)
     for type_ in types:
         script.add(name=smtcmd.DECLARE_SORT, args=[type_.decl])
 
-    deps = formula.get_free_variables()
+    deps = env.fvo.get_free_variables(formula)
     # Declare all variables
     for symbol in deps:
         assert symbol.is_symbol()

--- a/pysmt/smtlib/script.py
+++ b/pysmt/smtlib/script.py
@@ -314,19 +314,24 @@ class SmtLibScript(object):
                         del max_smt_goals[k]
                         del max_smt_goals_backtrack[k]
             elif cmd.name == smtcmd.MAXIMIZE:
-                goals.append(MaximizationGoal(cmd.args[0], _command_is_signed(cmd)))
+                goals.append(MaximizationGoal(cmd.args[0], _command_is_signed(cmd),
+                                              env=mgr.env))
             elif cmd.name == smtcmd.MINIMIZE:
-                goals.append(MinimizationGoal(cmd.args[0], _command_is_signed(cmd)))
+                goals.append(MinimizationGoal(cmd.args[0], _command_is_signed(cmd),
+                                              env=mgr.env))
             elif cmd.name == smtcmd.MINMAX:
-                goals.append(MinMaxGoal(cmd.args[0], _command_is_signed(cmd)))
+                goals.append(MinMaxGoal(cmd.args[0], _command_is_signed(cmd),
+                                        env=mgr.env))
             elif cmd.name == smtcmd.MAXMIN:
-                goals.append(MaxMinGoal(cmd.args[0], _command_is_signed(cmd)))
+                goals.append(MaxMinGoal(cmd.args[0], _command_is_signed(cmd),
+                                        env=mgr.env))
             elif cmd.name == smtcmd.ASSERT_SOFT:
                 formula = cmd.args[0]
                 cmd_annotations = dict(cmd.args[1])
                 max_smt_id = cmd_annotations.get(":id", "")
                 max_smt_weight = cmd_annotations.get(":weight", mgr.Int(1))
-                _, goal = max_smt_goals.setdefault(max_smt_id, (len(goals), MaxSMTGoal()))
+                _, goal = max_smt_goals.setdefault(
+                    max_smt_id, (len(goals), MaxSMTGoal(env=mgr.env)))
                 goal.add_soft_clause(formula, max_smt_weight)
                 # if len(goal.soft) > 1 the goal is already in goals
                 if len(goal.soft) == 1:
@@ -517,12 +522,12 @@ class InterpreterOMT(InterpreterSMT):
             return None
 
         elif cmd.name == smtcmd.MAXIMIZE:
-            g: Goal = MaximizationGoal(cmd.args[0])
+            g: Goal = MaximizationGoal(cmd.args[0], env=optimizer.environment)
             self.optimization_goals[0].append(g)
             return g
 
         elif cmd.name == smtcmd.MINIMIZE:
-            g = MinimizationGoal(cmd.args[0])
+            g = MinimizationGoal(cmd.args[0], env=optimizer.environment)
             self.optimization_goals[0].append(g)
             return g
 
@@ -569,12 +574,12 @@ class InterpreterOMT(InterpreterSMT):
             return rt
 
         elif cmd.name == smtcmd.MAXMIN:
-            g = MaxMinGoal(cmd.args[0])
+            g = MaxMinGoal(cmd.args[0], env=optimizer.environment)
             self.optimization_goals[0].append(g)
             return g
 
         elif cmd.name == smtcmd.MINMAX:
-            g = MinMaxGoal(cmd.args[0])
+            g = MinMaxGoal(cmd.args[0], env=optimizer.environment)
             self.optimization_goals[0].append(g)
             return g
 

--- a/pysmt/smtlib/solver.py
+++ b/pysmt/smtlib/solver.py
@@ -166,12 +166,12 @@ class SmtLibSolver(Solver): # TODO this class is defined twice in pysmt. Here an
     def add_assertion(self, formula, named=None):
         # This is needed because Z3 (and possibly other solvers) incorrectly
         # recognize N * M * x as a non-linear term
-        formula = formula.simplify()
+        formula = self.environment.simplifier.simplify(formula)
         sorts = self.to.get_types(formula, custom_only=True)
         for s in sorts:
             if all(s not in ds for ds in self.declared_sorts):
                 self._declare_sort(s)
-        deps = formula.get_free_variables()
+        deps = self.environment.fvo.get_free_variables(formula)
         for d in deps:
             if all(d not in dv for dv in self.declared_vars):
                 self._declare_variable(d)

--- a/pysmt/solvers/bdd.py
+++ b/pysmt/solvers/bdd.py
@@ -243,7 +243,7 @@ class BddSolver(Solver):
 class BddConverter(Converter, DagWalker):
 
     def __init__(self, environment, ddmanager):
-        DagWalker.__init__(self)
+        DagWalker.__init__(self, env=environment)
 
         self.environment = environment
         self.fmgr = self.environment.formula_manager
@@ -265,7 +265,7 @@ class BddConverter(Converter, DagWalker):
         return self.walk(formula)
 
     def back(self, bdd_expr):
-        return self._walk_back(bdd_expr, self.fmgr).simplify()
+        return self.env.simplifier.simplify(self._walk_back(bdd_expr, self.fmgr))
 
     def get_all_vars_array(self):
         # NOTE: This way of building the var_array does not look

--- a/pysmt/solvers/btor.py
+++ b/pysmt/solvers/btor.py
@@ -322,7 +322,7 @@ class BoolectorSolver(IncrementalTrackingSolver, UnsatCoreSolver, SmtLibBasicSol
 
     def get_value(self, item):
         self._assert_no_function_type(item)
-        itype = item.get_type()
+        itype = self.environment.stc.get_type(item)
         titem = self.converter.convert(item)
 
         def _back_bv_func(width):

--- a/pysmt/solvers/cvcfive.py
+++ b/pysmt/solvers/cvcfive.py
@@ -363,7 +363,7 @@ class CVC5Converter(Converter, DagWalker):
         return self.cvc5_solver.mkTerm(Kind.SELECT, args[0], args[1])
 
     def walk_array_value(self, formula, args, **kwargs):
-        arr_sort = self._type_to_cvc5(formula.get_type())
+        arr_sort = self._type_to_cvc5(self.env.stc.get_type(formula))
         # args[0] is the converted default value
         const_arr = self.cvc5_solver.mkConstArray(arr_sort, args[0])
         # Remaining args are (index, value) pairs for point overrides
@@ -572,15 +572,15 @@ class CVC5Converter(Converter, DagWalker):
             # Recursively convert the types of index and elem
             idx_type = self._cvc5_type_to_type(type_.getArrayIndexSort())
             elem_type = self._cvc5_type_to_type(type_.getArrayElementSort())
-            return types.ArrayType(idx_type, elem_type)
+            return self.env.type_manager.ArrayType(idx_type, elem_type)
         elif type_.isBitVector():
-            return types.BVType(type_.getBitVectorSize())
+            return self.env.type_manager.BVType(type_.getBitVectorSize())
         elif type_.isFunction():
             # Casting Type into FunctionType
             type_ = cvc5.FunctionType(type_)
             return_type = type_.getRangeType()
             param_types = tuple(self._cvc5_type_to_type(ty) for ty in type_.getArgTypes())
-            return types.FunctionType(return_type, param_types)
+            return self.env.type_manager.FunctionType(return_type, param_types)
         else:
             raise NotImplementedError("Unsupported type: %s" % type_)
 

--- a/pysmt/solvers/cvcfour.py
+++ b/pysmt/solvers/cvcfour.py
@@ -341,7 +341,8 @@ class CVC4Converter(Converter, DagWalker):
         return self.mkExpr(CVC4.EQUAL, args[0], args[1])
 
     def walk_times(self, formula, args, **kwargs):
-        if sum(1 for x in formula.args() if x.get_free_variables()) > 1:
+        if sum(1 for x in formula.args()
+               if self.env.fvo.get_free_variables(x)) > 1:
             raise NonLinearError(formula)
         res = args[0]
         for x in args[1:]:
@@ -598,17 +599,17 @@ class CVC4Converter(Converter, DagWalker):
             # Recursively convert the types of index and elem
             idx_type = self._cvc4_type_to_type(type_.getIndexType())
             elem_type = self._cvc4_type_to_type(type_.getConstituentType())
-            return types.ArrayType(idx_type, elem_type)
+            return self.env.type_manager.ArrayType(idx_type, elem_type)
         elif type_.isBitVector():
             # Casting Type into BitVectorType
             type_ = CVC4.BitVectorType(type_)
-            return types.BVType(type_.getSize())
+            return self.env.type_manager.BVType(type_.getSize())
         elif type_.isFunction():
             # Casting Type into FunctionType
             type_ = CVC4.FunctionType(type_)
             return_type = type_.getRangeType()
             param_types = tuple(self._cvc4_type_to_type(ty) for ty in type_.getArgTypes())
-            return types.FunctionType(return_type, param_types)
+            return self.env.type_manager.FunctionType(return_type, param_types)
         else:
             raise NotImplementedError("Unsupported type: %s" % type_)
 

--- a/pysmt/solvers/eager.py
+++ b/pysmt/solvers/eager.py
@@ -43,13 +43,13 @@ class EagerModel(Model):
     def get_value(self, formula: FNode, model_completion: bool=True) -> FNode:
         substituter = self.environment.substituter
         if model_completion:
-            syms = formula.get_free_variables()
+            syms = self.environment.fvo.get_free_variables(formula)
             self._complete_model(syms)
             r = substituter.substitute(formula, self.completed_assignment)
         else:
             r = substituter.substitute(formula, self.assignment)
 
-        res = r.simplify()
+        res = self.environment.simplifier.simplify(r)
         if not res.is_constant():
             raise PysmtTypeError("Was expecting a constant but got %s" % res)
         return res

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -380,6 +380,7 @@ class MSatConverter(Converter, DagWalker):
         self._msat_lib = MSATLibLoader(self.__class__.__lib_name__)
         self.msat_env = msat_env
         self.mgr = environment.formula_manager
+        self.tm = environment.type_manager
         self._get_type = environment.stc.get_type
 
         # Maps a Symbol into the corresponding msat_decl instance in the msat_env
@@ -450,20 +451,20 @@ class MSatConverter(Converter, DagWalker):
             self._msat_lib.MSAT_TAG_TRUE: lambda term, args: types.BOOL,
             self._msat_lib.MSAT_TAG_FALSE: lambda term, args: types.BOOL,
             self._msat_lib.MSAT_TAG_AND: lambda term, args:\
-                types.FunctionType(types.BOOL, [types.BOOL, types.BOOL]),
+                self.tm.FunctionType(types.BOOL, [types.BOOL, types.BOOL]),
             self._msat_lib.MSAT_TAG_OR: lambda term, args:\
-                types.FunctionType(types.BOOL, [types.BOOL, types.BOOL]),
+                self.tm.FunctionType(types.BOOL, [types.BOOL, types.BOOL]),
             self._msat_lib.MSAT_TAG_NOT: lambda term, args:\
-                types.FunctionType(types.BOOL, [types.BOOL]),
+                self.tm.FunctionType(types.BOOL, [types.BOOL]),
             self._msat_lib.MSAT_TAG_IFF: lambda term, args:\
-                types.FunctionType(types.BOOL, [types.BOOL, types.BOOL]),
+                self.tm.FunctionType(types.BOOL, [types.BOOL, types.BOOL]),
             self._msat_lib.MSAT_TAG_ITE: self._sig_ite,
             self._msat_lib.MSAT_TAG_EQ: self._sig_most_generic_bool_binary,
             self._msat_lib.MSAT_TAG_LEQ: self._sig_most_generic_bool_binary,
             self._msat_lib.MSAT_TAG_PLUS:  self._sig_most_generic_bool_binary,
             self._msat_lib.MSAT_TAG_TIMES: self._sig_most_generic_bool_binary,
             self._msat_lib.MSAT_TAG_FLOOR: lambda term, args:\
-                types.FunctionType(types.INT, [types.REAL]),
+                self.tm.FunctionType(types.INT, [types.REAL]),
             self._msat_lib.MSAT_TAG_BV_MUL: self._sig_binary,
             self._msat_lib.MSAT_TAG_BV_ADD: self._sig_binary,
             self._msat_lib.MSAT_TAG_BV_UDIV:self._sig_binary,
@@ -531,66 +532,66 @@ class MSatConverter(Converter, DagWalker):
 
     def _sig_binary(self, term, args):
         t = self.env.stc.get_type(args[0])
-        return types.FunctionType(t, [t, t])
+        return self.tm.FunctionType(t, [t, t])
 
     def _sig_bool_binary(self, term, args):
         t = self.env.stc.get_type(args[0])
-        return types.FunctionType(types.BOOL, [t, t])
+        return self.tm.FunctionType(types.BOOL, [t, t])
 
     def _sig_most_generic_bool_binary(self, term, args):
         t1 = self.env.stc.get_type(args[0])
         t2 = self.env.stc.get_type(args[1])
         t = self._most_generic(t1, t2)
-        return types.FunctionType(types.BOOL, [t, t])
+        return self.tm.FunctionType(types.BOOL, [t, t])
 
     def _sig_unary(self, term, args):
         t = self.env.stc.get_type(args[0])
-        return types.FunctionType(t, [t])
+        return self.tm.FunctionType(t, [t])
 
     def _sig_ite(self, term, args):
         t1 = self.env.stc.get_type(args[1])
         t2 = self.env.stc.get_type(args[2])
         t = self._most_generic(t1, t2)
-        return types.FunctionType(t, [types.BOOL, t, t])
+        return self.tm.FunctionType(t, [types.BOOL, t, t])
 
     def _sig_bv_comp(self, term,  args):
         t = self.env.stc.get_type(args[0])
-        return types.FunctionType(types.BVType(1), [t, t])
+        return self.tm.FunctionType(self.tm.BVType(1), [t, t])
 
     def _sig_bv_sext(self, term, args):
         _, amount = self._msat_lib.msat_term_is_bv_sext(self.msat_env(), term)
         t = self.env.stc.get_type(args[0])
-        return types.FunctionType(types.BVType(amount + t.width), [t])
+        return self.tm.FunctionType(self.tm.BVType(amount + t.width), [t])
 
     def _sig_bv_zext(self, term, args):
         _, amount = self._msat_lib.msat_term_is_bv_zext(self.msat_env(), term)
         t = self.env.stc.get_type(args[0])
-        return types.FunctionType(types.BVType(amount + t.width), [t])
+        return self.tm.FunctionType(self.tm.BVType(amount + t.width), [t])
 
     def _sig_bv_extract(self, term, args):
         _, msb, lsb = self._msat_lib.msat_term_is_bv_extract(self.msat_env(), term)
         t = self.env.stc.get_type(args[0])
-        return types.FunctionType(types.BVType(msb - lsb + 1), [t])
+        return self.tm.FunctionType(self.tm.BVType(msb - lsb + 1), [t])
 
     def _sig_bv_concat(self, term, args):
         t1 = self.env.stc.get_type(args[0])
         t2 = self.env.stc.get_type(args[1])
-        return types.FunctionType(types.BVType(t1.width + t2.width), [t1, t2])
+        return self.tm.FunctionType(self.tm.BVType(t1.width + t2.width), [t1, t2])
 
     def _sig_array_read(self, term, args):
         t1 = self.env.stc.get_type(args[0])
         t = t1.elem_type
-        return types.FunctionType(t, [t1, t1.index_type])
+        return self.tm.FunctionType(t, [t1, t1.index_type])
 
     def _sig_array_write(self, term, args):
         ty = self._msat_lib.msat_term_get_type(term)
         at = self._msat_type_to_type(ty)
-        return types.FunctionType(at, [at, at.index_type, at.elem_type])
+        return self.tm.FunctionType(at, [at, at.index_type, at.elem_type])
 
     def _sig_array_const(self, term,  args):
         ty = self._msat_lib.msat_term_get_type(term)
         pyty = self._msat_type_to_type(ty)
-        return types.FunctionType(pyty, [pyty.elem_type])
+        return self.tm.FunctionType(pyty, [pyty.elem_type])
 
     def _sig_unknown(self, term: Any, args: List[Any]) -> PySMTType:
         if self._msat_lib.msat_term_is_boolean_constant(self.msat_env(), term):
@@ -604,7 +605,7 @@ class MSatConverter(Converter, DagWalker):
             else:
                 assert "_" in str(term), "Unrecognized type for '%s'" % str(term)
                 width = int(str(term).split("_")[1])
-                res = types.BVType(width)
+                res = self.tm.BVType(width)
             return res
         elif self._msat_lib.msat_term_is_constant(self.msat_env(), term):
             ty = self._msat_lib.msat_term_get_type(term)
@@ -712,11 +713,11 @@ class MSatConverter(Converter, DagWalker):
                 if check_arr:
                     i = self._msat_type_to_type(idx_type)
                     e = self._msat_type_to_type(val_type)
-                    res = self.mgr.Symbol(rep, types.ArrayType(i, e))
+                    res = self.mgr.Symbol(rep, self.tm.ArrayType(i, e))
                 else:
                     _, width = self._msat_lib.msat_is_bv_type(self.msat_env(), ty)
                     assert isinstance(width, int), "Unsupported variable type for '%s'"%str(term)
-                    res = self.mgr.Symbol(rep, types.BVType(width))
+                    res = self.mgr.Symbol(rep, self.tm.BVType(width))
 
         elif self._msat_lib.msat_term_is_uf(self.msat_env(), term):
             d = self._msat_lib.msat_term_get_decl(term)
@@ -1079,11 +1080,11 @@ class MSatConverter(Converter, DagWalker):
             if check_arr != 0:
                 i = self._msat_type_to_type(idx_type)
                 e = self._msat_type_to_type(val_type)
-                return types.ArrayType(i, e)
+                return self.tm.ArrayType(i, e)
 
             check_bv, bv_width = self._msat_lib.msat_is_bv_type(self.msat_env(), tp)
             if check_bv != 0:
-                return types.BVType(bv_width)
+                return self.tm.BVType(bv_width)
 
             # It must be a function type, currently unsupported
             raise NotImplementedError("Function types are unsupported")
@@ -1307,9 +1308,9 @@ class MSatBoolUFRewriter(IdentityDagWalker):
         IdentityDagWalker.__init__(self, environment)
         self.get_type = self.env.stc.get_type
         self.mgr = self.env.formula_manager
+        self.tm = self.env.type_manager
 
     def walk_function(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
-        from pysmt.typing import FunctionType
         # Separate arguments
         bool_args = []
         other_args = []
@@ -1329,7 +1330,7 @@ class MSatBoolUFRewriter(IdentityDagWalker):
         if len(ptype) == 0:
             ftype = rtype
         else:
-            ftype = FunctionType(rtype, ptype)
+            ftype = self.tm.FunctionType(rtype, ptype)
 
         # Base-case
         stack = []

--- a/pysmt/solvers/pico.py
+++ b/pysmt/solvers/pico.py
@@ -227,7 +227,7 @@ class PicosatSolver(Solver):
     @catch_conversion_error
     def add_assertion(self, formula, named=None):
         # First, we get rid of True/False constants
-        formula = formula.simplify()
+        formula = self.environment.simplifier.simplify(formula)
         if formula.is_false():
             picosat.picosat_add(self.pico, 0)
         elif not formula.is_true():

--- a/pysmt/solvers/qelim.py
+++ b/pysmt/solvers/qelim.py
@@ -94,8 +94,9 @@ class ShannonQuantifierEliminator(QuantifierEliminator, IdentityDagWalker):
         self._assert_vars_boolean(qvars)
         res = []
         f = args[0]
+        substitute = self.env.substituter.substitute
         for subs in all_assignments(qvars, self.env):
-            res.append(f.substitute(subs))
+            res.append(substitute(f, subs))
         return res
 
     def walk_forall(self, formula: FNode, args: Sequence[FNode], **kwargs) -> FNode:
@@ -128,9 +129,10 @@ class SelfSubstitutionQuantifierEliminator(QuantifierEliminator, IdentityDagWalk
         return self.walk(formula)
 
     def self_substitute(self, formula: FNode, qvars: Sequence[FNode], token: FNode) -> FNode:
+        substitute = self.env.substituter.substitute
         for v in qvars[::-1]:
-            inner_sub = formula.substitute({v: token})
-            formula = formula.substitute({v: inner_sub})
+            inner_sub = substitute(formula, {v: token})
+            formula = substitute(formula, {v: inner_sub})
         return formula
 
     def walk_forall(self, formula: FNode, args: Sequence[FNode], **kwargs) -> FNode:

--- a/pysmt/solvers/smtlib.py
+++ b/pysmt/solvers/smtlib.py
@@ -19,9 +19,14 @@ from pysmt.fnode import FNode
 from pysmt.logics import Logic
 from typing import Iterable, Optional, Union
 
+from pysmt.environment import Environment
 from pysmt.solvers.solver import Model, Solver
 
 class SmtLibSolver(object):
+    # Implementations combine this interface with Solver (see
+    # SmtLibIgnoreMixin below), so they carry the environment they work in.
+    environment: Environment
+
     #
     # SMT-LIB 2 Interface
     #

--- a/pysmt/solvers/solver.py
+++ b/pysmt/solvers/solver.py
@@ -270,7 +270,7 @@ class Solver(object):
 
         Raises TypeError.
         """
-        if formula.get_type() != BOOL:
+        if self.environment.stc.get_type(formula) != BOOL:
             raise PysmtTypeError("Argument '%s' must be boolean." % formula)
 
 
@@ -492,14 +492,16 @@ class Model(object):
         models.
         """
 
-        subs = self.get_values(formula.get_free_variables())
-        simp = formula.substitute(subs).simplify()
+        env = self.environment
+        get_free_vars = env.fvo.get_free_variables
+        subs = self.get_values(get_free_vars(formula))
+        simp = env.simplifier.simplify(env.substituter.substitute(formula, subs))
         if simp.is_true():
             return True
         if simp.is_false():
             return False
 
-        free_vars = simp.get_free_variables()
+        free_vars = get_free_vars(simp)
         if  len(free_vars) > 0:
             # Partial model
             return False
@@ -520,7 +522,7 @@ class Model(object):
                 stack += x.args()
 
             subs = self.get_values(div_0)
-            simp = simp.substitute(subs).simplify()
+            simp = env.simplifier.simplify(env.substituter.substitute(simp, subs))
             return simp.is_true()
         return False
 

--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -298,7 +298,7 @@ class Z3Solver(IncrementalTrackingSolver, UnsatCoreSolver, SmtLibBasicSolver):
         z3_res = self.z3.model().eval(titem, model_completion=True)
         res = self.converter.back(z3_res, self.z3.model())
         if not res.is_constant():
-            return res.simplify()
+            return self.environment.simplifier.simplify(res)
         return res
 
     def _exit(self):
@@ -877,10 +877,11 @@ class Z3Converter(Converter, DagWalker):
         elif sort.kind() == z3.Z3_REAL_SORT:
             return types.REAL
         elif sort.kind() == z3.Z3_ARRAY_SORT:
-            return types.ArrayType(self._z3_to_type(sort.domain()),
-                                   self._z3_to_type(sort.range()))
+            return self.env.type_manager.ArrayType(
+                self._z3_to_type(sort.domain()),
+                self._z3_to_type(sort.range()))
         elif sort.kind() == z3.Z3_BV_SORT:
-            return types.BVType(sort.size())
+            return self.env.type_manager.BVType(sort.size())
         else:
             raise NotImplementedError("Unsupported sort in conversion: %s" % sort)
 

--- a/pysmt/substituter.py
+++ b/pysmt/substituter.py
@@ -139,13 +139,14 @@ class Substituter(pysmt.walkers.IdentityDagWalker):
             # 1. We create a new substitution in which we remove the
             #    bound variables from the substitution map
             substitutions = kwargs["substitutions"]
+            get_free_vars = self.env.fvo.get_free_variables
             new_subs = {}
             for k,v in substitutions.items():
                 # If at least one bound variable is in the cone of k,
                 # we do not consider this substitution in the body of
                 # the quantifier.
                 if all(m not in formula.quantifier_vars()
-                       for m in k.get_free_variables()):
+                       for m in get_free_vars(k)):
                     new_subs[k] = v
 
             # 2. We apply the substitution on the quantifier body with

--- a/pysmt/test/test_env.py
+++ b/pysmt/test/test_env.py
@@ -19,6 +19,9 @@ from io import StringIO
 
 from pysmt.shortcuts import Symbol
 import pysmt.factory
+from pysmt.optimization.goal import (MaxMinGoal, MaximizationGoal,
+                                     MaxSMTGoal, MinimizationGoal,
+                                     MinMaxGoal)
 from pysmt.rewritings import CNFizer, NNFizer, PrenexNormalizer
 from pysmt.smtlib.printers import to_smtlib
 from pysmt.smtlib.script import smtlibscript_from_formula
@@ -146,6 +149,29 @@ class TestEnvironment(TestCase):
         buf = StringIO()
         smtlibscript_from_formula(f, env=env).serialize(buf, env=env)
         self.assertIn("bvult", buf.getvalue())
+
+        self.assertEqual(len(global_env.formula_manager.formulae), global_size,
+                         "the global environment was polluted")
+
+    def test_goals_use_given_env(self):
+        """Optimization goals must build their terms in the given env."""
+        global_env = get_env()
+        env, x, y, _ = self._local_env_formula()
+        mgr = env.formula_manager
+        global_size = len(global_env.formula_manager.formulae)
+
+        maxsmt = MaxSMTGoal(real_weights=False, env=env)
+        maxsmt.add_soft_clause(mgr.BVULT(x, y), mgr.Int(1))
+
+        goals = [MaximizationGoal(x, env=env),
+                 MinimizationGoal(x, env=env),
+                 MinMaxGoal([x, y], env=env),
+                 MaxMinGoal([x, y], env=env),
+                 maxsmt]
+        for goal in goals:
+            self.assertIs(goal.env, env)
+            self.assertIn(goal.term(), mgr)
+            goal.get_logic()
 
         self.assertEqual(len(global_env.formula_manager.formulae), global_size,
                          "the global environment was polluted")

--- a/pysmt/test/test_env.py
+++ b/pysmt/test/test_env.py
@@ -15,8 +15,13 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from io import StringIO
+
 from pysmt.shortcuts import Symbol
 import pysmt.factory
+from pysmt.rewritings import CNFizer, NNFizer, PrenexNormalizer
+from pysmt.smtlib.printers import to_smtlib
+from pysmt.smtlib.script import smtlibscript_from_formula
 from pysmt.test import TestCase, main
 from pysmt.typing import REAL
 from pysmt.environment import Environment, pop_env, push_env, get_env
@@ -81,6 +86,69 @@ class TestEnvironment(TestCase):
 
         with self.assertRaises(AttributeError):
             env.stc = None
+
+    @staticmethod
+    def _local_env_formula():
+        """A BV formula built in a fresh, non-global environment."""
+        env = Environment()
+        mgr = env.formula_manager
+        # width 7 is not one of the globally pre-registered BV types, so
+        # each environment holds its own instance of it.
+        bv7 = env.type_manager.BVType(7)
+        x = mgr.Symbol("x", bv7)
+        y = mgr.Symbol("y", bv7)
+        f = mgr.And(mgr.BVULT(x, y), mgr.Not(mgr.Equals(x, y)))
+        return env, x, y, f
+
+    def test_no_global_env_pollution(self):
+        """Walkers must not build nodes in the global environment.
+
+        Library internals used to reach for the global environment via
+        FNode.simplify/substitute/get_free_variables/get_type, creating
+        nodes owned by the wrong formula manager.
+        """
+        global_env = get_env()
+        env, x, y, f = self._local_env_formula()
+        self.assertNotEqual(global_env, env)
+        mgr = env.formula_manager
+        qf = mgr.Exists([x], f)
+
+        global_size = len(global_env.formula_manager.formulae)
+        for res in (env.simplifier.simplify(f),
+                    env.simplifier.simplify(qf),
+                    env.substituter.substitute(f, {x: mgr.BV(1, 7)}),
+                    CNFizer(env).convert_as_formula(f),
+                    NNFizer(env).convert(f),
+                    PrenexNormalizer(env).normalize(qf)):
+            self.assertIn(res, mgr)
+        self.assertEqual(len(global_env.formula_manager.formulae), global_size,
+                         "the global environment was polluted")
+
+    def test_types_come_from_given_env(self):
+        """Derived types must be built by the environment's type manager."""
+        env, x, y, _ = self._local_env_formula()
+        mgr = env.formula_manager
+        self.assertIs(env.stc.get_type(mgr.BVConcat(x, y)),
+                      env.type_manager.BVType(14))
+        arr = mgr.Array(env.type_manager.BVType(7), mgr.BV(0, 7))
+        self.assertIs(env.stc.get_type(arr),
+                      env.type_manager.ArrayType(env.type_manager.BVType(7),
+                                                 env.type_manager.BVType(7)))
+
+    def test_smtlib_printers_accept_env(self):
+        """SMT-LIB serialization must not need the global environment."""
+        global_env = get_env()
+        env, _, _, f = self._local_env_formula()
+        global_size = len(global_env.formula_manager.formulae)
+
+        to_smtlib(f, env=env)
+        to_smtlib(f, daggify=False, env=env)
+        buf = StringIO()
+        smtlibscript_from_formula(f, env=env).serialize(buf, env=env)
+        self.assertIn("bvult", buf.getvalue())
+
+        self.assertEqual(len(global_env.formula_manager.formulae), global_size,
+                         "the global environment was polluted")
 
     def test_solver_factory_preferences(self):
         env = get_env()

--- a/pysmt/type_checker.py
+++ b/pysmt/type_checker.py
@@ -29,7 +29,7 @@ import pysmt.walkers as walkers
 import pysmt.operators as op
 import pysmt.typing as types
 
-from pysmt.typing import PySMTType, BOOL, REAL, INT, BVType, ArrayType, STRING
+from pysmt.typing import PySMTType, BOOL, REAL, INT, STRING
 from pysmt.exceptions import PysmtTypeError
 from pysmt.fnode import FNode
 
@@ -103,7 +103,7 @@ class SimpleTypeChecker(walkers.DagWalker):
     def walk_bv_to_bv(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
         #pylint: disable=unused-argument
         # We check that all children are BV and the same size
-        target_bv_type = BVType(formula.bv_width())
+        target_bv_type = self.env.type_manager.BVType(formula.bv_width())
         for a in args:
             if not a == target_bv_type:
                 return None
@@ -134,7 +134,7 @@ class SimpleTypeChecker(walkers.DagWalker):
         a, b = args
         if a != b or (not a.is_bv_type()):
             return None
-        return BVType(1)
+        return self.env.type_manager.BVType(1)
 
     @walkers.handles(op.BV_ULT, op.BV_ULE, op.BV_SLT, op.BV_SLE)
     def walk_bv_to_bool(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
@@ -163,7 +163,7 @@ class SimpleTypeChecker(walkers.DagWalker):
             return None
         if not l_width + r_width == target_width:
             return None
-        return BVType(target_width)
+        return self.env.type_manager.BVType(target_width)
 
     def walk_bv_extract(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
         arg = args[0]
@@ -179,7 +179,7 @@ class SimpleTypeChecker(walkers.DagWalker):
             return None
         if target_width != (end-start+1):
             return None
-        return BVType(target_width)
+        return self.env.type_manager.BVType(target_width)
 
     @walkers.handles(op.BV_ROL, op.BV_ROR)
     def walk_bv_rotate(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
@@ -189,7 +189,7 @@ class SimpleTypeChecker(walkers.DagWalker):
             return None
         if target_width != cast(types._BVType, args[0]).width:
             return None
-        return BVType(target_width)
+        return self.env.type_manager.BVType(target_width)
 
     @walkers.handles(op.BV_ZEXT, op.BV_SEXT)
     def walk_bv_extend(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
@@ -197,7 +197,7 @@ class SimpleTypeChecker(walkers.DagWalker):
         target_width = formula.bv_width()
         if target_width < cast(types._BVType, args[0]).width or target_width < 0:
             return None
-        return BVType(target_width)
+        return self.env.type_manager.BVType(target_width)
 
     def walk_equals(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
         #pylint: disable=unused-argument
@@ -257,7 +257,7 @@ class SimpleTypeChecker(walkers.DagWalker):
         #pylint: disable=unused-argument
         assert formula is not None
         assert len(args) == 0
-        return BVType(formula.bv_width())
+        return self.env.type_manager.BVType(formula.bv_width())
 
     def walk_symbol(self, formula: FNode, args: List[Any], **kwargs) -> Optional[PySMTType]:
         assert formula is not None
@@ -336,7 +336,7 @@ class SimpleTypeChecker(walkers.DagWalker):
                 return None # Wrong index type
             elif i % 2 == 1 and c != default_type:
                 return None
-        return ArrayType(idx_type, default_type)
+        return self.env.type_manager.ArrayType(idx_type, default_type)
 
     def walk_pow(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
         if args[0] != args[1]:


### PR DESCRIPTION
Supersedes #700 (@enmag), which is 409 commits behind master and no longer applies. As requested in the review of that PR by @marcogario and @mikand, this ports **only the correctness part** — avoiding the global environment when a more appropriate one is available. The breaking `environment` → `env` rename is left out and can be done separately.

None of #700 landed in the meantime, and master has since grown new instances of the same problem (`cvcfive.py`, `optimization/`, more of `rewritings.py`), so this covers those too.

### The problem

Library internals reached for the global environment in two ways:

1. The `FNode` convenience methods — `get_free_variables()`, `simplify()`, `substitute()`, `get_type()` — all of which go through `pysmt.environment.get_env()`.
2. The module-level type constructors in `pysmt.typing` — `BVType()`, `ArrayType()`, `FunctionType()` — which do the same.

For `simplify`, `substitute` and the type constructors this is not just hygiene. The nodes and type instances that come back are owned by the *global* formula/type manager, so a walker or solver bound to a non-global environment silently ends up mixing objects from two environments. Concretely, on master:

```python
env = Environment()                      # not the global env
mgr = env.formula_manager
x = mgr.Symbol("x", env.type_manager.BVType(7))
y = mgr.Symbol("y", env.type_manager.BVType(7))

env.stc.get_type(mgr.BVConcat(x, y)) is env.type_manager.BVType(14)
# False -- the type came from the global env's type manager
```

and running `CNFizer`, `NNFizer`, `PrenexNormalizer` or the simplifier over such a formula adds nodes to the *global* formula manager as a side effect.

### The change

Every call site that has an environment at hand now goes through it: `env.fvo`, `env.simplifier`, `env.substituter`, `env.stc`, `env.type_manager`.

Three related fixes fall out of it:

* `BddConverter` never passed its environment to `DagWalker.__init__`, so `self.env` was always the global one.
* `SmtPrinter` / `SmtDagPrinter` had no way to be told which environment to use (they called `get_env()` directly). They now take an optional `env`, and `to_smtlib`, `smtlibscript_from_formula`, `SmtLibCommand.serialize` and `SmtLibScript.serialize`/`to_file` thread it through.
* The optimization goals in `pysmt/optimization/goal.py` had the same problem and no environment of their own. `MaximizationGoal`, `MinimizationGoal`, `MinMaxGoal`, `MaxMinGoal` and `MaxSMTGoal` now all accept an optional `env`, and `Goal` holds it so that `Goal.get_logic()` stops consulting the global one. The places that build goals internally pass the environment they already have: `SmtLibScript.get_last_formula` uses the environment of the formula manager it was given, `InterpreterOMT` the optimizer's, and `ExternalOptimizerMixin._optimize` its own.

All new parameters are optional and appended, so this is source-compatible. `Goal` subclasses that do not call `Goal.__init__` keep falling back to the global environment, through the `Goal.env` property.

One annotation-only change: `SmtLibSolver` (the SMT-LIB command interface in `pysmt/solvers/smtlib.py`) now declares `environment`. Its implementations combine it with `Solver` — see `SmtLibIgnoreMixin` — so they all carry one, and declaring it lets callers holding the interface type reach it.

### Deliberately left out

* The `environment` → `env` keyword rename (the cosmetic, breaking half of #700), and the whitespace/import restyling and solver version bumps that PR also carried.
* `type_checker.assert_*_args` and `decorators.typecheck_result`, which take no environment and are unused outside the test suite (`typecheck_result`'s docstring documents the global environment as intentional).
* `Substituter`'s `FunctionInterpretation.__init__`, which has no environment; its one `get_free_variables()` call only feeds a subset check whose answer does not depend on the environment.
* `portfolio._run_solver`, which runs in a child process where the global environment is the only one there is.

### Testing

Four new tests in `pysmt/test/test_env.py`, all of which fail without the corresponding fix:

* `test_no_global_env_pollution` — walkers run in a local environment must not add nodes to the global one (before: +5 nodes).
* `test_types_come_from_given_env` — derived BV and array types must come from the local type manager (before: `BV{14} is not BV{14}`).
* `test_smtlib_printers_accept_env` — SMT-LIB serialization works without the global environment.
* `test_goals_use_given_env` — goals build their terms in the environment they were given.

`mypy pysmt` is clean. Full suite passes locally (btor, cvc5 and optimsat installed); the two `test_omt_lib_solver.py::test_parsed_examples[...-optimsat]` failures are pre-existing on master and unrelated.
