### PR TITLE
reorder operands of commutative operators based on node-id

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -23,6 +23,7 @@ Radomir Stevanovic <radomir.stevanovic@gmail.com>  Radomir Stevanovic <radomir@d
 Yike Zhou <yikezhou@outlook.com>  Yike Zhou <43945722+YikeZhou@users.noreply.github.com>
 Yoni Zohar <yoni206@gmail.com>  yoni206 <yoni206@users.noreply.github.com>
 Yuri Malheiros <yurimalheiros@gmail.com>  yurimalheiros <yurimalheiros@gmail.com>
+Enrico Magnago <en.magnago@gmail.com> enmag <en.magnago@gmail.com>
 Enrico Magnago <en.magnago@gmail.com> Enrico Magnago <EnricoMagnago@users.noreply.github.com>
 Enrico Magnago <en.magnago@gmail.com> Enrico Magnago <13752450+enmag@users.noreply.github.com>
 Enrico Magnago <en.magnago@gmail.com> enmag <en.magnago@gmail.com>

--- a/pysmt/environment.py
+++ b/pysmt/environment.py
@@ -51,7 +51,7 @@ class Environment(object):
     HRSerializerClass = pysmt.printers.HRSerializer
     QuantifierOracleClass = pysmt.oracles.QuantifierOracle
     TheoryOracleClass = pysmt.oracles.TheoryOracle
-    FreeVarsOracleClass= pysmt.oracles.FreeVarsOracle
+    FreeVarsOracleClass = pysmt.oracles.FreeVarsOracle
     SizeOracleClass = pysmt.oracles.SizeOracle
     AtomsOracleClass = pysmt.oracles.AtomsOracle
     TypesOracleClass = pysmt.oracles.TypesOracle
@@ -76,6 +76,10 @@ class Environment(object):
         # Configurations
         self.enable_infix_notation = False
         self.enable_div_by_0 = True
+        # set to true to enable FormulaManager reordering of arguments
+        # of commutative operations.
+        # NOTE: ordering across runs depends on order in which FNodes are created.
+        self.sort_commutative_args = False
 
         # This option allows the construction of a symbol with empty
         # name (i.e. `Symbol("", INT)`). This feature is allowed by

--- a/pysmt/fnode.py
+++ b/pysmt/fnode.py
@@ -45,10 +45,10 @@ from pysmt.operators import (FORALL, EXISTS, AND, OR, NOT, IMPLIES, IFF,
                              ARRAY_SELECT, ARRAY_STORE, ARRAY_VALUE,
                              ALGEBRAIC_CONSTANT)
 
-from pysmt.operators import  (BOOL_OPERATORS, THEORY_OPERATORS,
-                              BV_OPERATORS, IRA_OPERATORS, ARRAY_OPERATORS,
-                              STR_OPERATORS,
-                              RELATIONS, CONSTANTS)
+from pysmt.operators import (BOOL_OPERATORS, THEORY_OPERATORS,
+                             BV_OPERATORS, IRA_OPERATORS, ARRAY_OPERATORS,
+                             STR_OPERATORS,
+                             RELATIONS, CONSTANTS)
 
 from pysmt.typing import PySMTType, BOOL, REAL, INT, BVType, STRING
 from pysmt.decorators import deprecated, assert_infix_enabled
@@ -61,7 +61,8 @@ from pysmt.exceptions import (PysmtValueError, PysmtModeError,
 FNodeContent = collections.namedtuple("FNodeContent",
                                       ["node_type", "args", "payload"])
 
-class FNode(object):
+
+class FNode:
     r"""FNode represent the basic structure for representing a formula.
 
     FNodes are built using the FormulaManager, and should not be
@@ -78,6 +79,7 @@ class FNode(object):
     The node_id is an integer uniquely identifying the node within the
     FormulaManager it belongs.
     """
+
     __slots__ = ["_content", "_node_id"]
 
     def __init__(self, content: "FNodeContent", node_id: int):

--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -25,12 +25,13 @@ defined (operators.py). This is because many operators are rewritten,
 and therefore are only virtual. Common examples are GE, GT that are
 rewritten as LE and LT. Similarly, the operator Xor is rewritten using
 its definition.
+In addition,  operators of n-ary commutative operators are sorted.
 """
 
 import sys
 import fractions
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, cast, Iterable
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union, cast, Iterable
 
 if sys.version_info >= (3, 3):
     from collections.abc import Iterable as CollectionsIterable
@@ -42,11 +43,10 @@ import pysmt
 
 import pysmt.typing as types
 import pysmt.operators as op
-from pysmt.fnode import FNode
 from pysmt.typing import PySMTType
 from pysmt.fnode import FNode, FNodeContent
 from pysmt.exceptions import (UndefinedSymbolError, PysmtValueError,
-                             PysmtTypeError, PysmtEmptySymbolNameError)
+                              PysmtTypeError, PysmtEmptySymbolNameError)
 from pysmt.walkers.identitydag import IdentityDagWalker
 from pysmt.constants import Fraction, Numeral
 from pysmt.constants import (is_pysmt_fraction,
@@ -165,7 +165,7 @@ class FormulaManager(object):
          - Formula must be of boolean type
          - Variables must be BOOL, REAL or INT
         """
-        variables_tuple = tuple(variables)
+        variables_tuple = self._sorted_tuple(variables)
         if len(variables_tuple) == 0:
             return formula
         return self.create_node(node_type=op.FORALL,
@@ -180,7 +180,7 @@ class FormulaManager(object):
          - Formula must be of boolean type
          - Variables must be BOOL, REAL or INT
         """
-        variables_tuple = tuple(variables)
+        variables_tuple = self._sorted_tupletuple(variables)
         if len(variables_tuple) == 0:
             return formula
         return self.create_node(node_type=op.EXISTS,
@@ -225,7 +225,8 @@ class FormulaManager(object):
 
         Restriction: Left and Right must be of boolean type
         """
-        return self.create_node(node_type=op.IFF, args=(left, right))
+        return self.create_node(node_type=op.IFF,
+                                args=self._args_to_sorted_tuple(left, right))
 
     def Minus(self, left: FNode, right: FNode) -> FNode:
         """ Creates an expression of the form:
@@ -246,15 +247,14 @@ class FormulaManager(object):
          - Arguments must be all of the same type
          - Arguments must be INT or REAL
         """
-        tuple_args = self._polymorph_args_to_tuple(args)
+        tuple_args = self._args_to_sorted_tuple(args)
         if len(tuple_args) == 0:
             raise PysmtTypeError("Cannot create a Times without arguments.")
 
         if len(tuple_args) == 1:
             return tuple_args[0]
         else:
-            return self.create_node(node_type=op.TIMES,
-                                    args=tuple_args)
+            return self.create_node(node_type=op.TIMES, args=tuple_args)
 
     def Pow(self, base: FNode, exponent: FNode) -> FNode:
         """ Creates the n-th power of the base.
@@ -292,7 +292,7 @@ class FormulaManager(object):
         For the boolean case use Iff
         """
         return self.create_node(node_type=op.EQUALS,
-                                args=(left, right))
+                                args=self._args_to_sorted_tuple(left, right))
 
     def NotEquals(self, left: FNode, right: FNode):
         """ Creates an expression of the form: left != right"""
@@ -361,7 +361,7 @@ class FormulaManager(object):
         elif is_python_rational(value):
             val = pysmt_fraction_from_rational(value)
         else:
-            raise PysmtTypeError("Invalid type in constant. The type was:" + \
+            raise PysmtTypeError("Invalid type in constant. The type was:" +
                                  str(type(value)))
 
         n = self.create_node(node_type=op.REAL_CONSTANT,
@@ -380,7 +380,7 @@ class FormulaManager(object):
         elif is_python_integer(value):
             val = pysmt_integer_from_integer(value)
         else:
-            raise PysmtTypeError("Invalid type in constant. The type was:" + \
+            raise PysmtTypeError("Invalid type in constant. The type was:" +
                                  str(type(value)))
         n = self.create_node(node_type=op.INT_CONSTANT,
                              args=tuple(),
@@ -400,7 +400,7 @@ class FormulaManager(object):
             self.string_constants[value] = n
             return n
         else:
-            raise TypeError("Invalid type in constant. The type was:" + \
+            raise TypeError("Invalid type in constant. The type was:" +
                             str(type(value)))
 
     def TRUE(self) -> FNode:
@@ -412,13 +412,10 @@ class FormulaManager(object):
         return self.false_formula
 
     def Bool(self, value: bool) -> FNode:
-        if type(value) != bool:
+        if not isinstance(value, bool):
             raise PysmtTypeError("Expecting bool, got %s" % type(value))
 
-        if value:
-            return self.true_formula
-        else:
-            return self.false_formula
+        return self.true_formula if value else self.false_formula
 
     def And(self, *args: Union[FNode, Iterable[FNode]]) -> FNode:
         """ Returns a conjunction of terms.
@@ -429,7 +426,7 @@ class FormulaManager(object):
 
         Restriction: Arguments must be boolean
         """
-        tuple_args = self._polymorph_args_to_tuple(args)
+        tuple_args = self._args_to_sorted_tuple(args)
 
         if len(tuple_args) == 0:
             return self.TRUE()
@@ -448,7 +445,7 @@ class FormulaManager(object):
 
         Restriction: Arguments must be boolean
         """
-        tuple_args = self._polymorph_args_to_tuple(args)
+        tuple_args = self._args_to_sorted_tuple(args)
 
         if len(tuple_args) == 0:
             return self.FALSE()
@@ -469,7 +466,7 @@ class FormulaManager(object):
          - Arguments must be all of the same type
          - Arguments must be INT or REAL
         """
-        tuple_args = self._polymorph_args_to_tuple(args)
+        tuple_args = self._args_to_sorted_tuple(args)
         if len(tuple_args) == 0:
             raise PysmtTypeError("Cannot create a Plus without arguments.")
 
@@ -539,13 +536,12 @@ class FormulaManager(object):
            A -> !(B \\/ C)
            B -> !(C)
         """
-        bool_exprs = self._polymorph_args_to_tuple(args)
+        bool_exprs = self._args_to_sorted_tuple(args)
         constraints = []
         for (i, elem) in enumerate(bool_exprs[:-1], start=1):
             constraints.append(self.Implies(elem,
                                             self.Not(self.Or(bool_exprs[i:]))))
         return self.And(constraints)
-
 
     def ExactlyOne(self, *args: Union[FNode, Iterable[FNode]]) -> FNode:
         """ Encodes an exactly-one constraint on the boolean symbols.
@@ -555,7 +551,7 @@ class FormulaManager(object):
            A -> !(B \\/ C)
            B -> !(C)
         """
-        args = self._polymorph_args_to_tuple(args)
+        args = self._args_to_sorted_tuple(args)
         return self.And(self.Or(*args),
                         self.AtMostOne(*args))
 
@@ -565,7 +561,7 @@ class FormulaManager(object):
 
         AllDifferent(x, y, z) := (x != y) & (x != z) & (y != z)
         """
-        exprs = self._polymorph_args_to_tuple(args)
+        exprs = self._args_to_sorted_tuple(args)
         res = []
         for i, a in enumerate(exprs):
             for b in exprs[i+1:]:
@@ -578,7 +574,7 @@ class FormulaManager(object):
 
     def _MinWrap(self, le: Callable[[FNode, FNode], FNode], *args: Union[FNode, Iterable[FNode]]) -> FNode:
         """Returns the encoding of the minimum expression within args using the specified 'Lower-Equal' operator"""
-        exprs = self._polymorph_args_to_tuple(args)
+        exprs = self._args_to_sorted_tuple(args)
         assert len(exprs) > 0
         if len(exprs) == 1:
             return exprs[0]
@@ -591,7 +587,7 @@ class FormulaManager(object):
 
     def _MaxWrap(self, le: Callable[[FNode, FNode], FNode], *args: Union[FNode, Iterable[FNode]]) -> FNode:
         """Returns the encoding of the maximum expression within args using the specified 'Lower-Equal' operator"""
-        exprs = self._polymorph_args_to_tuple(args)
+        exprs = self._args_to_sorted_tuple(args)
         assert len(exprs) > 0
         if len(exprs) == 1:
             return exprs[0]
@@ -607,14 +603,14 @@ class FormulaManager(object):
         le = self.BVULE
         if sign:
             le = self.BVSLE
-        return self._MinWrap( le, *args)
+        return self._MinWrap(le, *args)
 
     def MaxBV(self, sign: bool, *args: Union[FNode, Iterable[FNode]]) -> FNode:
         """Returns the encoding of the maximum expression within args"""
         le = self.BVULE
         if sign:
             le = self.BVSLE
-        return self._MaxWrap( le, *args)
+        return self._MaxWrap(le, *args)
 
     def Min(self, *args: Union[FNode, Iterable[FNode]]) -> FNode:
         """Returns the encoding of the minimum expression within args"""
@@ -651,17 +647,17 @@ class FormulaManager(object):
 
         if isinstance(value, str):
             if value.startswith("#b"):
-                str_width = len(value)-2
-                value = int(value[2:],2)
+                str_width = len(value) - 2
+                value = int(value[2:], 2)
             elif all(v in ["0", "1"] for v in value):
                 str_width = len(value)
                 value = int(value, 2)
             else:
-                raise PysmtValueError("Expecting binary value as string, got " \
+                raise PysmtValueError("Expecting binary value as string, got "
                                       "%s instead." % value)
 
             if width is not None and width != str_width:
-                raise PysmtValueError("Specified width does not match string " \
+                raise PysmtValueError("Specified width does not match string "
                                       "width (%d != %d)" % (width, str_width))
             width = str_width
 
@@ -674,21 +670,20 @@ class FormulaManager(object):
             assert isinstance(value, int), "Non-accepted typing"
             _value = pysmt_integer_from_integer(value)
         else:
-            raise PysmtTypeError("Invalid type in constant. The type was: %s" \
+            raise PysmtTypeError("Invalid type in constant. The type was: %s"
                                  % str(type(value)))
         if _value < 0:
-            raise PysmtValueError("Cannot specify a negative value: %s" \
+            raise PysmtValueError("Cannot specify a negative value: %s"
                                   % (str(_value)))
         if _value >= 2**width:
-            raise PysmtValueError("Cannot express %s in %s bits" \
+            raise PysmtValueError("Cannot express %s in %s bits"
                                   % (str(_value), str(width)))
 
         return self.create_node(node_type=op.BV_CONSTANT,
                                 args=tuple(),
                                 payload=(_value, width))
 
-
-    def SBV(self, value: Union[int, str], width: Optional[int]=None) -> FNode:
+    def SBV(self, value: Union[int, str], width: Optional[int] = None) -> FNode:
         """Returns a constant of type BitVector interpreting the sign.
 
         If the specified value is an integer, it is converted in the
@@ -703,18 +698,18 @@ class FormulaManager(object):
             min_val = -(2**(width-1))
             max_val = (2**(width-1)) - 1
             if value < min_val:
-                raise PysmtValueError("Cannot represent a value (%s) lower " \
+                raise PysmtValueError("Cannot represent a value (%s) lower "
                                       "than %d in %d bits" % (str(value), min_val,
                                                               width))
             if value > max_val:
-                raise PysmtValueError("Cannot represent a value (%s) greater " \
+                raise PysmtValueError("Cannot represent a value (%s) greater "
                                       "than %d in %d bits" % (str(value), max_val,
                                                               width))
 
             if value >= 0:
                 return self.BV(value, width)
             else:
-                comp_value = (2**width) + value # value is negative!
+                comp_value = (2**width) + value  # value is negative!
                 return self.BV(comp_value, width)
         else:
             return self.BV(value, width=width)
@@ -734,55 +729,63 @@ class FormulaManager(object):
                                 payload=(formula.bv_width(),))
 
     def BVAnd(self, *args: Union[FNode, Sequence[FNode]]) -> FNode:
-        """Returns the Bit-wise AND of bitvectors of the same size.
-        If more than 2 arguments are passed, a left-associative formula is generated."""
-        args = self._polymorph_args_to_tuple(args)
+        """Returns the Bit-wise AND of bitvectors of the same size."""
+        args = self._args_to_sorted_tuple(args)
+
         if len(args) == 0:
             raise PysmtValueError("BVAnd expects at least one argument to be passed")
-        res = args[0]
-        for arg in args[1:]:
-            res = self.create_node(node_type=op.BV_AND,
-                             args=(res,arg),
-                             payload=(res.bv_width(),))
-        return res
+
+        if len(args) == 1:
+            return args[0]
+
+        assert all(v.bv_width() == args[0].bv_width() for v in args)
+        return self.create_node(node_type=op.BV_AND,
+                                args=args,
+                                payload=(args[0].bv_width(), ))
 
     def BVOr(self, *args: Union[FNode, Sequence[FNode]]) -> FNode:
-        """Returns the Bit-wise OR of bitvectors of the same size.
-        If more than 2 arguments are passed, a left-associative formula is generated."""
-        args = self._polymorph_args_to_tuple(args)
+        """Returns the Bit-wise OR of bitvectors of the same size."""
+        args = self._args_to_sorted_tuple(args)
+
         if len(args) == 0:
             raise PysmtValueError("BVOr expects at least one argument to be passed")
-        res = args[0]
-        for arg in args[1:]:
-            res = self.create_node(node_type=op.BV_OR,
-                             args=(res,arg),
-                             payload=(res.bv_width(),))
-        return res
+
+        if len(args) == 1:
+            return args[0]
+
+        assert all(v.bv_width() == args[0].bv_width() for v in args)
+        return self.create_node(node_type=op.BV_OR,
+                                args=args,
+                                payload=(args[0].bv_width(), ))
 
     def BVXor(self, left: FNode, right: FNode) -> FNode:
         """Returns the Bit-wise XOR of two bitvectors of the same size."""
         return self.create_node(node_type=op.BV_XOR,
-                                args=(left,right),
+                                args=self._args_to_sorted_tuple(left, right),
                                 payload=(left.bv_width(),))
 
     def BVConcat(self, *args: Union[FNode, Sequence[FNode]]) -> FNode:
         """Returns the Concatenation of the given BVs"""
-        ex = self._polymorph_args_to_tuple(args)
-        base = self.create_node(node_type=op.BV_CONCAT,
-                                args=(ex[0], ex[1]),
-                                payload=(ex[0].bv_width() + ex[1].bv_width(),))
-        for e in ex[2:]:
-            base = self.create_node(node_type=op.BV_CONCAT,
-                                    args=(base, e),
-                                    payload=(base.bv_width() + e.bv_width(),))
-        return base
+        args = self._args_to_tuple(args)
+        if len(args) == 0:
+            raise PysmtValueError("BVConcat expects at least one argument to be passed.")
+
+        if len(args) == 1:
+            return args[0]
+
+        return self.create_node(node_type=op.BV_CONCAT,
+                                args=args,
+                                payload=(sum(v.bv_width() for v in args), ))
 
     def BVExtract(self, formula: FNode, start: int=0, end: Optional[int]=None) -> FNode:
         """Returns the slice of formula from start to end (inclusive)."""
-        if end is None: end = formula.bv_width()-1
+        if end is None:
+            end = formula.bv_width() - 1
+
         assert is_python_integer(start) and is_python_integer(end)
         assert end >= start and start >= 0, "Start: %d ; End: %d" % (start,end)
-        size = end-start+1
+
+        size = end-start + 1
 
         assert size <= formula.bv_width(), \
             "Invalid size: start=%d, end=%d, width=%d" % \
@@ -793,23 +796,19 @@ class FormulaManager(object):
 
     def BVULT(self, left: FNode, right: FNode) -> FNode:
         """Returns the formula left < right."""
-        return self.create_node(node_type=op.BV_ULT,
-                                args=(left, right))
+        return self.create_node(node_type=op.BV_ULT, args=(left, right))
 
     def BVUGT(self, left: FNode, right: FNode) -> FNode:
         """Returns the formula left > right."""
-        return self.create_node(node_type=op.BV_ULT,
-                                args=(right, left))
+        return self.create_node(node_type=op.BV_ULT, args=(right, left))
 
     def BVULE(self, left: FNode, right: FNode) -> FNode:
         """Returns the formula left <= right."""
-        return self.create_node(node_type=op.BV_ULE,
-                                args=(left, right))
+        return self.create_node(node_type=op.BV_ULE, args=(left, right))
 
     def BVUGE(self, left: FNode, right: FNode) -> FNode:
         """Returns the formula left >= right."""
-        return self.create_node(node_type=op.BV_ULE,
-                                args=(right, left))
+        return self.create_node(node_type=op.BV_ULE, args=(right, left))
 
     def BVNeg(self, formula: FNode) -> FNode:
         """Returns the arithmetic negation of the BV."""
@@ -818,17 +817,19 @@ class FormulaManager(object):
                                 payload=(formula.bv_width(),))
 
     def BVAdd(self, *args: Union[FNode, Sequence[FNode]]) -> FNode:
-        """Returns the sum of BV.
-        If more than 2 arguments are passed, a left-associative formula is generated."""
-        args = self._polymorph_args_to_tuple(args)
+        """Returns the sum of BV."""
+        args = self._args_to_sorted_tuple(args)
+
         if len(args) == 0:
             raise PysmtValueError("BVAdd expects at least one argument to be passed")
-        res = args[0]
-        for arg in args[1:]:
-            res = self.create_node(node_type=op.BV_ADD,
-                             args=(res,arg),
-                             payload=(res.bv_width(),))
-        return res
+
+        if len(args) == 1:
+            return args[0]
+
+        assert all(v.bv_width() == args[0].bv_width() for v in args)
+        return self.create_node(node_type=op.BV_ADD,
+                                args=args,
+                                payload=(args[0].bv_width(),))
 
     def BVSub(self, left: FNode, right: FNode) -> FNode:
         """Returns the difference of two BV."""
@@ -837,17 +838,19 @@ class FormulaManager(object):
                                 payload=(left.bv_width(),))
 
     def BVMul(self, *args: Union[FNode, Sequence[FNode]]) -> FNode:
-        """Returns the product of BV.
-        If more than 2 arguments are passed, a left-associative formula is generated."""
-        args = self._polymorph_args_to_tuple(args)
+        """Returns the product of BV."""
+        args = self._args_to_sorted_tuple(args)
+
         if len(args) == 0:
             raise PysmtValueError("BVMul expects at least one argument to be passed")
-        res = args[0]
-        for arg in args[1:]:
-            res = self.create_node(node_type=op.BV_MUL,
-                             args=(res,arg),
-                             payload=(res.bv_width(),))
-        return res
+
+        if len(args) == 1:
+            return args[0]
+
+        assert all(v.bv_width() == args[0].bv_width() for v in args)
+        return self.create_node(node_type=op.BV_MUL,
+                                args=args,
+                                payload=(args[0].bv_width(),))
 
     def BVUDiv(self, left: FNode, right: FNode) -> FNode:
         """Returns the division of the two BV."""
@@ -882,7 +885,7 @@ class FormulaManager(object):
     def BVRol(self, formula: FNode, steps: int) -> FNode:
         """Returns the LEFT rotation of the BV by the number of steps."""
         if not is_python_integer(steps):
-            raise PysmtTypeError("BVRol: 'steps' should be an integer. Got %s" \
+            raise PysmtTypeError("BVRol: 'steps' should be an integer. Got %s"
                                  % steps)
         return self.create_node(node_type=op.BV_ROL,
                                 args=(formula,),
@@ -891,7 +894,7 @@ class FormulaManager(object):
     def BVRor(self, formula: FNode, steps: int) -> FNode:
         """Returns the RIGHT rotation of the BV by the number of steps."""
         if not is_python_integer(steps):
-            raise PysmtTypeError("BVRor: 'steps' should be an integer. Got %s" \
+            raise PysmtTypeError("BVRor: 'steps' should be an integer. Got %s"
                                  % steps)
         return self.create_node(node_type=op.BV_ROR,
                                 args=(formula,),
@@ -907,7 +910,7 @@ class FormulaManager(object):
                                  "Got %s" % increase)
         return self.create_node(node_type=op.BV_ZEXT,
                                 args=(formula,),
-                                payload=(formula.bv_width()+increase,
+                                payload=(formula.bv_width() + increase,
                                          increase))
 
     def BVSExt(self, formula: FNode, increase: int) -> FNode:
@@ -920,18 +923,16 @@ class FormulaManager(object):
                                  "Got %s" % increase)
         return self.create_node(node_type=op.BV_SEXT,
                                 args=(formula,),
-                                payload=(formula.bv_width()+increase,
+                                payload=(formula.bv_width() + increase,
                                          increase))
 
     def BVSLT(self, left: FNode, right: FNode) -> FNode:
         """Returns the SIGNED LOWER-THAN comparison for BV."""
-        return self.create_node(node_type=op.BV_SLT,
-                                args=(left, right))
+        return self.create_node(node_type=op.BV_SLT, args=(left, right))
 
     def BVSLE(self, left: FNode, right: FNode) -> FNode:
         """Returns the SIGNED LOWER-THAN-OR-EQUAL-TO comparison for BV."""
-        return self.create_node(node_type=op.BV_SLE,
-                                args=(left, right))
+        return self.create_node(node_type=op.BV_SLE, args=(left, right))
 
     def BVComp(self, left: FNode, right: FNode) -> FNode:
         """Returns a BV of size 1 equal to 0 if left is equal to right,
@@ -1026,12 +1027,9 @@ class FormulaManager(object):
         return self.Ite(self.Or(cond1, cond2), u,
                         self.Ite(cond3, case3, self.Ite(cond4, case4, case5)))
 
-    def BVRepeat(self, formula: FNode, count: int=1) -> FNode:
+    def BVRepeat(self, formula: FNode, count: int = 1) -> FNode:
         """Returns the concatenation of count copies of formula."""
-        res = formula
-        for _ in range(count-1):
-            res = self.BVConcat(res, formula)
-        return res
+        return self.BVConcat((formula,) * count)
 
     def StrLength(self, formula: FNode) -> FNode:
         """Returns the length of a formula resulting a String"""
@@ -1041,15 +1039,20 @@ class FormulaManager(object):
         """Returns the concatenation of n Strings.
 
         s1, s2, ..., and sn are String terms.
-        String concatenation takes at least 2 arguments.
+        String concatenation requires at least 1 arguments.
+        String concatenation of 1 argument returns the String given as argument.
         """
-        tuple_args = self._polymorph_args_to_tuple(args)
-        if len(tuple_args) <= 1:
+        tuple_args = self._args_to_tuple(args)
+        if len(tuple_args) == 0:
             raise TypeError("Cannot create a Str_Concat without arguments.")
+
+        if len(tuple_args) == 1:
+            return tuple_args[0]
+
         return self.create_node(node_type=op.STR_CONCAT, args=tuple_args)
 
     def StrContains(self, s: FNode, t: FNode) -> FNode:
-        """Returns wether the String s contains the String t.
+        """Returns whether the String s contains the String t.
 
         s and t are String terms.
         """
@@ -1144,7 +1147,7 @@ class FormulaManager(object):
             for k in sorted(assigned_values, key=id):
                 if not k.is_constant():
                     raise PysmtValueError("Array initialization indexes must "
-                                          "be constants")
+                                          "be constants.")
                 # It is useless to represent assignments equal to the default
                 if assigned_values[k] != default:
                     args.append(k)
@@ -1176,7 +1179,7 @@ class FormulaManager(object):
 
         return assert_not_none(self._normalizer).walk(formula)
 
-    def _polymorph_args_to_tuple(self, args: Sequence[Union[FNode, Iterable[FNode]]]) -> Tuple[FNode, ...]:
+    def _args_to_tuple(self, args: Sequence[Union[FNode, Iterable[FNode]]]) -> Tuple[FNode, ...]:
         """ Helper function to return a tuple of arguments from args.
 
         This function is used to allow N-ary operators to express their arguments
@@ -1188,11 +1191,30 @@ class FormulaManager(object):
             itargs: Iterable[FNode] = args[0]
         else:
             itargs = cast(Sequence[FNode], args)
+
         def _check_fnode(f: Union[FNode, Iterable[FNode]]) -> FNode:
             if not isinstance(f, FNode):
                 raise PysmtTypeError("Typing not respected")
             return f
         return tuple(map(_check_fnode, itargs))
+
+    def _sorted_tuple(self, nodes: Iterable[FNode]) -> Tuple[FNode, ...]:
+        """Build sorted tuple of FNode from iterable of FNode"""
+        result = tuple(sorted(nodes, key=lambda p: p.node_id()))
+
+        if not all(isinstance(res, FNode) for res in result):
+            raise PysmtTypeError("Typing not respected")
+
+        return result
+
+    def _args_to_sorted_tuple(self, args: Sequence[Union[FNode, Iterable[FNode]]]) -> Tuple[FNode, ...]:
+        """Helper function to return a sorted tuple of arguments from args.
+        This function is used to allow N-ary commutative operators to express
+        their arguments both as a list of arguments or as a tuple of arguments:
+          e.g. And([a,b,c]) and And(a,b,c)
+        are both valid, and they are converted into a sorted tuple (a,b,c)."""
+
+        return self._sorted_tuple(self._args_to_tuple(args))
 
     def __contains__(self, node: FNode) -> bool:
         """Checks whether the given node belongs to this formula manager.

--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -475,8 +475,7 @@ class FormulaManager(object):
         if len(tuple_args) == 1:
             return tuple_args[0]
         else:
-            return self.create_node(node_type=op.PLUS,
-                                    args=tuple_args)
+            return self.create_node(node_type=op.PLUS, args=tuple_args)
 
     def ToReal(self, formula: FNode) -> FNode:
         """ Cast a formula to real type. """
@@ -755,16 +754,23 @@ class FormulaManager(object):
         if len(args) == 1:
             return args[0]
 
-        assert all(v.bv_width() == args[0].bv_width() for v in args)
         return self.create_node(node_type=op.BV_OR,
                                 args=args,
                                 payload=(args[0].bv_width(), ))
 
-    def BVXor(self, left: FNode, right: FNode) -> FNode:
-        """Returns the Bit-wise XOR of two bitvectors of the same size."""
+    def BVXor(self, *args: Union[FNode, Sequence[FNode]]) -> FNode:
+        """Returns the Bit-wise XOR of bitvectors of the same size."""
+        args = self._args_to_sorted_tuple(args)
+
+        if len(args) == 0:
+            raise PysmtValueError("BVXOr expects at least one argument to be passed")
+
+        if len(args) == 1:
+            return args[0]
+
         return self.create_node(node_type=op.BV_XOR,
-                                args=self._sorted_tuple((left, right)),
-                                payload=(left.bv_width(),))
+                                args=args,
+                                payload=(args[0].bv_width(), ))
 
     def BVConcat(self, *args: Union[FNode, Sequence[FNode]]) -> FNode:
         """Returns the Concatenation of the given BVs"""
@@ -828,7 +834,6 @@ class FormulaManager(object):
         if len(args) == 1:
             return args[0]
 
-        assert all(v.bv_width() == args[0].bv_width() for v in args)
         return self.create_node(node_type=op.BV_ADD,
                                 args=args,
                                 payload=(args[0].bv_width(),))
@@ -849,7 +854,6 @@ class FormulaManager(object):
         if len(args) == 1:
             return args[0]
 
-        assert all(v.bv_width() == args[0].bv_width() for v in args)
         return self.create_node(node_type=op.BV_MUL,
                                 args=args,
                                 payload=(args[0].bv_width(),))
@@ -1197,16 +1201,20 @@ class FormulaManager(object):
 
         def _check_fnode(f: Union[FNode, Iterable[FNode]]) -> FNode:
             if not isinstance(f, FNode):
-                raise PysmtTypeError("Typing not respected")
+                raise PysmtTypeError("Typing not respected expected FNode found: %s" % type(f))
             return f
         return tuple(map(_check_fnode, itargs))
 
     def _sorted_tuple(self, nodes: Iterable[FNode]) -> Tuple[FNode, ...]:
         """Build sorted tuple of FNode from iterable of FNode"""
-        result = tuple(sorted(nodes, key=lambda p: p.node_id()))
+        # skip sorting if not enabled.
+        if self.env.sort_commutative_args:
+            nodes = sorted(nodes, key=lambda p: p.node_id())
+
+        result = tuple(nodes)
 
         if not all(isinstance(res, FNode) for res in result):
-            raise PysmtTypeError("Typing not respected")
+            raise PysmtTypeError("Typing not respected expected")
 
         return result
 

--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -741,7 +741,6 @@ class FormulaManager(object):
         if len(args) == 1:
             return args[0]
 
-        assert all(v.bv_width() == args[0].bv_width() for v in args)
         return self.create_node(node_type=op.BV_AND,
                                 args=args,
                                 payload=(args[0].bv_width(), ))

--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -90,10 +90,10 @@ class FormulaManager(object):
 
     def _do_type_check(self, formula: FNode):
         self.get_type = self.env.stc.get_type
-        self._do_type_check = self._do_type_check_real # type: ignore[method-assign]
+        self._do_type_check = self._do_type_check_real  # type: ignore[method-assign]
         return self._do_type_check(formula)
 
-    def create_node(self, node_type: int, args: Tuple[FNode, ...], payload: Optional[Any]=None) -> FNode:
+    def create_node(self, node_type: int, args: Tuple[FNode, ...], payload: Optional[Any] = None) -> FNode:
         content = FNodeContent(node_type, args, payload)
         if content in self.formulae:
             n = self.formulae[content]
@@ -106,7 +106,7 @@ class FormulaManager(object):
             self._do_type_check(n)
             return n
 
-    def _create_symbol(self, name: str, typename: PySMTType=types.BOOL) -> FNode:
+    def _create_symbol(self, name: str, typename: PySMTType = types.BOOL) -> FNode:
         if len(name) == 0 and not self.env.allow_empty_var_names:
             raise PysmtEmptySymbolNameError()
         if not isinstance(typename, types.PySMTType):
@@ -117,7 +117,8 @@ class FormulaManager(object):
         self.symbols[name] = n
         return n
 
-    def new_fresh_symbol(self, typename: PySMTType, base: str="FV%d") -> FNode:
+    def new_fresh_symbol(self, typename: PySMTType,
+                         base: str = "FV%d") -> FNode:
         count = self._fresh_guess
         while (base % count) in self.symbols:
             count = count + 1
@@ -149,10 +150,11 @@ class FormulaManager(object):
 
     # Node definitions start here
 
-    def Symbol(self, name: str, typename: PySMTType=types.BOOL) -> FNode:
+    def Symbol(self, name: str, typename: PySMTType = types.BOOL) -> FNode:
         return self.get_or_create_symbol(name, typename)
 
-    def FreshSymbol(self, typename: PySMTType=types.BOOL, template: Optional[str]=None) -> FNode:
+    def FreshSymbol(self, typename: PySMTType = types.BOOL,
+                    template: Optional[str] = None) -> FNode:
         if template is None:
             return self.new_fresh_symbol(typename)
         return self.new_fresh_symbol(typename, template)
@@ -180,7 +182,7 @@ class FormulaManager(object):
          - Formula must be of boolean type
          - Variables must be BOOL, REAL or INT
         """
-        variables_tuple = self._sorted_tupletuple(variables)
+        variables_tuple = self._sorted_tuple(variables)
         if len(variables_tuple) == 0:
             return formula
         return self.create_node(node_type=op.EXISTS,
@@ -226,7 +228,7 @@ class FormulaManager(object):
         Restriction: Left and Right must be of boolean type
         """
         return self.create_node(node_type=op.IFF,
-                                args=self._args_to_sorted_tuple(left, right))
+                                args=self._sorted_tuple((left, right)))
 
     def Minus(self, left: FNode, right: FNode) -> FNode:
         """ Creates an expression of the form:
@@ -292,7 +294,7 @@ class FormulaManager(object):
         For the boolean case use Iff
         """
         return self.create_node(node_type=op.EQUALS,
-                                args=self._args_to_sorted_tuple(left, right))
+                                args=self._sorted_tuple((left, right)))
 
     def NotEquals(self, left: FNode, right: FNode):
         """ Creates an expression of the form: left != right"""
@@ -596,7 +598,7 @@ class FormulaManager(object):
             return self.Ite(le(a, b), b, a)
         else:
             h = len(exprs) // 2
-            return self._MaxWrap(le, self._MaxWrap(le,exprs[0:h]), self._MaxWrap(le,exprs[h:]))
+            return self._MaxWrap(le, self._MaxWrap(le, exprs[0:h]), self._MaxWrap(le, exprs[h:]))
 
     def MinBV(self, sign: bool, *args: Union[FNode, Iterable[FNode]]) -> FNode:
         """Returns the encoding of the minimum expression within args"""
@@ -633,7 +635,7 @@ class FormulaManager(object):
             return self.Equals(left, right)
 
     # BitVectors
-    def BV(self, value: Union[str, int], width: Optional[int]=None) -> FNode:
+    def BV(self, value: Union[str, int], width: Optional[int] = None) -> FNode:
         """Return a constant of type BitVector.
 
         value can be either:
@@ -665,7 +667,8 @@ class FormulaManager(object):
             raise PysmtValueError("Need to specify a width for the constant")
 
         if is_pysmt_integer(value):
-            _value = cast(int, value) #TODO: this is incorrect, we should define a custom "Integer" type including mpz. Try with IntegerClass from constants
+            # TODO: this is incorrect, we should define a custom "Integer" type including mpz. Try with IntegerClass from constants
+            _value = cast(int, value)
         elif is_python_integer(value):
             assert isinstance(value, int), "Non-accepted typing"
             _value = pysmt_integer_from_integer(value)
@@ -699,12 +702,12 @@ class FormulaManager(object):
             max_val = (2**(width-1)) - 1
             if value < min_val:
                 raise PysmtValueError("Cannot represent a value (%s) lower "
-                                      "than %d in %d bits" % (str(value), min_val,
-                                                              width))
+                                      "than %d in %d bits" %
+                                      (str(value), min_val, width))
             if value > max_val:
                 raise PysmtValueError("Cannot represent a value (%s) greater "
-                                      "than %d in %d bits" % (str(value), max_val,
-                                                              width))
+                                      "than %d in %d bits" %
+                                      (str(value), max_val, width))
 
             if value >= 0:
                 return self.BV(value, width)
@@ -761,7 +764,7 @@ class FormulaManager(object):
     def BVXor(self, left: FNode, right: FNode) -> FNode:
         """Returns the Bit-wise XOR of two bitvectors of the same size."""
         return self.create_node(node_type=op.BV_XOR,
-                                args=self._args_to_sorted_tuple(left, right),
+                                args=self._sorted_tuple((left, right)),
                                 payload=(left.bv_width(),))
 
     def BVConcat(self, *args: Union[FNode, Sequence[FNode]]) -> FNode:
@@ -777,13 +780,13 @@ class FormulaManager(object):
                                 args=args,
                                 payload=(sum(v.bv_width() for v in args), ))
 
-    def BVExtract(self, formula: FNode, start: int=0, end: Optional[int]=None) -> FNode:
+    def BVExtract(self, formula: FNode, start: int = 0, end: Optional[int] = None) -> FNode:
         """Returns the slice of formula from start to end (inclusive)."""
         if end is None:
             end = formula.bv_width() - 1
 
         assert is_python_integer(start) and is_python_integer(end)
-        assert end >= start and start >= 0, "Start: %d ; End: %d" % (start,end)
+        assert end >= start and start >= 0, "Start: %d ; End: %d" % (start, end)
 
         size = end-start + 1
 
@@ -1131,7 +1134,8 @@ class FormulaManager(object):
         """Creates a node representing an array update."""
         return self.create_node(node_type=op.ARRAY_STORE, args=(arr, idx, val))
 
-    def Array(self, idx_type: PySMTType, default: FNode, assigned_values: Optional[Dict[FNode, FNode]]=None) -> FNode:
+    def Array(self, idx_type: PySMTType, default: FNode,
+              assigned_values: Optional[Dict[FNode, FNode]] = None) -> FNode:
         """Creates a node representing an array having index type equal to
            idx_type, initialized with default values.
 
@@ -1227,14 +1231,13 @@ class FormulaManager(object):
             return self.formulae[node._content] == node
         else:
             return False
-
-#EOC FormulaManager
+# EOC FormulaManager
 
 
 class FormulaContextualizer(IdentityDagWalker):
     """Helper class to recreate a formula within a new environment."""
 
-    def __init__(self, env: Optional["pysmt.environment.Environment"]=None):
+    def __init__(self, env: Optional["pysmt.environment.Environment"] = None):
         IdentityDagWalker.__init__(self, env=env)
         self.type_normalize = self.env.type_manager.normalize
 

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -27,7 +27,7 @@ properties of formulae.
 """
 
 from itertools import chain
-from typing import FrozenSet, Iterable, List, Any, Optional, Union, cast
+from typing import FrozenSet, Iterable, List, Optional, cast
 
 import pysmt
 import pysmt.walkers as walkers

--- a/pysmt/shortcuts.py
+++ b/pysmt/shortcuts.py
@@ -514,7 +514,7 @@ def BVOr(*args: Union[FNode, Sequence[FNode]]) -> FNode:
     return get_env().formula_manager.BVOr(*args)
 
 
-def BVXor(left: FNode, right: FNode) -> FNode:
+def BVXor(*args: Union[FNode, Sequence[FNode]]) -> FNode:
     """Returns the Bit-wise XOR of two bitvectors of the same size.
 
     :param left: Specify the left bitvector
@@ -522,7 +522,7 @@ def BVXor(left: FNode, right: FNode) -> FNode:
     :returns: The bit-wise XOR of left and right
     :rtype: FNode
     """
-    return get_env().formula_manager.BVXor(left, right)
+    return get_env().formula_manager.BVXor(*args)
 
 
 def BVConcat(*args: Union[FNode, Sequence[FNode]]) -> FNode:

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -475,38 +475,6 @@ class Simplifier(pysmt.walkers.DagWalker):
         # Folding of real constants is done by the FormulaManager
         return self.manager.ToInt(args[0])
 
-    def walk_bv_and(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
-        simplified = None
-        width = formula.bv_width()
-
-        if args[0].is_bv_constant():
-            lhs = args[0].bv_unsigned_value()
-
-            if lhs == 0:
-                # 0 & x -> 0
-                simplified = self.manager.BVZero(width)
-            elif lhs == 2**width - 1:
-                # 0xf...f & x -> x
-                simplified = args[1]
-            elif args[1].is_bv_constant():
-                rhs = args[1].bv_unsigned_value()
-                res = lhs & rhs
-                simplified = self.manager.BV(res, width=width)
-        elif args[1].is_bv_constant():
-            rhs = args[1].bv_unsigned_value()
-
-            if rhs == 0:
-                # x & 0 -> 0
-                simplified = self.manager.BVZero(width)
-            elif rhs == 2**width - 1:
-                # x & 0xf...f -> x
-                simplified = args[0]
-
-        if simplified is not None:
-            return simplified
-
-        return self.manager.BVAnd(args[0], args[1])
-
     def walk_bv_not(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
         if args[0].is_bv_constant():
             res = ~cast(int, args[0].constant_value()) & (2**formula.bv_width() - 1)
@@ -520,100 +488,134 @@ class Simplifier(pysmt.walkers.DagWalker):
             return self.manager.BV(res, width=formula.bv_width())
         return self.manager.BVNeg(args[0])
 
+    def walk_bv_and(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
+        width: int = formula.bv_width()
+
+        all_ones: int = (2 ** width) - 1
+        # drop duplicates
+        # `seen` separate from `new_args` to keep order of args.
+        seen = set()
+        # accumulate And of constant values.
+        bv_const: int = all_ones
+        new_args: List[FNode] = []
+
+        for arg in args:
+            if arg.is_bv_constant():
+                value: int = cast(int, arg.bv_unsigned_value())
+                if value == 0:
+                    return self.manager.BVZero(width)
+                # drop all ones.
+                if value != all_ones:
+                    # bit-wise & with bv_const
+                    bv_const &= value
+            # ignore duplicates: a & a <-> a
+            elif arg not in seen:
+                new_args.append(arg)
+                seen.add(arg)
+
+        if bv_const != all_ones or len(new_args) == 0:
+            # constant value always ends up at the end.
+            new_args.append(self.manager.BV(bv_const, width=width))
+        return self.manager.BVAnd(new_args)
+
     def walk_bv_or(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
-        simplified = None
+        width: int = formula.bv_width()
 
-        if args[0].is_bv_constant():
-            lhs = args[0].bv_unsigned_value()
+        all_ones: int = (2 ** width) - 1
+        # drop duplicates
+        # `seen` separate from `new_args` to keep order of args.
+        seen = set()
+        # accumulate And of constant values.
+        bv_const: int = 0
+        new_args: List[FNode] = []
 
-            if lhs == 0:
-                # 0 | x -> x
-                simplified = args[1]
-            else:
-                width = formula.bv_width()
-                mask = 2**width - 1
+        for arg in args:
+            if arg.is_bv_constant():
+                value: int = cast(int, arg.bv_unsigned_value())
+                if value == all_ones:
+                    return self.manager.BV(all_ones, width=width)
+                # drop zeros.
+                if value != 0:
+                    # bit-wise & with bv_const
+                    bv_const |= value
+            # ignore duplicates: a & a <-> a
+            elif arg not in seen:
+                new_args.append(arg)
+                seen.add(arg)
 
-                if lhs == mask:
-                    # 0xf...f | x -> 0xf...f
-                    simplified = self.manager.BV(mask, width=width)
-                elif args[1].is_constant():
-                    res = lhs | args[1].bv_unsigned_value()
-                    simplified = self.manager.BV(res, width=width)
-        elif args[1].is_bv_constant():
-            rhs = args[1].bv_unsigned_value()
-
-            if rhs == 0:
-                # x | 0 -> x
-                simplified = args[0]
-            else:
-                width = formula.bv_width()
-                mask = 2**width - 1
-                if rhs == mask:
-                    # x | 0xf...f -> 0xf...f
-                    simplified = self.manager.BV(mask, width=width)
-
-        if simplified is not None:
-            return simplified
-
-        return self.manager.BVOr(args[0], args[1])
+        if bv_const != 0 or len(new_args) == 0:
+            # constant value always ends up at the end.
+            new_args.append(self.manager.BV(bv_const, width=width))
+        return self.manager.BVOr(new_args)
 
     def walk_bv_xor(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
-        if args[0].is_bv_constant() and args[1].is_bv_constant():
-            res = cast(int, args[0].constant_value()) ^ cast(int, args[1].constant_value())
-            return self.manager.BV(res, width=formula.bv_width())
-        return self.manager.BVXor(args[0], args[1])
+        width: int = formula.bv_width()
+
+        # TODO: replace all FNodes occurring an even number of times with bv0.
+        # TODO: keep at most 1 bv0.
+        # TODO: retain only 1 occurrance map all FNodes occurring even number of times to 0s.
+
+        # accumulate And of constant values.
+        bv_const: Optional[int] = None
+        new_args: List[FNode] = []
+        for arg in args:
+            if arg.is_bv_constant():
+                value: int = cast(int, arg.bv_unsigned_value())
+                if bv_const is None:
+                    bv_const = value
+                else:
+                    bv_const ^= value
+            else:
+                new_args.append(arg)
+
+        if bv_const is not None:
+            # constant value always ends up at the end.
+            new_args.append(self.manager.BV(bv_const, width=width))
+
+        return self.manager.BVXor(new_args)
 
     def walk_bv_add(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
-        simplified = None
+        width: int = formula.bv_width()
+        bound: int = 2 ** width
 
-        if args[0].is_bv_constant():
-            lhs = args[0].bv_unsigned_value()
-            if lhs == 0:
-                # 0 + args[1] -> args[1]
-                simplified = args[1]
-            elif args[1].is_bv_constant():
-                width = formula.bv_width()
-                res = lhs + args[1].bv_unsigned_value()
-                res = res % 2**width
-                simplified = self.manager.BV(res, width=width)
-        elif args[1].is_bv_constant() and args[1].bv_unsigned_value() == 0:
-            # args[0] + 0 -> args[0]
-            simplified = args[0]
+        bv_const: int = 0
+        new_args: List[FNode] = []
+        for arg in args:
+            if arg.is_bv_constant():
+                value: int = cast(int, arg.bv_unsigned_value())
+                if value != 0:
+                    bv_const += value
+                    bv_const %= bound
+            else:
+                new_args.append(arg)
 
-        if simplified is not None:
-            return simplified
+        if bv_const != 0 or len(new_args) == 0:
+            new_args.append(self.manager.BV(bv_const, width=width))
 
-        return self.manager.BVAdd(args[0], args[1])
+        return self.manager.BVAdd(new_args)
 
     def walk_bv_mul(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
-        simplified = None
+        width: int = formula.bv_width()
+        bound: int = 2 ** width
 
-        if args[0].is_bv_constant():
-            lhs = args[0].bv_unsigned_value()
-            if lhs == 0:
-                # 0 * args[1] -> 0
-                simplified = self.manager.BVZero(formula.bv_width())
-            elif lhs == 1:
-                # 1 * args[1] -> args[1]
-                simplified = args[1]
-            elif args[1].is_bv_constant():
-                width = formula.bv_width()
-                res = lhs * args[1].bv_unsigned_value()
-                res = res % 2**width
-                simplified = self.manager.BV(res, width=width)
-        elif args[1].is_bv_constant():
-            rhs = args[1].bv_unsigned_value()
-            if rhs == 0:
-                # args[0] * 0 -> 0
-                simplified = self.manager.BVZero(formula.bv_width())
-            elif rhs == 1:
-                # args[0] * 1 -> args[0]
-                simplified = args[0]
+        bv_const: int = 1
+        new_args: list[FNode] = []
 
-        if simplified is not None:
-            return simplified
+        for arg in args:
+            if arg.is_bv_constant():
+                value: int = cast(int, arg.bv_unsigned_value())
+                if value == 0:
+                    return self.manager.BVZero(width)
+                if value != 1:
+                    bv_const *= value
+                    bv_const %= bound
+            else:
+                new_args.append(arg)
 
-        return self.manager.BVMul(args[0], args[1])
+        if bv_const != 1 or len(new_args) == 0:
+            new_args.append(self.manager.BV(bv_const, width))
+
+        return self.manager.BVMul(new_args)
 
     def walk_bv_udiv(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
         simplified = None
@@ -750,13 +752,30 @@ class Simplifier(pysmt.walkers.DagWalker):
         return self.manager.BVZExt(args[0], formula.bv_extend_step())
 
     def walk_bv_concat(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
-        if args[0].is_bv_constant() and args[1].is_bv_constant():
-            w0 = args[0].bv_width()
-            w1 = args[1].bv_width()
-            res = (2**w1) * args[0].bv_unsigned_value() + \
-                  args[1].bv_unsigned_value()
-            return self.manager.BV(res, w1 + w0)
-        return self.manager.BVConcat(args[0], args[1])
+
+        bv_acc_value: int = 0
+        bv_acc_width: int = 0
+        new_args: List[FNode] = []
+
+        for arg in args:
+            if arg.is_bv_constant():
+                value: int = cast(int, arg.bv_unsigned_value())
+                bv_acc_value *= 2 ** arg.bv_width()
+                bv_acc_value += value
+                bv_acc_width += arg.bv_width()
+            else:
+                if bv_acc_width != 0:
+                    # we have some accumulated constant to add first.
+                    new_args.append(self.manager.BV(bv_acc_value, width=bv_acc_width))
+                    bv_acc_value = 0
+                    bv_acc_width = 0
+                new_args.append(arg)
+
+        if bv_acc_width != 0:
+            new_args.append(self.manager.BV(bv_acc_value, width=bv_acc_width))
+            del bv_acc_value, bv_acc_width
+
+        return self.manager.BVConcat(new_args)
 
     def walk_bv_lshl(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
         simplified = None

--- a/pysmt/solvers/btor.py
+++ b/pysmt/solvers/btor.py
@@ -46,7 +46,7 @@ except ImportError:
 
 from pysmt.solvers.solver import (IncrementalTrackingSolver, UnsatCoreSolver,
                                   Converter, SolverOptions)
-from pysmt.solvers.smtlib import SmtLibBasicSolver, SmtLibIgnoreMixin
+from pysmt.solvers.smtlib import SmtLibBasicSolver
 from pysmt.solvers.eager import EagerModel
 from pysmt.walkers import DagWalker
 from pysmt.exceptions import (SolverReturnedUnknownResultError,
@@ -399,16 +399,14 @@ class BTORConverter(Converter, DagWalker):
         return decl
 
     def walk_and(self, formula, args, **kwargs):
-        assert len(args) >= 2
-        res = self._btor.And(args[0], args[1])
-        for conj in args[2:]:
+        res = args[0]
+        for conj in args[1:]:
             res = self._btor.And(res, conj)
         return res
 
     def walk_or(self, formula, args, **kwargs):
-        assert len(args) >= 2
-        res = self._btor.Or(args[0], args[1])
-        for disj in args[2:]:
+        res = args[0]
+        for disj in args[1:]:
             res = self._btor.Or(res, disj)
         return res
 
@@ -476,7 +474,10 @@ class BTORConverter(Converter, DagWalker):
         return self._btor.Ulte(args[0], args[1])
 
     def walk_bv_concat(self, formula, args, **kwargs):
-        return self._btor.Concat(args[0], args[1])
+        res = args[0]
+        for arg in args[1:]:
+            res = self._btor.Concat(res, arg)
+        return res
 
     def walk_bv_extract(self, formula, args, **kwargs):
         start = formula.bv_extract_start()
@@ -496,7 +497,10 @@ class BTORConverter(Converter, DagWalker):
         return self._btor.Xor(*args)
 
     def walk_bv_add(self, formula, args, **kwargs):
-        return self._btor.Add(args[0], args[1])
+        res = args[0]
+        for arg in args[1:]:
+            res = self._btor.Add(res, arg)
+        return res
 
     def walk_bv_sub(self, formula, args, **kwargs):
         return self._btor.Sub(args[0], args[1])
@@ -505,7 +509,10 @@ class BTORConverter(Converter, DagWalker):
         return -args[0]
 
     def walk_bv_mul(self, formula, args, **kwargs):
-        return args[0]*args[1]
+        res = args[0]
+        for arg in args[1:]:
+            res *= arg
+        return res
 
     def walk_bv_udiv(self, formula, args, **kwargs):
         return args[0] / args[1]

--- a/pysmt/solvers/btor.py
+++ b/pysmt/solvers/btor.py
@@ -494,7 +494,10 @@ class BTORConverter(Converter, DagWalker):
         return self.walk_and(formula, args, **kwargs)
 
     def walk_bv_xor(self, formula, args, **kwargs):
-        return self._btor.Xor(*args)
+        res = args[0]
+        for arg in args[1:]:
+            res = self._btor.Xor(res, arg)
+        return res
 
     def walk_bv_add(self, formula, args, **kwargs):
         res = args[0]

--- a/pysmt/solvers/cvcfive.py
+++ b/pysmt/solvers/cvcfive.py
@@ -418,19 +418,19 @@ class CVC5Converter(Converter, DagWalker):
     def walk_bv_concat(self, formula, args, **kwargs):
         res = args[0]
         for arg in args[1:]:
-            res = self.cvc5.mkTerm(Kind.BITVECTOR_CONCAT, res, arg)
+            res = self.cvc5_solver.mkTerm(Kind.BITVECTOR_CONCAT, res, arg)
         return res
 
     def walk_bv_extract(self, formula, args, **kwargs):
         ext = self.cvc5_solver.mkOp(Kind.BITVECTOR_EXTRACT,
-                             formula.bv_extract_end(),
-                             formula.bv_extract_start())
+                                    formula.bv_extract_end(),
+                                    formula.bv_extract_start())
         return self.cvc5_solver.mkTerm(ext, args[0])
 
     def walk_bv_or(self, formula, args, **kwargs):
         res = args[0]
         for arg in args[1:]:
-            res = self.cvc5.mkTerm(Kind.BITVECTOR_OR, res, arg)
+            res = self.cvc5_solver.mkTerm(Kind.BITVECTOR_OR, res, arg)
         return res
 
     def walk_bv_not(self, formula, args, **kwargs):
@@ -439,7 +439,7 @@ class CVC5Converter(Converter, DagWalker):
     def walk_bv_and(self, formula, args, **kwargs):
         res = args[0]
         for arg in args[1:]:
-            res = self.cvc5.mkTerm(Kind.BITVECTOR_AND, res, arg)
+            res = self.cvc5_solver.mkTerm(Kind.BITVECTOR_AND, res, arg)
         return res
 
     def walk_bv_xor(self, formula, args, **kwargs):
@@ -457,7 +457,7 @@ class CVC5Converter(Converter, DagWalker):
     def walk_bv_mul(self, formula, args, **kwargs):
         res = args[0]
         for arg in args[1:]:
-            res = self.cvc5.mkTerm(Kind.BITVECTOR_MULT, res, arg)
+            res = self.cvc5_solver.mkTerm(Kind.BITVECTOR_MULT, res, arg)
         return res
 
     def walk_bv_tonatural(self, formula, args, **kwargs):

--- a/pysmt/solvers/cvcfive.py
+++ b/pysmt/solvers/cvcfive.py
@@ -23,11 +23,11 @@ from pysmt.typing import PySMTType, _BVType, _ArrayType, _FunctionType
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 try:
-    import cvc5 # type: ignore[import]
+    import cvc5  # type: ignore[import]
 except ImportError:
     raise SolverAPINotFound
 
-from cvc5 import Kind # type: ignore[import]
+from cvc5 import Kind  # type: ignore[import]
 
 import pysmt.typing as types
 from pysmt.logics import PYSMT_LOGICS, AUFLIRA, AUFLIA, AUFNIRA, ALIA
@@ -38,7 +38,7 @@ from pysmt.exceptions import (SolverReturnedUnknownResultError,
                               PysmtValueError,
                               PysmtTypeError)
 from pysmt.walkers import DagWalker
-from pysmt.solvers.smtlib import SmtLibBasicSolver, SmtLibIgnoreMixin
+from pysmt.solvers.smtlib import SmtLibBasicSolver
 from pysmt.solvers.eager import EagerModel
 from pysmt.decorators import catch_conversion_error
 from pysmt.constants import Fraction, is_pysmt_integer
@@ -58,7 +58,7 @@ class CVC5Options(SolverOptions):
         try:
             cvc5_solver.setOption(name, value)
         except:
-            raise PysmtValueError("Error setting the option '%s=%s'" % (name,value))
+            raise PysmtValueError("Error setting the option '%s=%s'" % (name, value))
 
     def __call__(self, solver: "CVC5Solver"):
         if solver.logic_name == "QF_SLIA":
@@ -89,7 +89,7 @@ class CVC5Options(SolverOptions):
         #self._set_option(solver.cvc5_solver, "nl-ext-tplanes", "true")
 
         assert isinstance(self.solver_options, dict)
-        for k,v in self.solver_options.items():
+        for k, v in self.solver_options.items():
             self._set_option(solver.cvc5_solver, str(k), str(v))
 
 # EOC CVC5Options
@@ -121,7 +121,7 @@ class CVC5Solver(SmtLibBasicSolver):
             self.logic_name = self.logic_name[:-1]
         if "t" in self.logic_name:
             # Custom Type extension
-            self.logic_name = self.logic_name.replace("t","")
+            self.logic_name = self.logic_name.replace("t", "")
         if self.logic_name == "QF_BOOL":
             self.logic_name = "QF_LRA"
         elif self.logic_name == "BOOL":
@@ -156,12 +156,13 @@ class CVC5Solver(SmtLibBasicSolver):
         assignment = {}
         for s in self.environment.formula_manager.get_all_symbols():
             if s.is_term():
-                if s.symbol_type().is_custom_type(): continue
+                if s.symbol_type().is_custom_type():
+                    continue
                 v = self.get_value(s)
                 assignment[s] = v
         return EagerModel(assignment=assignment, environment=self.environment)
 
-    def solve(self, assumptions: Optional[Iterable[FNode]]=None) -> bool:
+    def solve(self, assumptions: Optional[Iterable[FNode]] = None) -> bool:
         if assumptions is not None:
             cvc5_assumptions = [self.converter.convert(a) for a in assumptions]
             res = self.cvc5_solver.checkSatAssuming(*cvc5_assumptions)
@@ -197,8 +198,7 @@ class CVC5Solver(SmtLibBasicSolver):
         if name_filter is None:
             var_set = self.declarations
         else:
-            var_set = (var for var in self.declarations\
-                       if name_filter(var))
+            var_set = (var for var in self.declarations if name_filter(var))
         for var in var_set:
             print("%s = %s", (var.symbol_name(), self.get_value(var)))
         return
@@ -303,7 +303,7 @@ class CVC5Converter(Converter, DagWalker):
         return self.cvc5_solver.mkTerm(Kind.NOT, *args)
 
     def walk_symbol(self, formula: FNode, args: List[Any], **kwargs) -> cvc5.Term:
-        #pylint: disable=unused-argument
+        # pylint: disable=unused-argument
         if formula not in self.declared_vars:
             self.declare_variable(formula)
         return self.declared_vars[formula]
@@ -325,7 +325,7 @@ class CVC5Converter(Converter, DagWalker):
 
     def walk_real_constant(self, formula, **kwargs):
         frac = formula.constant_value()
-        n,d = frac.numerator, frac.denominator
+        n, d = frac.numerator, frac.denominator
         rep = str(n) + "/" + str(d)
         return self.cvc5_solver.mkReal(rep)
 
@@ -416,7 +416,10 @@ class CVC5Converter(Converter, DagWalker):
         return self.cvc5_solver.mkTerm(Kind.BITVECTOR_ULE, args[0], args[1])
 
     def walk_bv_concat(self, formula, args, **kwargs):
-        return self.cvc5_solver.mkTerm(Kind.BITVECTOR_CONCAT, args[0], args[1])
+        res = args[0]
+        for arg in args[1:]:
+            res = self.cvc5.mkTerm(Kind.BITVECTOR_CONCAT, res, arg)
+        return res
 
     def walk_bv_extract(self, formula, args, **kwargs):
         ext = self.cvc5_solver.mkOp(Kind.BITVECTOR_EXTRACT,
@@ -425,13 +428,19 @@ class CVC5Converter(Converter, DagWalker):
         return self.cvc5_solver.mkTerm(ext, args[0])
 
     def walk_bv_or(self, formula, args, **kwargs):
-        return self.cvc5_solver.mkTerm(Kind.BITVECTOR_OR, args[0], args[1])
+        res = args[0]
+        for arg in args[1:]:
+            res = self.cvc5.mkTerm(Kind.BITVECTOR_OR, res, arg)
+        return res
 
     def walk_bv_not(self, formula, args, **kwargs):
         return self.cvc5_solver.mkTerm(Kind.BITVECTOR_NOT, args[0])
 
     def walk_bv_and(self, formula, args, **kwargs):
-        return self.cvc5_solver.mkTerm(Kind.BITVECTOR_AND, args[0], args[1])
+        res = args[0]
+        for arg in args[1:]:
+            res = self.cvc5.mkTerm(Kind.BITVECTOR_AND, res, arg)
+        return res
 
     def walk_bv_xor(self, formula, args, **kwargs):
         return self.cvc5_solver.mkTerm(Kind.BITVECTOR_XOR, args[0], args[1])
@@ -446,7 +455,10 @@ class CVC5Converter(Converter, DagWalker):
         return self.cvc5_solver.mkTerm(Kind.BITVECTOR_NEG, args[0])
 
     def walk_bv_mul(self, formula, args, **kwargs):
-        return self.cvc5_solver.mkTerm(Kind.BITVECTOR_MULT, args[0], args[1])
+        res = args[0]
+        for arg in args[1:]:
+            res = self.cvc5.mkTerm(Kind.BITVECTOR_MULT, res, arg)
+        return res
 
     def walk_bv_tonatural(self, formula, args, **kwargs):
         return self.cvc5_solver.mkTerm(Kind.BITVECTOR_TO_NAT, args[0])

--- a/pysmt/solvers/cvcfive.py
+++ b/pysmt/solvers/cvcfive.py
@@ -443,7 +443,7 @@ class CVC5Converter(Converter, DagWalker):
         return res
 
     def walk_bv_xor(self, formula, args, **kwargs):
-        return self.cvc5_solver.mkTerm(Kind.BITVECTOR_XOR, args[0], args[1])
+        return self.cvc5_solver.mkTerm(Kind.BITVECTOR_XOR, *args)
 
     def walk_bv_add(self, formula, args, **kwargs):
         return self.cvc5_solver.mkTerm(Kind.BITVECTOR_ADD, *args)

--- a/pysmt/solvers/cvcfour.py
+++ b/pysmt/solvers/cvcfour.py
@@ -418,7 +418,7 @@ class CVC4Converter(Converter, DagWalker):
         return self.mkExpr(CVC4.BITVECTOR_AND, args)
 
     def walk_bv_xor(self, formula, args, **kwargs):
-        return self.mkExpr(CVC4.BITVECTOR_XOR, args[0], args[1])
+        return self.mkExpr(CVC4.BITVECTOR_XOR, args)
 
     def walk_bv_add(self, formula, args, **kwargs):
         return self.mkExpr(CVC4.BITVECTOR_PLUS, args)

--- a/pysmt/solvers/cvcfour.py
+++ b/pysmt/solvers/cvcfour.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 from pysmt.exceptions import SolverAPINotFound
 
 try:
-    import CVC4 # type: ignore[import]
+    import CVC4  # type: ignore[import]
 except ImportError:
     raise SolverAPINotFound
 
@@ -33,10 +33,10 @@ from pysmt.exceptions import (SolverReturnedUnknownResultError,
                               NonLinearError, PysmtValueError,
                               PysmtTypeError)
 from pysmt.walkers import DagWalker
-from pysmt.solvers.smtlib import SmtLibBasicSolver, SmtLibIgnoreMixin
+from pysmt.solvers.smtlib import SmtLibBasicSolver
 from pysmt.solvers.eager import EagerModel
 from pysmt.decorators import catch_conversion_error
-from pysmt.constants import Fraction, is_pysmt_integer, to_python_integer
+from pysmt.constants import Fraction, is_pysmt_integer
 
 
 class CVC4Options(SolverOptions):
@@ -53,7 +53,7 @@ class CVC4Options(SolverOptions):
         try:
             cvc4.setOption(name, CVC4.SExpr(value))
         except:
-            raise PysmtValueError("Error setting the option '%s=%s'" % (name,value))
+            raise PysmtValueError("Error setting the option '%s=%s'" % (name, value))
 
     def __call__(self, solver):
         if solver.logic_name == "QF_SLIA":
@@ -68,7 +68,7 @@ class CVC4Options(SolverOptions):
             self._set_option(solver.cvc4,
                              "random-seed", str(self.random_seed))
 
-        for k,v in self.solver_options.items():
+        for k, v in self.solver_options.items():
             self._set_option(solver.cvc4, str(k), str(v))
 
 # EOC CVC4Options
@@ -96,7 +96,7 @@ class CVC4Solver(SmtLibBasicSolver):
             self.logic_name = self.logic_name[:-1]
         if "t" in self.logic_name:
             # Custom Type extension
-            self.logic_name = self.logic_name.replace("t","")
+            self.logic_name = self.logic_name.replace("t", "")
         if self.logic_name == "QF_BOOL":
             self.logic_name = "QF_LRA"
         elif self.logic_name == "BOOL":
@@ -109,7 +109,8 @@ class CVC4Solver(SmtLibBasicSolver):
         del self.cvc4
         # CVC4's SWIG interface is not acquiring ownership of the
         # SmtEngine object. Forcing it here.
-        self.cvc4 = CVC4.SmtEngine(self.em); self.cvc4.thisown=1
+        self.cvc4 = CVC4.SmtEngine(self.em)
+        self.cvc4.thisown = 1
         self.options(self)
         self.declarations = set()
         self.cvc4.setLogic(self.logic_name)
@@ -127,7 +128,8 @@ class CVC4Solver(SmtLibBasicSolver):
         assignment = {}
         for s in self.environment.formula_manager.get_all_symbols():
             if s.is_term():
-                if s.symbol_type().is_custom_type(): continue
+                if s.symbol_type().is_custom_type():
+                    continue
                 v = self.get_value(s)
                 assignment[s] = v
         return EagerModel(assignment=assignment, environment=self.environment)
@@ -171,8 +173,7 @@ class CVC4Solver(SmtLibBasicSolver):
         if name_filter is None:
             var_set = self.declarations
         else:
-            var_set = (var for var in self.declarations\
-                       if name_filter(var))
+            var_set = (var for var in self.declarations if name_filter(var))
         for var in var_set:
             print("%s = %s", (var.symbol_name(), self.get_value(var)))
         return
@@ -198,7 +199,6 @@ class CVC4Solver(SmtLibBasicSolver):
         :type value: String
         """
         self.cvc4.setOption(name, CVC4.SExpr(value))
-
 
 
 class CVC4Converter(Converter, DagWalker):
@@ -401,7 +401,7 @@ class CVC4Converter(Converter, DagWalker):
         return self.mkExpr(CVC4.BITVECTOR_ULE, args[0], args[1])
 
     def walk_bv_concat(self, formula, args, **kwargs):
-        return self.mkExpr(CVC4.BITVECTOR_CONCAT, args[0], args[1])
+        return self.mkExpr(CVC4.BITVECTOR_CONCAT, args)
 
     def walk_bv_extract(self, formula, args, **kwargs):
         ext = self.mkConst(CVC4.BitVectorExtract(formula.bv_extract_end(),
@@ -409,19 +409,19 @@ class CVC4Converter(Converter, DagWalker):
         return self.mkExpr(CVC4.BITVECTOR_EXTRACT, ext, args[0])
 
     def walk_bv_or(self, formula, args, **kwargs):
-        return self.mkExpr(CVC4.BITVECTOR_OR, args[0], args[1])
+        return self.mkExpr(CVC4.BITVECTOR_OR, args)
 
     def walk_bv_not(self, formula, args, **kwargs):
         return self.mkExpr(CVC4.BITVECTOR_NOT, args[0])
 
     def walk_bv_and(self, formula, args, **kwargs):
-        return self.mkExpr(CVC4.BITVECTOR_AND, args[0], args[1])
+        return self.mkExpr(CVC4.BITVECTOR_AND, args)
 
     def walk_bv_xor(self, formula, args, **kwargs):
         return self.mkExpr(CVC4.BITVECTOR_XOR, args[0], args[1])
 
     def walk_bv_add(self, formula, args, **kwargs):
-        return self.mkExpr(CVC4.BITVECTOR_PLUS, args[0], args[1])
+        return self.mkExpr(CVC4.BITVECTOR_PLUS, args)
 
     def walk_bv_sub(self, formula, args, **kwargs):
         return self.mkExpr(CVC4.BITVECTOR_SUB, args[0], args[1])
@@ -430,7 +430,7 @@ class CVC4Converter(Converter, DagWalker):
         return self.mkExpr(CVC4.BITVECTOR_NEG, args[0])
 
     def walk_bv_mul(self, formula, args, **kwargs):
-        return self.mkExpr(CVC4.BITVECTOR_MULT, args[0], args[1])
+        return self.mkExpr(CVC4.BITVECTOR_MULT, args)
 
     def walk_bv_tonatural(self, formula, args, **kwargs):
         return self.mkExpr(CVC4.BITVECTOR_TO_NAT, args[0])
@@ -438,7 +438,7 @@ class CVC4Converter(Converter, DagWalker):
     def walk_bv_udiv(self, formula, args, **kwargs):
         # Force deterministic semantics of division by 0
         # If the denominator is bv0, then the result is ~0
-        n,d = args
+        n, d = args
         if d.isConst():
             bv = d.getConstBitVector()
             v = bv.getValue().toString()
@@ -458,7 +458,7 @@ class CVC4Converter(Converter, DagWalker):
     def walk_bv_urem(self, formula, args, **kwargs):
         # Force deterministic semantics of reminder by 0
         # If the denominator is bv0, then the result is the numerator
-        n,d = args
+        n, d = args
         if d.isConst():
             bv = d.getConstBitVector()
             v = bv.getValue().toString()
@@ -492,7 +492,7 @@ class CVC4Converter(Converter, DagWalker):
         ext = self.mkConst(CVC4.BitVectorZeroExtend(formula.bv_extend_step()))
         return self.mkExpr(CVC4.BITVECTOR_ZERO_EXTEND, ext, args[0])
 
-    def walk_bv_sext (self, formula, args, **kwargs):
+    def walk_bv_sext(self, formula, args, **kwargs):
         ext = self.mkConst(CVC4.BitVectorSignExtend(formula.bv_extend_step()))
         return self.mkExpr(CVC4.BITVECTOR_SIGN_EXTEND, ext, args[0])
 
@@ -510,7 +510,7 @@ class CVC4Converter(Converter, DagWalker):
         # If the denominator is bv0, then the result is:
         #   * ~0 (if the numerator is signed >= 0)
         #   * 1 (if the numerator is signed < 0)
-        n,d = args
+        n, d = args
         # sign_expr : ( 0 s<= n ) ? ~0 : 1 )
         zero = self.mkConst(CVC4.BitVector(formula.bv_width(),
                                            CVC4.Integer("0")))
@@ -534,7 +534,7 @@ class CVC4Converter(Converter, DagWalker):
     def walk_bv_srem(self, formula, args, **kwargs):
         # Force deterministic semantics of reminder by 0
         # If the denominator is bv0, then the result is the numerator
-        n,d = args
+        n, d = args
         if d.isConst():
             v = d.getConstBitVector().getValue().toString()
             if v == "0":
@@ -555,8 +555,8 @@ class CVC4Converter(Converter, DagWalker):
     def walk_str_constant(self, formula, args, **kwargs):
         return self.mkConst(CVC4.CVC4String(formula.constant_value()))
 
-    def walk_str_length (self, formula, args, **kwargs):
-        return self.mkExpr(CVC4.STRING_LENGTH , args[0])
+    def walk_str_length(self, formula, args, **kwargs):
+        return self.mkExpr(CVC4.STRING_LENGTH, args[0])
 
     def walk_str_concat(self, formula, args, **kwargs):
         return self.mkExpr(CVC4.STRING_CONCAT, args)
@@ -611,7 +611,7 @@ class CVC4Converter(Converter, DagWalker):
         elif tp.is_custom_type():
             return self.cvc4_exprMgr.mkSort(str(tp))
         else:
-            raise NotImplementedError("Unsupported type: %s" %tp)
+            raise NotImplementedError("Unsupported type: %s" % tp)
 
     def _cvc4_type_to_type(self, type_):
         if type_.isBoolean():
@@ -635,7 +635,8 @@ class CVC4Converter(Converter, DagWalker):
             # Casting Type into FunctionType
             type_ = CVC4.FunctionType(type_)
             return_type = type_.getRangeType()
-            param_types = tuple(self._cvc4_type_to_type(ty) for ty in type_.getArgTypes())
+            param_types = tuple(self._cvc4_type_to_type(ty)
+                                for ty in type_.getArgTypes())
             return self.env.type_manager.FunctionType(return_type, param_types)
         else:
             raise NotImplementedError("Unsupported type: %s" % type_)
@@ -648,7 +649,7 @@ class CVC4Converter(Converter, DagWalker):
         """
         mkBoundVar = self.cvc4_exprMgr.mkBoundVar
         new_var_list = [mkBoundVar(x.symbol_name(),
-                                   self._type_to_cvc4(x.symbol_type())) \
+                                   self._type_to_cvc4(x.symbol_type()))
                         for x in variables]
         old_var_list = [self.walk_symbol(x, []) for x in variables]
         new_formula = formula.substitute(old_var_list, new_var_list)

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -957,8 +957,7 @@ class MSatConverter(Converter, DagWalker):
     def walk_bv_mul(self, formula: FNode, args: List[Any], **kwargs) -> Any:
         res = args[0]
         for arg in args[1:]:
-            res = self._msat_lib.msat_bv_times(self.msat_env(),
-                                               res, arg)
+            res = self._msat_lib.msat_make_bv_times(self.msat_env(), res, arg)
         return res
 
     def walk_bv_udiv(self, formula: FNode, args: List[Any], **kwargs) -> Any:

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -30,8 +30,7 @@ import pysmt.operators as op
 from pysmt import typing as types
 from pysmt.solvers.solver import (IncrementalTrackingSolver, UnsatCoreSolver,
                                   Model, Converter, SolverOptions)
-from pysmt.solvers.smtlib import SmtLibBasicSolver, SmtLibIgnoreMixin
-from pysmt.utils import assert_not_none
+from pysmt.solvers.smtlib import SmtLibBasicSolver
 from pysmt.walkers import DagWalker
 from pysmt.exceptions import (SolverReturnedUnknownResultError,
                               InternalSolverError,
@@ -46,6 +45,7 @@ from pysmt.fnode import FNode
 from pysmt.formula import FormulaManager
 from pysmt.typing import PySMTType
 
+
 class MSatEnv():
     """A wrapper for the msat_env object.
 
@@ -59,7 +59,7 @@ class MSatEnv():
     __slots__ = ['msat_env', '_msat_lib']
     __lib_name__ = "mathsat"
 
-    def __init__(self, msat_config: Optional[Any]=None):
+    def __init__(self, msat_config: Optional[Any] = None):
         self._msat_lib = MSATLibLoader(self.__class__.__lib_name__)
         self.msat_env = self._do_create_env(msat_config)
 
@@ -69,7 +69,7 @@ class MSatEnv():
     def __call__(self) -> Any:
         return self.msat_env
 
-    def _do_create_env(self, msat_config: Optional[Any]=None, msat_env: None=None) -> Any:
+    def _do_create_env(self, msat_config: Optional[Any] = None, msat_env: None = None) -> Any:
         return self._msat_lib.msat_create_env(msat_config, msat_env)
 
 
@@ -96,7 +96,7 @@ class MathSAT5Model(Model):
             self._msat_lib.msat_destroy_model(self.msat_model)
         del self.msat_env
 
-    def get_value(self, formula: FNode, model_completion: bool=True) -> FNode:
+    def get_value(self, formula: FNode, model_completion: bool = True) -> FNode:
         titem = self.converter.convert(formula)
         msat_res = self._msat_lib.msat_model_eval(self.msat_model, titem)
         if self._msat_lib.MSAT_ERROR_TERM(msat_res):
@@ -268,11 +268,11 @@ class MathSAT5Solver(IncrementalTrackingSolver, UnsatCoreSolver, SmtLibBasicSolv
 
     def _named_assertions_map(self):
         if self.options.unsat_cores_mode == "named":
-            return dict((t[0], (t[1],t[2])) for t in self.assertions)
+            return dict((t[0], (t[1], t[2])) for t in self.assertions)
         return None
 
     @clear_pending_pop
-    def _solve(self, assumptions: Optional[List[FNode]]=None) -> bool:
+    def _solve(self, assumptions: Optional[List[FNode]] = None) -> bool:
         res = None
         bool_ass = []
         other_ass = []
@@ -368,7 +368,7 @@ class MathSAT5Solver(IncrementalTrackingSolver, UnsatCoreSolver, SmtLibBasicSolv
         tvar = self.converter.convert(var)
         mval = self._msat_lib.MSAT_UNDEF
         if val is not None:
-            mval = self._msat_lib.MSAT_TRUE if val==True else self._msat_lib.MSAT_FALSE
+            mval = self._msat_lib.MSAT_TRUE if val is True else self._msat_lib.MSAT_FALSE
         self._msat_lib.msat_add_preferred_for_branching(self.msat_env(), tvar, mval)
         return
 
@@ -424,8 +424,8 @@ class MSatConverter(Converter, DagWalker):
         # Back Conversion
         self.back_memoization: Dict[Any, Optional[FNode]] = {}
         self.back_fun: Dict[Any, Callable[..., FNode]] = {
-            self._msat_lib.MSAT_TAG_TRUE: lambda term, args: self.mgr.TRUE(),
-            self._msat_lib.MSAT_TAG_FALSE:lambda term, args: self.mgr.FALSE(),
+            self._msat_lib.MSAT_TAG_TRUE:  lambda term, args: self.mgr.TRUE(),
+            self._msat_lib.MSAT_TAG_FALSE: lambda term, args: self.mgr.FALSE(),
             self._msat_lib.MSAT_TAG_AND: self._back_adapter(self.mgr.And),
             self._msat_lib.MSAT_TAG_OR:  self._back_adapter(self.mgr.Or),
             self._msat_lib.MSAT_TAG_NOT: self._back_adapter(self.mgr.Not),
@@ -441,35 +441,35 @@ class MSatConverter(Converter, DagWalker):
             self._msat_lib.MSAT_TAG_BV_UDIV: self._back_adapter(self.mgr.BVUDiv),
             self._msat_lib.MSAT_TAG_BV_UREM: self._back_adapter(self.mgr.BVURem),
             self._msat_lib.MSAT_TAG_BV_CONCAT: self._back_adapter(self.mgr.BVConcat),
-            self._msat_lib.MSAT_TAG_BV_OR: self._back_adapter(self.mgr.BVOr),
-            self._msat_lib.MSAT_TAG_BV_XOR:self._back_adapter(self.mgr.BVXor),
-            self._msat_lib.MSAT_TAG_BV_AND:self._back_adapter(self.mgr.BVAnd),
-            self._msat_lib.MSAT_TAG_BV_NOT:self._back_adapter(self.mgr.BVNot),
-            self._msat_lib.MSAT_TAG_BV_SUB:self._back_adapter(self.mgr.BVSub),
-            self._msat_lib.MSAT_TAG_BV_NEG:self._back_adapter(self.mgr.BVNeg),
-            self._msat_lib.MSAT_TAG_BV_SREM:self._back_adapter(self.mgr.BVSRem),
-            self._msat_lib.MSAT_TAG_BV_SDIV:self._back_adapter(self.mgr.BVSDiv),
-            self._msat_lib.MSAT_TAG_BV_ULT: self._back_adapter(self.mgr.BVULT),
-            self._msat_lib.MSAT_TAG_BV_SLT: self._back_adapter(self.mgr.BVSLT),
-            self._msat_lib.MSAT_TAG_BV_ULE: self._back_adapter(self.mgr.BVULE),
-            self._msat_lib.MSAT_TAG_BV_SLE: self._back_adapter(self.mgr.BVSLE),
+            self._msat_lib.MSAT_TAG_BV_OR:   self._back_adapter(self.mgr.BVOr),
+            self._msat_lib.MSAT_TAG_BV_XOR:  self._back_adapter(self.mgr.BVXor),
+            self._msat_lib.MSAT_TAG_BV_AND:  self._back_adapter(self.mgr.BVAnd),
+            self._msat_lib.MSAT_TAG_BV_NOT:  self._back_adapter(self.mgr.BVNot),
+            self._msat_lib.MSAT_TAG_BV_SUB:  self._back_adapter(self.mgr.BVSub),
+            self._msat_lib.MSAT_TAG_BV_NEG:  self._back_adapter(self.mgr.BVNeg),
+            self._msat_lib.MSAT_TAG_BV_SREM: self._back_adapter(self.mgr.BVSRem),
+            self._msat_lib.MSAT_TAG_BV_SDIV: self._back_adapter(self.mgr.BVSDiv),
+            self._msat_lib.MSAT_TAG_BV_ULT:  self._back_adapter(self.mgr.BVULT),
+            self._msat_lib.MSAT_TAG_BV_SLT:  self._back_adapter(self.mgr.BVSLT),
+            self._msat_lib.MSAT_TAG_BV_ULE:  self._back_adapter(self.mgr.BVULE),
+            self._msat_lib.MSAT_TAG_BV_SLE:  self._back_adapter(self.mgr.BVSLE),
             self._msat_lib.MSAT_TAG_BV_LSHL: self._back_adapter(self.mgr.BVLShl),
             self._msat_lib.MSAT_TAG_BV_LSHR: self._back_adapter(self.mgr.BVLShr),
             self._msat_lib.MSAT_TAG_BV_ASHR: self._back_adapter(self.mgr.BVAShr),
             self._msat_lib.MSAT_TAG_BV_COMP: self._back_adapter(self.mgr.BVComp),
-            self._msat_lib.MSAT_TAG_FLOOR: self._back_adapter(self.mgr.ToInt),
+            self._msat_lib.MSAT_TAG_FLOOR:   self._back_adapter(self.mgr.ToInt),
             self._msat_lib.MSAT_TAG_INT_FROM_UBV: self._back_adapter(self.mgr.BVToNatural),
-            self._msat_lib.MSAT_TAG_ARRAY_READ: self._back_adapter(self.mgr.Select),
+            self._msat_lib.MSAT_TAG_ARRAY_READ:  self._back_adapter(self.mgr.Select),
             self._msat_lib.MSAT_TAG_ARRAY_WRITE: self._back_adapter(self.mgr.Store),
             # Slightly more complex conversion
-            self._msat_lib.MSAT_TAG_BV_EXTRACT: self._back_bv_extract,
-            self._msat_lib.MSAT_TAG_BV_ZEXT: self._back_bv_zext,
-            self._msat_lib.MSAT_TAG_BV_SEXT: self._back_bv_sext,
-            self._msat_lib.MSAT_TAG_BV_ROL: self._back_bv_rol,
-            self._msat_lib.MSAT_TAG_BV_ROR: self._back_bv_ror,
+            self._msat_lib.MSAT_TAG_BV_EXTRACT:  self._back_bv_extract,
+            self._msat_lib.MSAT_TAG_BV_ZEXT:     self._back_bv_zext,
+            self._msat_lib.MSAT_TAG_BV_SEXT:     self._back_bv_sext,
+            self._msat_lib.MSAT_TAG_BV_ROL:      self._back_bv_rol,
+            self._msat_lib.MSAT_TAG_BV_ROR:      self._back_bv_ror,
             self._msat_lib.MSAT_TAG_ARRAY_CONST: self._back_array_const,
             # Symbols, Constants and UFs have TAG_UNKNOWN
-            self._msat_lib.MSAT_TAG_UNKNOWN: self._back_tag_unknown,
+            self._msat_lib.MSAT_TAG_UNKNOWN:     self._back_tag_unknown,
         }
 
         # Handling of UF bool args
@@ -479,13 +479,13 @@ class MSatConverter(Converter, DagWalker):
         self.term_sig = {
             self._msat_lib.MSAT_TAG_TRUE: lambda term, args: types.BOOL,
             self._msat_lib.MSAT_TAG_FALSE: lambda term, args: types.BOOL,
-            self._msat_lib.MSAT_TAG_AND: lambda term, args:\
+            self._msat_lib.MSAT_TAG_AND: lambda term, args:
                 self.tm.FunctionType(types.BOOL, [types.BOOL, types.BOOL]),
-            self._msat_lib.MSAT_TAG_OR: lambda term, args:\
+            self._msat_lib.MSAT_TAG_OR: lambda term, args:
                 self.tm.FunctionType(types.BOOL, [types.BOOL, types.BOOL]),
-            self._msat_lib.MSAT_TAG_NOT: lambda term, args:\
+            self._msat_lib.MSAT_TAG_NOT: lambda term, args:
                 self.tm.FunctionType(types.BOOL, [types.BOOL]),
-            self._msat_lib.MSAT_TAG_IFF: lambda term, args:\
+            self._msat_lib.MSAT_TAG_IFF: lambda term, args:
                 self.tm.FunctionType(types.BOOL, [types.BOOL, types.BOOL]),
             self._msat_lib.MSAT_TAG_ITE: self._sig_ite,
             self._msat_lib.MSAT_TAG_EQ: self._sig_most_generic_bool_binary,
@@ -493,18 +493,18 @@ class MSatConverter(Converter, DagWalker):
             self._msat_lib.MSAT_TAG_PLUS:  self._sig_most_generic_bool_binary,
             self._msat_lib.MSAT_TAG_TIMES: self._sig_most_generic_bool_binary,
             self._msat_lib.MSAT_TAG_DIVIDE: self._sig_most_generic_bool_binary,
-            self._msat_lib.MSAT_TAG_FLOOR: lambda term, args:\
+            self._msat_lib.MSAT_TAG_FLOOR: lambda term, args:
                 self.tm.FunctionType(types.INT, [types.REAL]),
-            self._msat_lib.MSAT_TAG_BV_MUL: self._sig_binary,
-            self._msat_lib.MSAT_TAG_BV_ADD: self._sig_binary,
-            self._msat_lib.MSAT_TAG_BV_UDIV:self._sig_binary,
-            self._msat_lib.MSAT_TAG_BV_UREM:self._sig_binary,
+            self._msat_lib.MSAT_TAG_BV_MUL:  self._sig_binary,
+            self._msat_lib.MSAT_TAG_BV_ADD:  self._sig_binary,
+            self._msat_lib.MSAT_TAG_BV_UDIV: self._sig_binary,
+            self._msat_lib.MSAT_TAG_BV_UREM: self._sig_binary,
             self._msat_lib.MSAT_TAG_BV_CONCAT: self._sig_bv_concat,
-            self._msat_lib.MSAT_TAG_BV_OR:  self._sig_binary,
-            self._msat_lib.MSAT_TAG_BV_XOR: self._sig_binary,
-            self._msat_lib.MSAT_TAG_BV_AND: self._sig_binary,
+            self._msat_lib.MSAT_TAG_BV_OR:   self._sig_binary,
+            self._msat_lib.MSAT_TAG_BV_XOR:  self._sig_binary,
+            self._msat_lib.MSAT_TAG_BV_AND:  self._sig_binary,
             self._msat_lib.MSAT_TAG_BV_NOT:  self._sig_unary,
-            self._msat_lib.MSAT_TAG_BV_SUB: self._sig_binary,
+            self._msat_lib.MSAT_TAG_BV_SUB:  self._sig_binary,
             self._msat_lib.MSAT_TAG_BV_NEG:  self._sig_unary,
             self._msat_lib.MSAT_TAG_BV_SREM: self._sig_binary,
             self._msat_lib.MSAT_TAG_BV_SDIV: self._sig_binary,
@@ -515,13 +515,13 @@ class MSatConverter(Converter, DagWalker):
             self._msat_lib.MSAT_TAG_BV_LSHL: self._sig_binary,
             self._msat_lib.MSAT_TAG_BV_LSHR: self._sig_binary,
             self._msat_lib.MSAT_TAG_BV_ASHR: self._sig_binary,
-            self._msat_lib.MSAT_TAG_BV_ROL: self._sig_binary,
+            self._msat_lib.MSAT_TAG_BV_ROL:  self._sig_binary,
             self._msat_lib.MSAT_TAG_BV_ROR:  self._sig_binary,
             self._msat_lib.MSAT_TAG_BV_EXTRACT: self._sig_bv_extract,
             self._msat_lib.MSAT_TAG_BV_ZEXT: self._sig_bv_zext,
             self._msat_lib.MSAT_TAG_BV_SEXT: self._sig_bv_sext,
             self._msat_lib.MSAT_TAG_BV_COMP: self._sig_bv_comp,
-            self._msat_lib.MSAT_TAG_ARRAY_READ: self._sig_array_read,
+            self._msat_lib.MSAT_TAG_ARRAY_READ:  self._sig_array_read,
             self._msat_lib.MSAT_TAG_ARRAY_WRITE: self._sig_array_write,
             self._msat_lib.MSAT_TAG_ARRAY_CONST: self._sig_array_const,
             ## Symbols, Constants and UFs have TAG_UNKNOWN
@@ -774,8 +774,8 @@ class MSatConverter(Converter, DagWalker):
                     son = self._msat_lib.msat_term_get_arg(current, i)
                     stack.append(son)
             elif self.back_memoization[current] is None:
-                args=[self.back_memoization[self._msat_lib.msat_term_get_arg(current,i)]
-                      for i in range(arity)]
+                args = [self.back_memoization[self._msat_lib.msat_term_get_arg(current,i)]
+                        for i in range(arity)]
 
                 signature = self._get_signature(current, args)
                 new_args = []
@@ -812,14 +812,18 @@ class MSatConverter(Converter, DagWalker):
         return res
 
     def walk_and(self, formula: FNode, args: List[Any], **kwargs) -> Any:
-        res = self._msat_lib.msat_make_true(self.msat_env())
-        for a in args:
+        if len(args) == 0:
+            return self._msat_lib.msat_make_true(self.msat_env())
+        res = args[0]
+        for a in args[1:]:
             res = self._msat_lib.msat_make_and(self.msat_env(), res, a)
         return res
 
     def walk_or(self, formula: FNode, args: List[Any], **kwargs) -> Any:
-        res = self._msat_lib.msat_make_false(self.msat_env())
-        for a in args:
+        if len(args) == 0:
+            return self._msat_lib.msat_make_false(self.msat_env())
+        res = args[0]
+        for a in args[1:]:
             res = self._msat_lib.msat_make_or(self.msat_env(), res, a)
         return res
 
@@ -846,10 +850,10 @@ class MSatConverter(Converter, DagWalker):
 
         if self._get_type(formula).is_bool_type():
             impl = self.mgr.Implies(formula.arg(0), formula.arg(1))
-            th = self.walk_implies(impl, [i,t])
+            th = self.walk_implies(impl, [i, t])
             nif = self.mgr.Not(formula.arg(0))
             ni = self.walk_not(nif, [i])
-            el = self.walk_implies(self.mgr.Implies(nif, formula.arg(2)), [ni,e])
+            el = self.walk_implies(self.mgr.Implies(nif, formula.arg(2)), [ni, e])
             return self._msat_lib.msat_make_and(self.msat_env(), th, el)
         else:
             return self._msat_lib.msat_make_term_ite(self.msat_env(), i, t, e)
@@ -857,7 +861,7 @@ class MSatConverter(Converter, DagWalker):
     def walk_real_constant(self, formula: FNode, **kwargs) -> Any:
         assert is_pysmt_fraction(formula.constant_value())
         frac = cast(pyFraction, formula.constant_value())
-        n,d = frac.numerator, frac.denominator
+        n, d = frac.numerator, frac.denominator
         rep = str(n) + "/" + str(d)
         return self._msat_lib.msat_make_number(self.msat_env(), rep)
 
@@ -903,8 +907,11 @@ class MSatConverter(Converter, DagWalker):
                                          args[0], args[1])
 
     def walk_bv_concat(self, formula: FNode, args: List[Any], **kwargs) -> Any:
-        return self._msat_lib.msat_make_bv_concat(self.msat_env(),
-                                           args[0], args[1])
+        res = args[0]
+        for arg in args[1:]:
+            res = self._msat_lib.msat_make_bv_concat(self.msat_env(),
+                                                     res, arg)
+        return res
 
     def walk_bv_extract(self, formula: FNode, args: List[Any], **kwargs) -> Any:
         return self._msat_lib.msat_make_bv_extract(self.msat_env(),
@@ -913,23 +920,32 @@ class MSatConverter(Converter, DagWalker):
                                             args[0])
 
     def walk_bv_or(self, formula: FNode, args: List[Any], **kwargs) -> Any:
-        return self._msat_lib.msat_make_bv_or(self.msat_env(),
-                                       args[0], args[1])
+        res = args[0]
+        for arg in args[1:]:
+            res = self._msat_lib.msat_make_bv_or(self.msat_env(),
+                                                 res, arg)
+        return res
 
     def walk_bv_not(self, formula: FNode, args: List[Any], **kwargs) -> Any:
         return self._msat_lib.msat_make_bv_not(self.msat_env(), args[0])
 
     def walk_bv_and(self, formula: FNode, args: List[Any], **kwargs) -> Any:
-        return self._msat_lib.msat_make_bv_and(self.msat_env(),
-                                        args[0], args[1])
+        res = args[0]
+        for arg in args[1:]:
+            res = self._msat_lib.msat_make_bv_and(self.msat_env(),
+                                                  res, arg)
+        return res
 
     def walk_bv_xor(self, formula: FNode, args: List[Any], **kwargs) -> Any:
         return self._msat_lib.msat_make_bv_xor(self.msat_env(),
                                         args[0], args[1])
 
     def walk_bv_add(self, formula: FNode, args: List[Any], **kwargs) -> Any:
-        return self._msat_lib.msat_make_bv_plus(self.msat_env(),
-                                         args[0], args[1])
+        res = args[0]
+        for arg in args[1:]:
+            res = self._msat_lib.msat_make_bv_plus(self.msat_env(),
+                                                   res, arg)
+        return res
 
     def walk_bv_sub(self, formula: FNode, args: List[Any], **kwargs) -> Any:
         return self._msat_lib.msat_make_bv_minus(self.msat_env(),
@@ -939,8 +955,11 @@ class MSatConverter(Converter, DagWalker):
         return self._msat_lib.msat_make_bv_neg(self.msat_env(), args[0])
 
     def walk_bv_mul(self, formula: FNode, args: List[Any], **kwargs) -> Any:
-        return self._msat_lib.msat_make_bv_times(self.msat_env(),
-                                          args[0], args[1])
+        res = args[0]
+        for arg in args[1:]:
+            res = self._msat_lib.msat_bv_times(self.msat_env(),
+                                               res, arg)
+        return res
 
     def walk_bv_udiv(self, formula: FNode, args: List[Any], **kwargs) -> Any:
         return self._msat_lib.msat_make_bv_udiv(self.msat_env(),
@@ -995,8 +1014,10 @@ class MSatConverter(Converter, DagWalker):
                                          args[0], args[1])
 
     def walk_plus(self, formula: FNode, args: List[Any], **kwargs) -> Any:
-        res = self._msat_lib.msat_make_number(self.msat_env(), "0")
-        for a in args:
+        if len(args) == 0:
+            return self._msat_lib.msat_make_number(self.msat_env(), "0")
+        res = args[0]
+        for a in args[1:]:
             res = self._msat_lib.msat_make_plus(self.msat_env(), res, a)
         return res
 
@@ -1074,9 +1095,9 @@ class MSatConverter(Converter, DagWalker):
                                              self._type_to_msat(arr_type),
                                              args[0])
         assert not self._msat_lib.MSAT_ERROR_TERM(rval)
-        for i,c in enumerate(args[1::2]):
+        for i, c in enumerate(args[1::2]):
             rval = self._msat_lib.msat_make_array_write(self.msat_env(), rval,
-                                                 c, args[(i*2)+2])
+                                                        c, args[(i*2)+2])
         return rval
 
     def _type_to_msat(self, tp: PySMTType) -> Any:
@@ -1112,7 +1133,6 @@ class MSatConverter(Converter, DagWalker):
         else:
             raise NotImplementedError("Usupported type for '%s'" % tp)
 
-
     def _msat_type_to_type(self, tp):
         """Converts a MathSAT type into a PySMT type."""
         if self._msat_lib.msat_is_bool_type(self.msat_env(), tp):
@@ -1135,7 +1155,6 @@ class MSatConverter(Converter, DagWalker):
 
             # It must be a function type, currently unsupported
             raise NotImplementedError("Function types are unsupported")
-
 
     def declare_variable(self, var: FNode):
         if not var.is_symbol():
@@ -1194,18 +1213,16 @@ class MSatQuantifierEliminator(QuantifierEliminator, IdentityDagWalker):
         """Returns a quantifier-free equivalent formula of `formula`."""
         return self.walk(formula)
 
-
     def exist_elim(self, variables, formula):
         logic = get_logic(formula, self.env)
         if not (logic <= LRA or logic <= LIA):
-            raise PysmtValueError("MathSAT quantifier elimination only"\
-                                  " supports LRA or LIA (detected logic " \
+            raise PysmtValueError("MathSAT quantifier elimination only"
+                                  " supports LRA or LIA (detected logic "
                                   "is: %s)" % str(logic))
 
         if not logic <= LRA and self.algorithm != "lw":
-            raise PysmtValueError("MathSAT quantifier elimination for LIA"\
+            raise PysmtValueError("MathSAT quantifier elimination for LIA"
                                   " only works with 'lw' algorithm")
-
 
         fterm = self.converter.convert(formula)
         tvars = [self.converter.convert(x) for x in variables]
@@ -1221,13 +1238,12 @@ class MSatQuantifierEliminator(QuantifierEliminator, IdentityDagWalker):
         except ConvertExpressionError:
             if logic <= LRA:
                 raise
-            raise ConvertExpressionError(message=("Unable to represent" \
-                  "expression %s in pySMT: the quantifier elimination for " \
-                  "LIA is incomplete as it requires the modulus. You can " \
-                  "find the MathSAT term representing the quantifier " \
-                  "elimination as the attribute 'expression' of this " \
+            raise ConvertExpressionError(message=("Unable to represent"
+                  "expression %s in pySMT: the quantifier elimination for "
+                  "LIA is incomplete as it requires the modulus. You can "
+                  "find the MathSAT term representing the quantifier "
+                  "elimination as the attribute 'expression' of this "
                   "exception object" % str(res)), expression=res)
-
 
     def walk_forall(self, formula, args, **kwargs):
         assert formula.is_forall()
@@ -1249,6 +1265,7 @@ class MSatQuantifierEliminator(QuantifierEliminator, IdentityDagWalker):
 
 class MSatFMQuantifierEliminator(MSatQuantifierEliminator):
     LOGICS = [LRA]
+
     def __init__(self, environment, logic=None):
         MSatQuantifierEliminator.__init__(self, environment,
                                           logic=logic, algorithm='fm')
@@ -1256,6 +1273,7 @@ class MSatFMQuantifierEliminator(MSatQuantifierEliminator):
 
 class MSatLWQuantifierEliminator(MSatQuantifierEliminator):
     LOGICS = [LRA, LIA]
+
     def __init__(self, environment, logic=None):
         MSatQuantifierEliminator.__init__(self, environment,
                                           logic=logic, algorithm='lw')
@@ -1284,7 +1302,7 @@ class MSatInterpolator(Interpolator):
             ok = any(logic <= l for l in self.LOGICS)
             if not ok:
                 raise PysmtValueError("Logic not supported by MathSAT "
-                                      "interpolation. (detected logic is: %s)" \
+                                      "interpolation. (detected logic is: %s)"
                                       % str(logic))
 
     def binary_interpolant(self, a, b):
@@ -1372,7 +1390,7 @@ class MSatBoolUFRewriter(IdentityDagWalker):
             return IdentityDagWalker.walk_function(self, formula, args, **kwargs)
 
         # Build new function type
-        rtype = cast(types._FunctionType, formula.function_name().symbol_type()).return_type
+        rtype = cast(types._FunctionType, formula.function_name().symbol_type()). return_type
         ptype = [self.get_type(a) for a in other_args]
         if len(ptype) == 0:
             ftype = rtype
@@ -1382,7 +1400,7 @@ class MSatBoolUFRewriter(IdentityDagWalker):
         # Base-case
         stack = []
         for i in range(2**len(bool_args)):
-            fname = self.mgr.Symbol("%s#%i" % (formula.function_name(),i), ftype)
+            fname = self.mgr.Symbol("%s#%i" % (formula.function_name(), i), ftype)
             if len(ptype) == 0:
                 stack.append(fname)
             else:

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -937,8 +937,11 @@ class MSatConverter(Converter, DagWalker):
         return res
 
     def walk_bv_xor(self, formula: FNode, args: List[Any], **kwargs) -> Any:
-        return self._msat_lib.msat_make_bv_xor(self.msat_env(),
-                                        args[0], args[1])
+        res = args[0]
+        for arg in args[1:]:
+            res = self._msat_lib.msat_make_bv_xor(self.msat_env(),
+                                                  res, arg)
+        return res
 
     def walk_bv_add(self, formula: FNode, args: List[Any], **kwargs) -> Any:
         res = args[0]

--- a/pysmt/solvers/yices.py
+++ b/pysmt/solvers/yices.py
@@ -27,13 +27,13 @@ from pysmt.solvers.eager import EagerModel
 from typing import Any, Dict, List, Optional, Set, cast
 
 try:
-    import yices_api # type: ignore[import]
+    import yices_api  # type: ignore[import]
 except ImportError:
     raise SolverAPINotFound
 
 
 from pysmt.solvers.solver import Solver, Converter, SolverOptions
-from pysmt.solvers.smtlib import SmtLibBasicSolver, SmtLibIgnoreMixin
+from pysmt.solvers.smtlib import SmtLibBasicSolver
 
 from pysmt.walkers import DagWalker
 from pysmt.exceptions import SolverReturnedUnknownResultError
@@ -51,14 +51,18 @@ def init():
         yices_api.yices_init()
     setattr(init, "initialized", True)
 
+
 def reset_yices():
     yices_api.yices_reset()
 
+
 init()
+
 
 @atexit.register
 def cleanup():
     yices_api.yices_exit()
+
 
 # Yices constants
 STATUS_UNKNOWN = 2
@@ -66,6 +70,7 @@ STATUS_SAT = 3
 STATUS_UNSAT = 4
 
 PRINTING_WIDTH = 999999999
+
 
 def yices_logic(pysmt_logic: pysmt.logics.Logic) -> str:
     """Return a Yices String representing the given pySMT logic."""
@@ -91,9 +96,9 @@ class YicesOptions(SolverOptions):
             # We raise the exception only if the parameter exists but the value
             # provided to the parameter is invalid.
             err = yices_api.yices_error_code()
-            if err == 502: # CTX_INVALID_PARAMETER_VALUE:
+            if err == 502:  # CTX_INVALID_PARAMETER_VALUE:
                 raise PysmtValueError("Error setting the option "
-                                      "'%s=%s'" % (name,value))
+                                      "'%s=%s'" % (name, value))
 
     def __call__(self, solver: "YicesSolver"):
         if self.generate_models:
@@ -108,7 +113,7 @@ class YicesOptions(SolverOptions):
             self._set_option(solver.yices_config,
                              "random-seed", str(self.random_seed))
 
-        for k,v in self.solver_options.items():
+        for k, v in self.solver_options.items():
             self._set_option(solver.yices_config, str(k), str(v))
 
     def set_params(self, solver: "YicesSolver"):
@@ -124,7 +129,7 @@ class YicesOptions(SolverOptions):
         """
         params = yices_api.yices_new_param_record()
         yices_api.yices_default_params_for_context(solver.yices, params)
-        for k,v in self.solver_options.items():
+        for k, v in self.solver_options.items():
             rv = yices_api.yices_set_param(params, k, v)
             if rv != 0:
                 raise PysmtValueError("Error setting the option '%s=%s'" % (k,v))
@@ -173,7 +178,7 @@ class YicesSolver(SmtLibBasicSolver):
         raise NotImplementedError
 
     @clear_pending_pop
-    def add_assertion(self, formula: FNode, named: None=None):
+    def add_assertion(self, formula: FNode, named: None = None):
         self._assert_is_boolean(formula)
         term = self.converter.convert(formula)
         code = yices_api.yices_assert_formula(self.yices, term)
@@ -181,9 +186,8 @@ class YicesSolver(SmtLibBasicSolver):
             msg = yices_api.yices_error_string()
             if code == -1 and "non-linear arithmetic" in msg:
                 raise NonLinearError(formula)
-            raise InternalSolverError("Yices returned non-zero code upon assert"\
-                                      ": %s (code: %s)" % \
-                                      (msg, code))
+            raise InternalSolverError("Yices returned non-zero code upon assert"
+                                      ": %s (code: %s)" % (msg, code))
 
     def get_model(self) -> EagerModel:
         assignment = {}
@@ -195,14 +199,16 @@ class YicesSolver(SmtLibBasicSolver):
             if s.is_symbol() and s.symbol_type().is_string_type():
                 continue
             if s.is_term():
-                if s.symbol_type().is_array_type(): continue
-                if s.symbol_type().is_custom_type(): continue
+                if s.symbol_type().is_array_type():
+                    continue
+                if s.symbol_type().is_custom_type():
+                    continue
                 v = self.get_value(s)
                 assignment[s] = v
         return EagerModel(assignment=assignment, environment=self.environment)
 
     @clear_pending_pop
-    def solve(self, assumptions: Optional[List[FNode]]=None) -> bool:
+    def solve(self, assumptions: Optional[List[FNode]] = None) -> bool:
         if assumptions is not None:
             self.push()
             self.add_assertion(self.mgr.And(assumptions))
@@ -228,7 +234,7 @@ class YicesSolver(SmtLibBasicSolver):
         raise NotImplementedError
 
     @clear_pending_pop
-    def push(self, levels: int=1):
+    def push(self, levels: int = 1):
         for _ in range(levels):
             c = yices_api.yices_push(self.yices)
             if c != 0:
@@ -240,18 +246,18 @@ class YicesSolver(SmtLibBasicSolver):
                     # spurious push calls
                     self.failed_pushes += 1
                 else:
-                    raise InternalSolverError("Error in push: %s" % \
+                    raise InternalSolverError("Error in push: %s" %
                                               yices_api.yices_error_string())
 
     @clear_pending_pop
-    def pop(self, levels: int=1):
+    def pop(self, levels: int = 1):
         for _ in range(levels):
             if self.failed_pushes > 0:
                 self.failed_pushes -= 1
             else:
                 c = yices_api.yices_pop(self.yices)
                 if c != 0:
-                    raise InternalSolverError("Error in pop: %s" % \
+                    raise InternalSolverError("Error in pop: %s" %
                                               yices_api.yices_error_string())
 
     def print_model(self, name_filter=None):
@@ -512,20 +518,21 @@ class YicesConverter(Converter, DagWalker):
         return res
 
     def walk_bv_concat(self, formula, args, **kwargs):
-        res = yices_api.yices_bvconcat2(args[0], args[1])
+        values = (yices_api.term_t * len(args))(*args)
+        res = yices_api.yices_bvconcat(len(args), values)
         self._check_term_result(res)
         return res
 
     def walk_bv_extract(self, formula, args, **kwargs):
         res = yices_api.yices_bvextract(args[0],
-                                       formula.bv_extract_start(),
-                                       formula.bv_extract_end())
+                                        formula.bv_extract_start(),
+                                        formula.bv_extract_end())
         self._check_term_result(res)
         return res
 
     def walk_bv_or(self, formula, args, **kwargs):
-        res = yices_api.yices_bvor2(args[0], args[1])
-        self._check_term_result(res)
+        values = (yices_api.term_t * len(args))(*args)
+        res = yices_api.yices_bvor(len(args), values)
         return res
 
     def walk_bv_not(self, formula, args, **kwargs):
@@ -534,8 +541,8 @@ class YicesConverter(Converter, DagWalker):
         return res
 
     def walk_bv_and(self, formula, args, **kwargs):
-        res = yices_api.yices_bvand2(args[0], args[1])
-        self._check_term_result(res)
+        values = (yices_api.term_t * len(args))(*args)
+        res = yices_api.yices_bvand(len(args), values)
         return res
 
     def walk_bv_xor(self, formula, args, **kwargs):
@@ -544,8 +551,8 @@ class YicesConverter(Converter, DagWalker):
         return res
 
     def walk_bv_add(self, formula, args, **kwargs):
-        res = yices_api.yices_bvadd(args[0], args[1])
-        self._check_term_result(res)
+        values = (yices_api.term_t * len(args))(*args)
+        res = yices_api.yices_bvsum(len(args), values)
         return res
 
     def walk_bv_sub(self, formula, args, **kwargs):
@@ -559,8 +566,8 @@ class YicesConverter(Converter, DagWalker):
         return res
 
     def walk_bv_mul(self, formula, args, **kwargs):
-        res = yices_api.yices_bvmul(args[0], args[1])
-        self._check_term_result(res)
+        values = (yices_api.term_t * len(args))(*args)
+        res = yices_api.yices_bvproduct(len(args), values)
         return res
 
     def walk_bv_udiv(self, formula, args, **kwargs):
@@ -598,7 +605,7 @@ class YicesConverter(Converter, DagWalker):
         self._check_term_result(res)
         return res
 
-    def walk_bv_sext (self, formula, args, **kwargs):
+    def walk_bv_sext(self, formula, args, **kwargs):
         res = yices_api.yices_sign_extend(args[0], formula.bv_extend_step())
         self._check_term_result(res)
         return res
@@ -608,13 +615,13 @@ class YicesConverter(Converter, DagWalker):
         self._check_term_result(res)
         return res
 
-    def walk_bv_sle (self, formula: FNode, args: List[int], **kwargs) -> int:
+    def walk_bv_sle(self, formula: FNode, args: List[int], **kwargs) -> int:
         res = yices_api.yices_bvsle_atom(args[0], args[1])
         self._check_term_result(res)
         return res
 
-    def walk_bv_comp (self, formula, args, **kwargs):
-        a,b = args
+    def walk_bv_comp(self, formula, args, **kwargs):
+        a, b = args
         eq = yices_api.yices_bveq_atom(a, b)
         self._check_term_result(eq)
         one = yices_api.yices_bvconst_int32(1, 1)
@@ -623,17 +630,17 @@ class YicesConverter(Converter, DagWalker):
         self._check_term_result(res)
         return res
 
-    def walk_bv_sdiv (self, formula, args, **kwargs):
+    def walk_bv_sdiv(self, formula, args, **kwargs):
         res = yices_api.yices_bvsdiv(args[0], args[1])
         self._check_term_result(res)
         return res
 
-    def walk_bv_srem (self, formula, args, **kwargs):
+    def walk_bv_srem(self, formula, args, **kwargs):
         res = yices_api.yices_bvsrem(args[0], args[1])
         self._check_term_result(res)
         return res
 
-    def walk_bv_ashr (self, formula, args, **kwargs):
+    def walk_bv_ashr(self, formula, args, **kwargs):
         res = yices_api.yices_bvashr(args[0], args[1])
         self._check_term_result(res)
         return res

--- a/pysmt/solvers/yices.py
+++ b/pysmt/solvers/yices.py
@@ -533,6 +533,7 @@ class YicesConverter(Converter, DagWalker):
     def walk_bv_or(self, formula, args, **kwargs):
         values = (yices_api.term_t * len(args))(*args)
         res = yices_api.yices_bvor(len(args), values)
+        self._check_term_result(res)
         return res
 
     def walk_bv_not(self, formula, args, **kwargs):
@@ -543,6 +544,7 @@ class YicesConverter(Converter, DagWalker):
     def walk_bv_and(self, formula, args, **kwargs):
         values = (yices_api.term_t * len(args))(*args)
         res = yices_api.yices_bvand(len(args), values)
+        self._check_term_result(res)
         return res
 
     def walk_bv_xor(self, formula, args, **kwargs):
@@ -553,6 +555,7 @@ class YicesConverter(Converter, DagWalker):
     def walk_bv_add(self, formula, args, **kwargs):
         values = (yices_api.term_t * len(args))(*args)
         res = yices_api.yices_bvsum(len(args), values)
+        self._check_term_result(res)
         return res
 
     def walk_bv_sub(self, formula, args, **kwargs):
@@ -568,6 +571,7 @@ class YicesConverter(Converter, DagWalker):
     def walk_bv_mul(self, formula, args, **kwargs):
         values = (yices_api.term_t * len(args))(*args)
         res = yices_api.yices_bvproduct(len(args), values)
+        self._check_term_result(res)
         return res
 
     def walk_bv_udiv(self, formula, args, **kwargs):

--- a/pysmt/solvers/yices.py
+++ b/pysmt/solvers/yices.py
@@ -548,7 +548,8 @@ class YicesConverter(Converter, DagWalker):
         return res
 
     def walk_bv_xor(self, formula, args, **kwargs):
-        res = yices_api.yices_bvxor2(args[0], args[1])
+        values = (yices_api.term_t * len(args))(*args)
+        res = yices_api.yices_bvxor(len(args), values)
         self._check_term_result(res)
         return res
 

--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -26,7 +26,7 @@ from pysmt.logics import Logic
 from pysmt.typing import PySMTType
 
 try:
-    import z3 # type: ignore[import]
+    import z3  # type: ignore[import]
 except ImportError:
     raise SolverAPINotFound
 
@@ -63,23 +63,26 @@ z3.is_function = lambda x: z3.is_app_of(x, z3.Z3_OP_UNINTERPRETED)
 z3.is_array_store = lambda x: z3.is_app_of(x, z3.Z3_OP_STORE)
 z3.is_infinite = lambda x: z3.is_const(x) and str(x.decl()) == "oo"
 z3.is_epsilon = lambda x: z3.is_const(x) and str(x.decl()) == "epsilon"
-z3.get_payload = lambda node,i : z3.Z3_get_decl_int_parameter(node.ctx.ref(),
+z3.get_payload = lambda node, i: z3.Z3_get_decl_int_parameter(node.ctx.ref(),
                                                               node.decl().ast, i)
+
 
 class AstRefKey:
     def __init__(self, n: z3.ExprRef):
         self.n = n
+
     def __hash__(self) -> int:
         return self.n.hash()
+
     def __eq__(self, other: object) -> bool:
         if isinstance(other, AstRefKey):
             return self.n.eq(other.n)
         return False
 
+
 def askey(n: z3.ExprRef) -> AstRefKey:
     assert isinstance(n, z3.AstRef)
     return AstRefKey(n)
-
 
 
 class Z3Model(Model):
@@ -89,7 +92,7 @@ class Z3Model(Model):
         self.z3_model = z3_model
         self.converter = Z3Converter(environment, z3_model.ctx)
 
-    def get_value(self, formula: FNode, model_completion: bool=True) -> FNode:
+    def get_value(self, formula: FNode, model_completion: bool = True) -> FNode:
         titem = self.converter.convert(formula)
         z3_res = self.z3_model.eval(titem, model_completion=model_completion)
         return self.converter.back(z3_res, model=self.z3_model)
@@ -137,13 +140,13 @@ class Z3Options(SolverOptions):
             self._set_option(solver.z3, 'unsat_core', True)
         if self.random_seed is not None:
             self._set_option(solver.z3, 'random_seed', self.random_seed)
-        for k,v in self.solver_options.items():
+        for k, v in self.solver_options.items():
             try:
                 self._set_option(solver.z3, str(k), v)
             except z3.Z3Exception:
-                raise PysmtValueError("Error setting the option '%s=%s'" % (k,v))
+                raise PysmtValueError("Error setting the option '%s=%s'" % (k, v))
             except z3.z3types.Z3Exception:
-                raise PysmtValueError("Error setting the option '%s=%s'" % (k,v))
+                raise PysmtValueError("Error setting the option '%s=%s'" % (k, v))
 # EOC Z3Options
 
 
@@ -189,7 +192,7 @@ class Z3Solver(IncrementalTrackingSolver, UnsatCoreSolver, SmtLibBasicSolver):
         raise NotImplementedError
 
     @clear_pending_pop
-    def _add_assertion(self, formula: FNode, named: Optional[str]=None):
+    def _add_assertion(self, formula: FNode, named: Optional[str] = None):
         self._assert_is_boolean(formula)
         term = self.converter.convert(formula)
 
@@ -208,7 +211,7 @@ class Z3Solver(IncrementalTrackingSolver, UnsatCoreSolver, SmtLibBasicSolver):
         return Z3Model(self.environment, self.z3.model())
 
     @clear_pending_pop
-    def _solve(self, assumptions: Optional[List[FNode]]=None) -> bool:
+    def _solve(self, assumptions: Optional[List[FNode]] = None) -> bool:
         if assumptions is not None:
             bool_ass = []
             other_ass = []
@@ -239,7 +242,7 @@ class Z3Solver(IncrementalTrackingSolver, UnsatCoreSolver, SmtLibBasicSolver):
 
     def _named_assertions_map(self):
         if self.options.unsat_cores_mode is not None:
-            return dict((t[0], (t[1],t[2])) for t in self.assertions)
+            return dict((t[0], (t[1], t[2])) for t in self.assertions)
         return None
 
     def get_named_unsat_core(self):
@@ -249,12 +252,11 @@ class Z3Solver(IncrementalTrackingSolver, UnsatCoreSolver, SmtLibBasicSolver):
             raise SolverNotConfiguredForUnsatCoresError
 
         if self.last_result is not False:
-            raise SolverStatusError("The last call to solve() was not" \
-                                    " unsatisfiable")
+            raise SolverStatusError("The last call to solve() was not unsatisfiable")
 
         if self.last_command != "solve":
-            raise SolverStatusError("The solver status has been modified by a" \
-                                    " '%s' command after the last call to" \
+            raise SolverStatusError("The solver status has been modified by a"
+                                    " '%s' command after the last call to"
                                     " solve()" % self.last_command)
 
         assumptions = self.z3.unsat_core()
@@ -277,12 +279,12 @@ class Z3Solver(IncrementalTrackingSolver, UnsatCoreSolver, SmtLibBasicSolver):
         raise NotImplementedError
 
     @clear_pending_pop
-    def _push(self, levels: int=1):
+    def _push(self, levels: int = 1):
         for _ in range(levels):
             self.z3.push()
 
     @clear_pending_pop
-    def _pop(self, levels: int=1):
+    def _pop(self, levels: int = 1):
         for _ in range(levels):
             self.z3.pop()
 
@@ -342,36 +344,36 @@ class Z3Converter(Converter, DagWalker):
             z3.Z3_OP_TO_REAL: lambda args, expr: self.mgr.ToReal(args[0]),
             z3.Z3_OP_TO_INT: lambda args, expr: self.mgr.ToInt(args[0]),
             z3.Z3_OP_IS_INT: lambda args, expr: self.mgr.IsInt(args[0]),
-            z3.Z3_OP_BAND : lambda args, expr: self.mgr.BVAnd(args),
-            z3.Z3_OP_BOR : lambda args, expr: self.mgr.BVOr(args),
-            z3.Z3_OP_BXOR : lambda args, expr: self.mgr.BVXor(args[0], args[1]),
-            z3.Z3_OP_BNOT : lambda args, expr: self.mgr.BVNot(args[0]),
-            z3.Z3_OP_BNEG : lambda args, expr: self.mgr.BVNeg(args[0]),
-            z3.Z3_OP_CONCAT : lambda args, expr: self.mgr.BVConcat(args),
-            z3.Z3_OP_ULT : lambda args, expr: self.mgr.BVULT(args[0], args[1]),
-            z3.Z3_OP_ULEQ : lambda args, expr: self.mgr.BVULE(args[0], args[1]),
-            z3.Z3_OP_SLT : lambda args, expr: self.mgr.BVSLT(args[0], args[1]),
-            z3.Z3_OP_SLEQ : lambda args, expr: self.mgr.BVSLE(args[0], args[1]),
-            z3.Z3_OP_UGT : lambda args, expr: self.mgr.BVUGT(args[0], args[1]),
-            z3.Z3_OP_UGEQ : lambda args, expr: self.mgr.BVUGE(args[0], args[1]),
-            z3.Z3_OP_SGT : lambda args, expr: self.mgr.BVSGT(args[0], args[1]),
-            z3.Z3_OP_SGEQ : lambda args, expr: self.mgr.BVSGE(args[0], args[1]),
-            z3.Z3_OP_BADD : lambda args, expr: self.mgr.BVAdd(args),
-            z3.Z3_OP_BMUL : lambda args, expr: self.mgr.BVMul(args),
-            z3.Z3_OP_BUDIV : lambda args, expr: self.mgr.BVUDiv(args[0], args[1]),
-            z3.Z3_OP_BSDIV : lambda args, expr: self.mgr.BVSDiv(args[0], args[1]),
-            z3.Z3_OP_BUREM : lambda args, expr: self.mgr.BVURem(args[0], args[1]),
-            z3.Z3_OP_BSREM : lambda args, expr: self.mgr.BVSRem(args[0], args[1]),
-            z3.Z3_OP_BSHL : lambda args, expr: self.mgr.BVLShl(args[0], args[1]),
-            z3.Z3_OP_BLSHR : lambda args, expr: self.mgr.BVLShr(args[0], args[1]),
-            z3.Z3_OP_BASHR : lambda args, expr: self.mgr.BVAShr(args[0], args[1]),
-            z3.Z3_OP_BSUB : lambda args, expr: self.mgr.BVSub(args[0], args[1]),
-            z3.Z3_OP_EXT_ROTATE_LEFT : lambda args, expr: self.mgr.BVRol(args[0], args[1].bv_unsigned_value()),
+            z3.Z3_OP_BAND: lambda args, expr: self.mgr.BVAnd(args),
+            z3.Z3_OP_BOR: lambda args, expr: self.mgr.BVOr(args),
+            z3.Z3_OP_BXOR: lambda args, expr: self.mgr.BVXor(args[0], args[1]),
+            z3.Z3_OP_BNOT: lambda args, expr: self.mgr.BVNot(args[0]),
+            z3.Z3_OP_BNEG: lambda args, expr: self.mgr.BVNeg(args[0]),
+            z3.Z3_OP_CONCAT: lambda args, expr: self.mgr.BVConcat(args),
+            z3.Z3_OP_ULT: lambda args, expr: self.mgr.BVULT(args[0], args[1]),
+            z3.Z3_OP_ULEQ: lambda args, expr: self.mgr.BVULE(args[0], args[1]),
+            z3.Z3_OP_SLT: lambda args, expr: self.mgr.BVSLT(args[0], args[1]),
+            z3.Z3_OP_SLEQ: lambda args, expr: self.mgr.BVSLE(args[0], args[1]),
+            z3.Z3_OP_UGT: lambda args, expr: self.mgr.BVUGT(args[0], args[1]),
+            z3.Z3_OP_UGEQ: lambda args, expr: self.mgr.BVUGE(args[0], args[1]),
+            z3.Z3_OP_SGT: lambda args, expr: self.mgr.BVSGT(args[0], args[1]),
+            z3.Z3_OP_SGEQ: lambda args, expr: self.mgr.BVSGE(args[0], args[1]),
+            z3.Z3_OP_BADD: lambda args, expr: self.mgr.BVAdd(args),
+            z3.Z3_OP_BMUL: lambda args, expr: self.mgr.BVMul(args),
+            z3.Z3_OP_BUDIV: lambda args, expr: self.mgr.BVUDiv(args[0], args[1]),
+            z3.Z3_OP_BSDIV: lambda args, expr: self.mgr.BVSDiv(args[0], args[1]),
+            z3.Z3_OP_BUREM: lambda args, expr: self.mgr.BVURem(args[0], args[1]),
+            z3.Z3_OP_BSREM: lambda args, expr: self.mgr.BVSRem(args[0], args[1]),
+            z3.Z3_OP_BSHL: lambda args, expr: self.mgr.BVLShl(args[0], args[1]),
+            z3.Z3_OP_BLSHR: lambda args, expr: self.mgr.BVLShr(args[0], args[1]),
+            z3.Z3_OP_BASHR: lambda args, expr: self.mgr.BVAShr(args[0], args[1]),
+            z3.Z3_OP_BSUB: lambda args, expr: self.mgr.BVSub(args[0], args[1]),
+            z3.Z3_OP_EXT_ROTATE_LEFT: lambda args, expr: self.mgr.BVRol(args[0], args[1].bv_unsigned_value()),
             z3.Z3_OP_EXT_ROTATE_RIGHT: lambda args, expr: self.mgr.BVRor(args[0], args[1].bv_unsigned_value()),
             z3.Z3_OP_BV2INT: lambda args, expr: self.mgr.BVToNatural(args[0]),
-            z3.Z3_OP_POWER : lambda args, expr: self.mgr.Pow(args[0], args[1]),
-            z3.Z3_OP_SELECT : lambda args, expr: self.mgr.Select(args[0], args[1]),
-            z3.Z3_OP_STORE : lambda args, expr: self.mgr.Store(args[0], args[1], args[2]),
+            z3.Z3_OP_POWER: lambda args, expr: self.mgr.Pow(args[0], args[1]),
+            z3.Z3_OP_SELECT: lambda args, expr: self.mgr.Select(args[0], args[1]),
+            z3.Z3_OP_STORE: lambda args, expr: self.mgr.Store(args[0], args[1], args[2]),
             # Actually use both args, expr
             z3.Z3_OP_SIGN_EXT: lambda args, expr: self.mgr.BVSExt(args[0], z3.get_payload(expr, 0)),
             z3.Z3_OP_ZERO_EXT: lambda args, expr: self.mgr.BVZExt(args[0], z3.get_payload(expr, 0)),
@@ -381,9 +383,9 @@ class Z3Converter(Converter, DagWalker):
                                                               z3.get_payload(expr, 1),
                                                               z3.get_payload(expr, 0)),
             # Complex Back Translation
-            z3.Z3_OP_EQ : self._back_z3_eq,
-            z3.Z3_OP_UMINUS : self._back_z3_uminus,
-            z3.Z3_OP_CONST_ARRAY : self._back_z3_const_array,
+            z3.Z3_OP_EQ: self._back_z3_eq,
+            z3.Z3_OP_UMINUS: self._back_z3_uminus,
+            z3.Z3_OP_CONST_ARRAY: self._back_z3_const_array,
         }
         # Unique reference to Sorts
         self.z3RealSort = z3.RealSort(self.ctx)
@@ -816,7 +818,7 @@ class Z3Converter(Converter, DagWalker):
                                 str(formula.bv_rotation_step()),
                                 bvsort.ast)
         z3term = z3.Z3_mk_ext_rotate_right(self.ctx.ref(),
-                                          args[0], step)
+                                           args[0], step)
         z3.Z3_inc_ref(self.ctx.ref(), z3term)
         return z3term
 
@@ -826,7 +828,7 @@ class Z3Converter(Converter, DagWalker):
         z3.Z3_inc_ref(self.ctx.ref(), z3term)
         return z3term
 
-    def walk_bv_sext (self, formula, args, **kwargs):
+    def walk_bv_sext(self, formula, args, **kwargs):
         z3term = z3.Z3_mk_sign_ext(self.ctx.ref(),
                                    formula.bv_extend_step(), args[0])
         z3.Z3_inc_ref(self.ctx.ref(), z3term)
@@ -905,6 +907,15 @@ class Z3Converter(Converter, DagWalker):
             return z3term
         return walk_binary
 
+    def make_walk_nary_to_binary(func):
+        def walk_n_to_b(self, formula, args, **kwargs):
+            z3term = args[0]
+            for arg in args[1:]:
+                z3term = func(self.ctx.ref(), z3term, arg)
+                z3.Z3_inc_ref(self.ctx.ref(), z3term)
+            return z3term
+        return walk_n_to_b
+
     walk_and     = make_walk_nary(z3.Z3_mk_and)
     walk_or      = make_walk_nary(z3.Z3_mk_or)
     walk_plus    = make_walk_nary(z3.Z3_mk_add)
@@ -921,13 +932,13 @@ class Z3Converter(Converter, DagWalker):
     walk_bv_ule  = make_walk_binary(z3.Z3_mk_bvule)
     walk_bv_slt  = make_walk_binary(z3.Z3_mk_bvslt)
     walk_bv_sle  = make_walk_binary(z3.Z3_mk_bvsle)
-    walk_bv_concat = make_walk_binary(z3.Z3_mk_concat)
-    walk_bv_or   = make_walk_binary(z3.Z3_mk_bvor)
-    walk_bv_and  = make_walk_binary(z3.Z3_mk_bvand)
+    walk_bv_concat = make_walk_nary_to_binary(z3.Z3_mk_concat)
+    walk_bv_or   = make_walk_nary_to_binary(z3.Z3_mk_bvor)
+    walk_bv_and  = make_walk_nary_to_binary(z3.Z3_mk_bvand)
     walk_bv_xor  = make_walk_binary(z3.Z3_mk_bvxor)
-    walk_bv_add  = make_walk_binary(z3.Z3_mk_bvadd)
+    walk_bv_add  = make_walk_nary_to_binary(z3.Z3_mk_bvadd)
     walk_bv_sub  = make_walk_binary(z3.Z3_mk_bvsub)
-    walk_bv_mul  = make_walk_binary(z3.Z3_mk_bvmul)
+    walk_bv_mul  = make_walk_nary_to_binary(z3.Z3_mk_bvmul)
     walk_bv_udiv = make_walk_binary(z3.Z3_mk_bvudiv)
     walk_bv_urem = make_walk_binary(z3.Z3_mk_bvurem)
     walk_bv_lshl = make_walk_binary(z3.Z3_mk_bvshl)
@@ -981,14 +992,15 @@ class Z3QuantifierEliminator(QuantifierEliminator):
     def eliminate_quantifiers(self, formula):
         logic = get_logic(formula, self.environment)
         if not logic <= LRA and not logic <= LIA:
-            raise PysmtValueError("Z3 quantifier elimination only "\
-                                  "supports LRA or LIA without combination."\
+            raise PysmtValueError("Z3 quantifier elimination only "
+                                  "supports LRA or LIA without combination."
                                   "(detected logic is: %s)" % str(logic))
 
         simplifier = z3.Tactic('simplify')
         eliminator = z3.Tactic('qe')
 
         f = self.converter.convert(formula)
+        # TODO: this is unused, remove or use?
         s = simplifier(f, elim_and=True,
                        pull_cheap_ite=True,
                        ite_extra_rules=True).as_expr()
@@ -1000,13 +1012,13 @@ class Z3QuantifierEliminator(QuantifierEliminator):
         except ConvertExpressionError:
             if logic <= LRA:
                 raise
-            raise ConvertExpressionError(message=("Unable to represent" \
-                "expression %s in pySMT: the quantifier elimination for " \
-                "LIA is incomplete as it requires the modulus. You can " \
-                "find the Z3 expression representing the quantifier " \
-                "elimination as the attribute 'expression' of this " \
+            raise ConvertExpressionError(message=("Unable to represent"
+                "expression %s in pySMT: the quantifier elimination for "
+                "LIA is incomplete as it requires the modulus. You can "
+                "find the Z3 expression representing the quantifier "
+                "elimination as the attribute 'expression' of this "
                 "exception object" % str(res)),
-                                          expression=res)
+                                         expression=res)
 
         return pysmt_res
 

--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -935,7 +935,7 @@ class Z3Converter(Converter, DagWalker):
     walk_bv_concat = make_walk_nary_to_binary(z3.Z3_mk_concat)
     walk_bv_or   = make_walk_nary_to_binary(z3.Z3_mk_bvor)
     walk_bv_and  = make_walk_nary_to_binary(z3.Z3_mk_bvand)
-    walk_bv_xor  = make_walk_binary(z3.Z3_mk_bvxor)
+    walk_bv_xor  = make_walk_nary_to_binary(z3.Z3_mk_bvxor)
     walk_bv_add  = make_walk_nary_to_binary(z3.Z3_mk_bvadd)
     walk_bv_sub  = make_walk_binary(z3.Z3_mk_bvsub)
     walk_bv_mul  = make_walk_nary_to_binary(z3.Z3_mk_bvmul)

--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -912,7 +912,7 @@ class Z3Converter(Converter, DagWalker):
             z3term = args[0]
             for arg in args[1:]:
                 z3term = func(self.ctx.ref(), z3term, arg)
-                z3.Z3_inc_ref(self.ctx.ref(), z3term)
+            z3.Z3_inc_ref(self.ctx.ref(), z3term)
             return z3term
         return walk_n_to_b
 

--- a/pysmt/test/__init__.py
+++ b/pysmt/test/__init__.py
@@ -40,10 +40,12 @@ class TestCase(unittest.TestCase):
         pass
 
     if "assertRaisesRegex" not in dir(unittest.TestCase):
-        assertRaisesRegex = unittest.TestCase.assertRaisesRegexp # type: ignore[attr-defined]
+        assertRaisesRegex = unittest.TestCase.assertRaisesRegexp  # type: ignore[attr-defined]
 
-
-    def assertValid(self, formula: FNode, msg: Optional[Union[str, Tuple[FNode, FNode], FNode]]=None, solver_name: None=None, logic: Optional[Logic]=None):
+    def assertValid(self, formula: FNode,
+                    msg: Optional[Union[str, Tuple[FNode, FNode], FNode]] = None,
+                    solver_name: None = None,
+                    logic: Optional[Logic] = None):
         """Assert that formula is VALID."""
         self.assertTrue(self.env.factory.is_valid(formula=formula,
                                                   solver_name=solver_name,

--- a/pysmt/test/examples.py
+++ b/pysmt/test/examples.py
@@ -29,10 +29,10 @@ from pysmt.shortcuts import (Symbol, Function,
                              BVNot, BVAnd, BVOr, BVXor,
                              BVConcat, BVExtract,
                              BVULT, BVUGT, BVULE, BVUGE, BVSGE,
-                             BVNeg, BVAdd, BVMul, BVUDiv, BVURem, BVSub,
-                             BVLShl, BVLShr,BVRol, BVRor,
+                             BVNeg, BVAdd, BVMul, BVUDiv, BVURem,
+                             BVLShl, BVLShr, BVRol, BVRor,
                              BVZExt, BVSExt, BVSub, BVComp, BVAShr, BVSLE,
-                             BVSLT, BVSGT, BVSGE, BVSDiv, BVSRem,
+                             BVSLT, BVSGT, BVSDiv, BVSRem,
                              String, StrCharAt, StrConcat, StrContains,
                              StrIndexOf, StrLength, StrPrefixOf, StrReplace,
                              StrSubstr, StrSuffixOf, StrToInt,
@@ -146,8 +146,8 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_IDL
                 ),
 
-            Example(hr="(((p + q) = 5) & (q < p))",
-                    expr=And(Equals(Plus(p,q),Int(5)) , GT(p, q)),
+            Example(hr="((q < p) & ((p + q) = 5))",
+                    expr=And(Equals(Plus(p, q), Int(5)), GT(p, q)),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_LIA
@@ -174,7 +174,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_IDL
                 ),
 
-            Example(hr="((x ? 7 : ((p + -1) * 3)) = q)",
+            Example(hr="(q = (x ? 7 : ((p + -1) * 3)))",
                     expr=Equals(Ite(x,
                                     Int(7),
                                     Times(Plus(p, Int(-1)), Int(3))), q),
@@ -193,15 +193,16 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
             #
             # LRA
             #
-            Example(hr="((s < r) & (x -> y))",
+            Example(hr="((x -> y) & (s < r))",
                     expr=And(GT(r, s), Implies(x, y)),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_RDL
                 ),
 
-            Example(hr="(((r + s) = 28/5) & (s < r))",
-                    expr=And(Equals(Plus(r,s), Real(Fraction("5.6"))) , GT(r, s)),
+            Example(hr="((s < r) & ((r + s) = 28/5))",
+                    expr=And(Equals(Plus(r, s), Real(Fraction("5.6"))),
+                             GT(r, s)),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_LRA
@@ -228,8 +229,10 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_RDL
                 ),
 
-            Example(hr="((x ? 7.0 : ((s + -1.0) * 3.0)) = r)",
-                    expr=Equals( Ite(x, Real(7), Times(Plus(s, Real(-1)), Real(3))), r),
+            Example(hr="(r = (x ? 7.0 : ((s + -1.0) * 3.0)))",
+                    expr=Equals(Ite(x, Real(7),
+                                    Times(Plus(s, Real(-1)), Real(3))),
+                                r),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_LRA
@@ -252,7 +255,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_UFLRA
                 ),
 
-            Example(hr="((rg(r) = (5.0 + 2.0)) <-> (rg(r) = 7.0))",
+            Example(hr="((rg(r) = (2.0 + 5.0)) <-> (7.0 = rg(r)))",
                     expr=Iff(Equals(Function(rg, [r]), Plus(Real(5), Real(2))),
                              Equals(Function(rg, [r]), Real(7))),
                     is_valid=True,
@@ -260,7 +263,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_UFLRA
                 ),
 
-            Example(hr="((r = (s + 1.0)) & (rg(s) = 5.0) & (rg((r - 1.0)) = 7.0))",
+            Example(hr="((r = (s + 1.0)) & (5.0 = rg(s)) & (7.0 = rg((r - 1.0))))",
                     expr=And([Equals(r, Plus(s, Real(1))),
                               Equals(Function(rg, [s]), Real(5)),
                               Equals(
@@ -273,7 +276,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
             #
             # BV
             #
-            Example(hr="((1_32 & 0_32) = 0_32)",
+            Example(hr="(0_32 = (1_32 & 0_32))",
                     expr=Equals(BVAnd(BVOne(32), BVZero(32)),
                                 BVZero(32)),
                     is_valid=True,
@@ -289,7 +292,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((! bv3) = 5_3)",
+            Example(hr="(5_3 = (! bv3))",
                     expr=Equals(BVNot(bv3),
                                 BV("101")),
                     is_valid=False,
@@ -297,7 +300,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((7_3 xor 0_3) = 0_3)",
+            Example(hr="(0_3 = (7_3 xor 0_3))",
                     expr=Equals(BVXor(BV("111"), BV("000")),
                                 BV("000")),
                     is_valid=False,
@@ -305,7 +308,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((7_3 xor bv3) = (6_3 xor bv3))",
+            Example(hr="((bv3 xor 7_3) = (bv3 xor 6_3))",
                     expr=Equals(BVXor(BV("111"), bv3),
                                 BVXor(BV("110"), bv3)),
                     is_valid=False,
@@ -368,7 +371,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((((1_32 + (- 1_32)) << 1_32) >> 1_32) = 1_32)",
+            Example(hr="(1_32 = (((1_32 + (- 1_32)) << 1_32) >> 1_32))",
                     expr=Equals(BVLShr(BVLShl(BVAdd(BVOne(32),
                                                     BVNeg(BVOne(32))),
                                               1), 1),
@@ -378,7 +381,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((1_32 - 1_32) = 0_32)",
+            Example(hr="(0_32 = (1_32 - 1_32))",
                     expr=Equals(BVSub(BVOne(32), BVOne(32)), BVZero(32)),
                     is_valid=True,
                     is_sat=True,
@@ -386,7 +389,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                 ),
 
             # Rotations
-            Example(hr="(((1_32 ROL 1) ROR 1) = 1_32)",
+            Example(hr="(1_32 = ((1_32 ROL 1) ROR 1))",
                     expr=Equals(BVRor(BVRol(BVOne(32), 1),1), BVOne(32)),
                     is_valid=True,
                     is_sat=True,
@@ -418,14 +421,14 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((bv16 - bv16) = 0_16)",
+            Example(hr="(0_16 = (bv16 - bv16))",
                     expr=Equals(BVSub(bv16, bv16), BVZero(16)),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((bv16 - bv16)[0:7] = bv8)",
+            Example(hr="(bv8 = (bv16 - bv16)[0:7])",
                     expr=Equals(BVExtract(BVSub(bv16, bv16), 0, 7), bv8),
                     is_valid=False,
                     is_sat=True,
@@ -439,7 +442,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((bv16 bvcomp bv16) = 0_1)",
+            Example(hr="(0_1 = (bv16 bvcomp bv16))",
                     expr=Equals(BVComp(bv16, bv16), BVZero(1)),
                     is_valid=False,
                     is_sat=False,
@@ -460,7 +463,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((bv16 s< 0_16) | (0_16 s<= bv16))",
+            Example(hr="((0_16 s<= bv16) | (bv16 s< 0_16))",
                     expr=Or(BVSGT(BVZero(16), bv16), BVSGE(bv16, BVZero(16))),
                     is_valid=True,
                     is_sat=True,
@@ -481,28 +484,28 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((bv16 | 0_16) = bv16)",
+            Example(hr="(bv16 = (bv16 | 0_16))",
                     expr=Equals(BVOr(bv16, BVZero(16)), bv16),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((bv16 | 5_16) = bv16)",
+            Example(hr="(bv16 = (bv16 | 5_16))",
                     expr=Equals(BVOr(bv16, BV(5, 16)), bv16),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((bv16 & 0_16) = 0_16)",
+            Example(hr="(0_16 = (bv16 & 0_16))",
                     expr=Equals(BVAnd(bv16, BVZero(16)), BVZero(16)),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((bv16 & 7_16) = 0_16)",
+            Example(hr="(0_16 = (bv16 & 7_16))",
                     expr=Equals(BVAnd(bv16, BV(7, 16)), BVZero(16)),
                     is_valid=False,
                     is_sat=True,
@@ -525,35 +528,35 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((bv16 u% 1_16) = 0_16)",
+            Example(hr="(0_16 = (bv16 u% 1_16))",
                     expr=Equals(BVURem(bv16, BVOne(16)), BVZero(16)),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((bv16 u% bv16) = 0_16)",
+            Example(hr="(0_16 = (bv16 u% bv16))",
                     expr=Equals(BVURem(bv16, bv16), BVZero(16)),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((bv16 s% 1_16) = 0_16)",
+            Example(hr="(0_16 = (bv16 s% 1_16))",
                     expr=Equals(BVSRem(bv16, BVOne(16)), BVZero(16)),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((bv16 s% bv16) = 0_16)",
+            Example(hr="(0_16 = (bv16 s% bv16))",
                     expr=Equals(BVSRem(bv16, bv16), BVZero(16)),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((bv16 s% (- 1_16)) = 0_16)",
+            Example(hr="(0_16 = (bv16 s% (- 1_16)))",
                     expr=Equals(BVSRem(bv16, BVNeg(BVOne(16))), BVZero(16)),
                     is_valid=True,
                     is_sat=True,
@@ -567,7 +570,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((bv16 a>> 0_16) = bv16)",
+            Example(hr="(bv16 = (bv16 a>> 0_16))",
                     expr=Equals(BVAShr(bv16, BVZero(16)), bv16),
                     is_valid=True,
                     is_sat=True,
@@ -583,7 +586,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(bv2nat(1_8) = 1)",
+            Example(hr="(1 = bv2nat(1_8))",
                     expr=Equals(BVToNatural(BVOne(8)), Int(1)),
                     is_valid=True,
                     is_sat=True,
@@ -661,14 +664,14 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
             #
             # UFLIRA
             #
-            Example(hr="((p < ih(r, q)) & (x -> y))",
+            Example(hr="((x -> y) & (p < ih(r, q)))",
                     expr=And(GT(Function(ih, (r, q)), p), Implies(x, y)),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_UFLIRA
                 ),
 
-            Example(hr="(((p - 3) = q) -> ((p < ih(r, (q + 3))) | (ih(r, p) <= p)))",
+            Example(hr="((q = (p - 3)) -> ((p < ih(r, (q + 3))) | (ih(r, p) <= p)))",
                     expr=Implies(Equals(Minus(p, Int(3)), q),
                                  Or(GT(Function(ih, (r, Plus(q, Int(3)))), p),
                                     LE(Function(ih, (r, p)), p))),
@@ -677,7 +680,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_UFLIRA
                 ),
 
-            Example(hr="(((ToReal((p - 3)) = r) & (ToReal(q) = r)) -> ((p < ih(ToReal((p - 3)), (q + 3))) | (ih(r, p) <= p)))",
+            Example(hr="(((r = ToReal((p - 3))) & (r = ToReal(q))) -> ((ih(r, p) <= p) | (p < ih(ToReal((p - 3)), (q + 3)))))",
                     expr=Implies(And(Equals(ToReal(Minus(p, Int(3))), r),
                                      Equals(ToReal(q), r)),
                                  Or(GT(Function(ih, (ToReal(Minus(p, Int(3))),
@@ -688,7 +691,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_UFLIRA
                 ),
 
-            Example(hr="(! (((ToReal((p - 3)) = r) & (ToReal(q) = r)) -> ((p < ih(ToReal((p - 3)), (q + 3))) | (ih(r, p) <= p))))",
+            Example(hr="(! (((r = ToReal((p - 3))) & (r = ToReal(q))) -> ((ih(r, p) <= p) | (p < ih(ToReal((p - 3)), (q + 3))))))",
                     expr=Not(Implies(And(Equals(ToReal(Minus(p, Int(3))), r),
                                          Equals(ToReal(q), r)),
                                      Or(GT(Function(ih, (ToReal(Minus(p, Int(3))),
@@ -709,7 +712,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                 ),
 
             # ToInt must not truncate towards zero
-            Example(hr="((r = -3/2) & (ToInt(r) = -1))",
+            Example(hr="((r = -3/2) & (-1 = ToInt(r)))",
                     expr=And(Equals(r, Real(Fraction(-3, 2))),
                              Equals(ToInt(r), Int(-1))),
                     is_valid=False,
@@ -717,7 +720,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_LIRA
                 ),
 
-            Example(hr="((ToInt(r) = p) & (0.0 < r))",
+            Example(hr="((0.0 < r) & (p = ToInt(r)))",
                     expr=And(Equals(ToInt(r), p),
                              GT(r, Real(0))),
                     is_valid=False,
@@ -727,14 +730,14 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
             #
             # STR
             #
-            Example(hr='("mystr" = str1)',
+            Example(hr='(str1 = "mystr")',
                     expr=Equals(String("mystr"), str1),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_SLIA
                 ),
 
-            Example(hr='((5 < str.len(str1)) & ("mystr" = str1))',
+            Example(hr='((str1 = "mystr") & (5 < str.len(str1)))',
                     expr=And(LT(Int(5), StrLength(str1)),
                              Equals(String("mystr"), str1)),
                     is_valid=False,
@@ -742,7 +745,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_SLIA
                 ),
 
-            Example(hr='((5 = str.len(str1)) & (str.++("my", "str") = str1))',
+            Example(hr='((5 = str.len(str1)) & (str1 = str.++("my", "str")))',
                     expr=And(Equals(Int(5), StrLength(str1)),
                              Equals(StrConcat(String("my"),String("str")), str1)),
                     is_valid=False,
@@ -758,20 +761,20 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                 ),
 
             Example(hr='str.contains("mystr", "my")',
-                    expr=StrContains(String("mystr"),String("my")),
+                    expr=StrContains(String("mystr"), String("my")),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_SLIA
                 ),
 
-            Example(hr='(str.indexof("mystr", "str", 1) = 2)',
-                    expr=Equals(StrIndexOf(String("mystr"),String("str"),Int(1)),Int(2)),
+            Example(hr='(2 = str.indexof("mystr", "str", 1))',
+                    expr=Equals(StrIndexOf(String("mystr"), String("str"), Int(1)), Int(2)),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_SLIA
                 ),
 
-            Example(hr='(str.indexof(str1, "str", 1) = 2)',
+            Example(hr='(2 = str.indexof(str1, "str", 1))',
                     expr=Equals(StrIndexOf(str1,String("str"),Int(1)),Int(2)),
                     is_valid=False,
                     is_sat=True,
@@ -811,7 +814,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     is_sat=True,
                     logic=pysmt.logics.QF_SLIA),
 
-            Example(hr='(str.to.int("9") = 9)',
+            Example(hr='(9 = str.to.int("9"))',
                     expr=Equals(StrToInt(String("9")), Int(9)),
                     is_valid=True,
                     is_sat=True,
@@ -838,7 +841,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     is_sat=True,
                     logic=pysmt.logics.QF_ALIA),
 
-            Example(hr="(aii[0 := 0][0] = 0)",
+            Example(hr="(0 = aii[0 := 0][0])",
                     expr=Equals(Select(Store(aii, Int(0), Int(0)), Int(0)),
                                 Int(0)),
                     is_valid=True,
@@ -846,28 +849,28 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_ALIA
                 ),
 
-            Example(hr="((Array{Int, Int}(0)[1 := 1] = aii) & (aii[1] = 0))",
+            Example(hr="((aii = Array{Int, Int}(0)[1 := 1]) & (0 = aii[1]))",
                     expr=And(Equals(Array(INT, Int(0), {Int(1) : Int(1)}), aii), Equals(Select(aii, Int(1)), Int(0))),
                     is_valid=False,
                     is_sat=False,
                     logic=pysmt.logics.get_logic_by_name("QF_ALIA*")
                 ),
 
-            Example(hr="((Array{Int, Int}(0)[1 := 3] = aii) & (aii[1] = 3))",
+            Example(hr="((aii = Array{Int, Int}(0)[1 := 3]) & (3 = aii[1]))",
                     expr=And(Equals(Array(INT, Int(0), {Int(1) : Int(3)}), aii), Equals(Select(aii, Int(1)), Int(3))),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.get_logic_by_name("QF_ALIA*")
                 ),
 
-            Example(hr="((Array{Real, Int}(10) = ari) & (ari[6/5] = 0))",
+            Example(hr="((ari = Array{Real, Int}(10)) & (0 = ari[6/5]))",
                     expr=And(Equals(Array(REAL, Int(10)), ari), Equals(Select(ari, Real((6, 5))), Int(0))),
                     is_valid=False,
                     is_sat=False,
                     logic=pysmt.logics.get_logic_by_name("QF_AUFBVLIRA*")
                 ),
 
-            Example(hr="((Array{Real, Int}(0)[1.0 := 10][2.0 := 20][3.0 := 30][4.0 := 40] = ari) & (! ((ari[0.0] = 0) & (ari[1.0] = 10) & (ari[2.0] = 20) & (ari[3.0] = 30) & (ari[4.0] = 40))))",
+            Example(hr="((ari = Array{Real, Int}(0)[1.0 := 10][2.0 := 20][3.0 := 30][4.0 := 40]) & (! ((0 = ari[0.0]) & (10 = ari[1.0]) & (20 = ari[2.0]) & (30 = ari[3.0]) & (40 = ari[4.0]))))",
                     expr=And(Equals(Array(REAL, Int(0), {Real(1) : Int(10), Real(2) : Int(20), Real(3) : Int(30), Real(4) : Int(40)}), ari),
                              Not(And(Equals(Select(ari, Real(0)), Int(0)),
                                      Equals(Select(ari, Real(1)), Int(10)),
@@ -879,7 +882,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.get_logic_by_name("QF_AUFBVLIRA*")
                 ),
 
-            Example(hr="((Array{Real, Int}(0)[1.0 := 10][2.0 := 20][3.0 := 30][4.0 := 40][5.0 := 50] = ari) & (! ((ari[0.0] = 0) & (ari[1.0] = 10) & (ari[2.0] = 20) & (ari[3.0] = 30) & (ari[4.0] = 40) & (ari[5.0] = 50))))",
+            Example(hr="((ari = Array{Real, Int}(0)[1.0 := 10][2.0 := 20][3.0 := 30][4.0 := 40][5.0 := 50]) & (! ((0 = ari[0.0]) & (10 = ari[1.0]) & (20 = ari[2.0]) & (30 = ari[3.0]) & (40 = ari[4.0]) & (50 = ari[5.0]))))",
                     expr=And(Equals(Array(REAL, Int(0), {Real(1) : Int(10), Real(2) : Int(20), Real(3) : Int(30), Real(4) : Int(40), Real(5) : Int(50)}), ari),
                              Not(And(Equals(Select(ari, Real(0)), Int(0)),
                                      Equals(Select(ari, Real(1)), Int(10)),
@@ -892,14 +895,14 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.get_logic_by_name("QF_AUFBVLIRA*")
                 ),
 
-            Example(hr="((Array{BV{8}, BV{8}}(0_8)[1_8 := 42_8] = abb) & (abb[1_8] = 42_8))",
+            Example(hr="((abb = Array{BV{8}, BV{8}}(0_8)[1_8 := 42_8]) & (42_8 = abb[1_8]))",
                     expr=And(Equals(Array(BV8, BV(0, 8), {BV(1, 8) : BV(42, 8)}), abb), Equals(Select(abb, BV(1, 8)), BV(42, 8))),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.get_logic_by_name("QF_ABV*")
                 ),
 
-            Example(hr="((a_arb_aii = Array{Array{Real, BV{8}}, Array{Int, Int}}(Array{Int, Int}(7))) -> (a_arb_aii[arb][42] = 7))",
+            Example(hr="((a_arb_aii = Array{Array{Real, BV{8}}, Array{Int, Int}}(Array{Int, Int}(7))) -> (7 = a_arb_aii[arb][42]))",
                     expr=Implies(Equals(nested_a, Array(ArrayType(REAL, BV8),
                                                         Array(INT, Int(7)))),
                                  Equals(Select(Select(nested_a, arb), Int(42)),
@@ -932,14 +935,14 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_NRA
                 ),
 
-            Example(hr="((p ^ 2) = 0.0)",
+            Example(hr="(0.0 = (p ^ 2))",
                     expr=Equals(Pow(p, Int(2)), Real(0)),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_NIRA
                     ),
 
-            Example(hr="((r ^ 2.0) = 0.0)",
+            Example(hr="(0.0 = (r ^ 2.0))",
                     expr=Equals(Pow(r, Real(2)), Real(0)),
                     is_valid=False,
                     is_sat=True,
@@ -953,7 +956,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_NRA
                 ),
 
-            Example(hr="((5.0 * r * 5.0) = 25.0)",
+            Example(hr="(25.0 = (r * 5.0 * 5.0))",
                     expr=Equals(Times(Real(5), r, Real(5)), Real(25)),
                     is_valid=False,
                     is_sat=True,
@@ -967,14 +970,14 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_NIA
                 ),
 
-            Example(hr="((5 * p * 5) = 25)",
+            Example(hr="(25 = (p * 5 * 5))",
                     expr=Equals(Times(Int(5), p, Int(5)), Int(25)),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_LIA
                 ),
 
-            Example(hr="(((1 - 1) * p * 1) = 0)",
+            Example(hr="(0 = (p * 1 * (1 - 1)))",
                     expr=Equals(Times(Minus(Int(1), Int(1)), p, Int(1)),
                                 Int(0)),
                     is_valid=True,
@@ -991,7 +994,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_LRA
                 ),
 
-            Example(hr="(((r + 5.0 + s) * (s + 2.0 + r)) = 0.0)",
+            Example(hr="(0.0 = ((r + s + 5.0) * (r + s + 2.0)))",
                     expr=Equals(Times(Plus(r, Real(5), s),
                                       Plus(s, Real(2), r)),
                                 Real(0)),
@@ -999,7 +1002,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     is_sat=True,
                     logic=pysmt.logics.QF_NRA),
 
-            Example(hr="(((p + 5 + q) * (p - (q - 5))) = ((p * p) + (10 * p) + 25 + (-1 * q * q)))",
+            Example(hr="(((p + q + 5) * (p - (q - 5))) = (25 + (p * p) + (p * 10) + (q * q * -1)))",
                     expr=Equals(Times(Plus(p, Int(5), q),
                                       Minus(p, Minus(q, Int(5)))),
                                 Plus(Times(p, p),

--- a/pysmt/test/examples.py
+++ b/pysmt/test/examples.py
@@ -29,10 +29,10 @@ from pysmt.shortcuts import (Symbol, Function,
                              BVNot, BVAnd, BVOr, BVXor,
                              BVConcat, BVExtract,
                              BVULT, BVUGT, BVULE, BVUGE, BVSGE,
-                             BVNeg, BVAdd, BVMul, BVUDiv, BVURem,
-                             BVLShl, BVLShr, BVRol, BVRor,
+                             BVNeg, BVAdd, BVMul, BVUDiv, BVURem, BVSub,
+                             BVLShl, BVLShr,BVRol, BVRor,
                              BVZExt, BVSExt, BVSub, BVComp, BVAShr, BVSLE,
-                             BVSLT, BVSGT, BVSDiv, BVSRem,
+                             BVSLT, BVSGT, BVSGE, BVSDiv, BVSRem,
                              String, StrCharAt, StrConcat, StrContains,
                              StrIndexOf, StrLength, StrPrefixOf, StrReplace,
                              StrSubstr, StrSuffixOf, StrToInt,
@@ -146,8 +146,8 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_IDL
                 ),
 
-            Example(hr="((q < p) & ((p + q) = 5))",
-                    expr=And(Equals(Plus(p, q), Int(5)), GT(p, q)),
+            Example(hr="(((p + q) = 5) & (q < p))",
+                    expr=And(Equals(Plus(p,q),Int(5)) , GT(p, q)),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_LIA
@@ -174,7 +174,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_IDL
                 ),
 
-            Example(hr="(q = (x ? 7 : ((p + -1) * 3)))",
+            Example(hr="((x ? 7 : ((p + -1) * 3)) = q)",
                     expr=Equals(Ite(x,
                                     Int(7),
                                     Times(Plus(p, Int(-1)), Int(3))), q),
@@ -193,16 +193,15 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
             #
             # LRA
             #
-            Example(hr="((x -> y) & (s < r))",
+            Example(hr="((s < r) & (x -> y))",
                     expr=And(GT(r, s), Implies(x, y)),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_RDL
                 ),
 
-            Example(hr="((s < r) & ((r + s) = 28/5))",
-                    expr=And(Equals(Plus(r, s), Real(Fraction("5.6"))),
-                             GT(r, s)),
+            Example(hr="(((r + s) = 28/5) & (s < r))",
+                    expr=And(Equals(Plus(r,s), Real(Fraction("5.6"))) , GT(r, s)),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_LRA
@@ -229,10 +228,8 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_RDL
                 ),
 
-            Example(hr="(r = (x ? 7.0 : ((s + -1.0) * 3.0)))",
-                    expr=Equals(Ite(x, Real(7),
-                                    Times(Plus(s, Real(-1)), Real(3))),
-                                r),
+            Example(hr="((x ? 7.0 : ((s + -1.0) * 3.0)) = r)",
+                    expr=Equals( Ite(x, Real(7), Times(Plus(s, Real(-1)), Real(3))), r),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_LRA
@@ -255,7 +252,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_UFLRA
                 ),
 
-            Example(hr="((rg(r) = (2.0 + 5.0)) <-> (7.0 = rg(r)))",
+            Example(hr="((rg(r) = (5.0 + 2.0)) <-> (rg(r) = 7.0))",
                     expr=Iff(Equals(Function(rg, [r]), Plus(Real(5), Real(2))),
                              Equals(Function(rg, [r]), Real(7))),
                     is_valid=True,
@@ -263,7 +260,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_UFLRA
                 ),
 
-            Example(hr="((r = (s + 1.0)) & (5.0 = rg(s)) & (7.0 = rg((r - 1.0))))",
+            Example(hr="((r = (s + 1.0)) & (rg(s) = 5.0) & (rg((r - 1.0)) = 7.0))",
                     expr=And([Equals(r, Plus(s, Real(1))),
                               Equals(Function(rg, [s]), Real(5)),
                               Equals(
@@ -276,7 +273,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
             #
             # BV
             #
-            Example(hr="(0_32 = (1_32 & 0_32))",
+            Example(hr="((1_32 & 0_32) = 0_32)",
                     expr=Equals(BVAnd(BVOne(32), BVZero(32)),
                                 BVZero(32)),
                     is_valid=True,
@@ -292,7 +289,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(5_3 = (! bv3))",
+            Example(hr="((! bv3) = 5_3)",
                     expr=Equals(BVNot(bv3),
                                 BV("101")),
                     is_valid=False,
@@ -300,7 +297,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(0_3 = (7_3 xor 0_3))",
+            Example(hr="((7_3 xor 0_3) = 0_3)",
                     expr=Equals(BVXor(BV("111"), BV("000")),
                                 BV("000")),
                     is_valid=False,
@@ -308,7 +305,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((bv3 xor 7_3) = (bv3 xor 6_3))",
+            Example(hr="((7_3 xor bv3) = (6_3 xor bv3))",
                     expr=Equals(BVXor(BV("111"), bv3),
                                 BVXor(BV("110"), bv3)),
                     is_valid=False,
@@ -371,7 +368,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(1_32 = (((1_32 + (- 1_32)) << 1_32) >> 1_32))",
+            Example(hr="((((1_32 + (- 1_32)) << 1_32) >> 1_32) = 1_32)",
                     expr=Equals(BVLShr(BVLShl(BVAdd(BVOne(32),
                                                     BVNeg(BVOne(32))),
                                               1), 1),
@@ -381,7 +378,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(0_32 = (1_32 - 1_32))",
+            Example(hr="((1_32 - 1_32) = 0_32)",
                     expr=Equals(BVSub(BVOne(32), BVOne(32)), BVZero(32)),
                     is_valid=True,
                     is_sat=True,
@@ -389,7 +386,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                 ),
 
             # Rotations
-            Example(hr="(1_32 = ((1_32 ROL 1) ROR 1))",
+            Example(hr="(((1_32 ROL 1) ROR 1) = 1_32)",
                     expr=Equals(BVRor(BVRol(BVOne(32), 1),1), BVOne(32)),
                     is_valid=True,
                     is_sat=True,
@@ -421,14 +418,14 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(0_16 = (bv16 - bv16))",
+            Example(hr="((bv16 - bv16) = 0_16)",
                     expr=Equals(BVSub(bv16, bv16), BVZero(16)),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(bv8 = (bv16 - bv16)[0:7])",
+            Example(hr="((bv16 - bv16)[0:7] = bv8)",
                     expr=Equals(BVExtract(BVSub(bv16, bv16), 0, 7), bv8),
                     is_valid=False,
                     is_sat=True,
@@ -442,7 +439,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(0_1 = (bv16 bvcomp bv16))",
+            Example(hr="((bv16 bvcomp bv16) = 0_1)",
                     expr=Equals(BVComp(bv16, bv16), BVZero(1)),
                     is_valid=False,
                     is_sat=False,
@@ -463,7 +460,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="((0_16 s<= bv16) | (bv16 s< 0_16))",
+            Example(hr="((bv16 s< 0_16) | (0_16 s<= bv16))",
                     expr=Or(BVSGT(BVZero(16), bv16), BVSGE(bv16, BVZero(16))),
                     is_valid=True,
                     is_sat=True,
@@ -484,28 +481,28 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(bv16 = (bv16 | 0_16))",
+            Example(hr="((bv16 | 0_16) = bv16)",
                     expr=Equals(BVOr(bv16, BVZero(16)), bv16),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(bv16 = (bv16 | 5_16))",
+            Example(hr="((bv16 | 5_16) = bv16)",
                     expr=Equals(BVOr(bv16, BV(5, 16)), bv16),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(0_16 = (bv16 & 0_16))",
+            Example(hr="((bv16 & 0_16) = 0_16)",
                     expr=Equals(BVAnd(bv16, BVZero(16)), BVZero(16)),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(0_16 = (bv16 & 7_16))",
+            Example(hr="((bv16 & 7_16) = 0_16)",
                     expr=Equals(BVAnd(bv16, BV(7, 16)), BVZero(16)),
                     is_valid=False,
                     is_sat=True,
@@ -528,35 +525,35 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(0_16 = (bv16 u% 1_16))",
+            Example(hr="((bv16 u% 1_16) = 0_16)",
                     expr=Equals(BVURem(bv16, BVOne(16)), BVZero(16)),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(0_16 = (bv16 u% bv16))",
+            Example(hr="((bv16 u% bv16) = 0_16)",
                     expr=Equals(BVURem(bv16, bv16), BVZero(16)),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(0_16 = (bv16 s% 1_16))",
+            Example(hr="((bv16 s% 1_16) = 0_16)",
                     expr=Equals(BVSRem(bv16, BVOne(16)), BVZero(16)),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(0_16 = (bv16 s% bv16))",
+            Example(hr="((bv16 s% bv16) = 0_16)",
                     expr=Equals(BVSRem(bv16, bv16), BVZero(16)),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(0_16 = (bv16 s% (- 1_16)))",
+            Example(hr="((bv16 s% (- 1_16)) = 0_16)",
                     expr=Equals(BVSRem(bv16, BVNeg(BVOne(16))), BVZero(16)),
                     is_valid=True,
                     is_sat=True,
@@ -570,7 +567,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(bv16 = (bv16 a>> 0_16))",
+            Example(hr="((bv16 a>> 0_16) = bv16)",
                     expr=Equals(BVAShr(bv16, BVZero(16)), bv16),
                     is_valid=True,
                     is_sat=True,
@@ -586,7 +583,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_BV
                 ),
 
-            Example(hr="(1 = bv2nat(1_8))",
+            Example(hr="(bv2nat(1_8) = 1)",
                     expr=Equals(BVToNatural(BVOne(8)), Int(1)),
                     is_valid=True,
                     is_sat=True,
@@ -664,14 +661,14 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
             #
             # UFLIRA
             #
-            Example(hr="((x -> y) & (p < ih(r, q)))",
+            Example(hr="((p < ih(r, q)) & (x -> y))",
                     expr=And(GT(Function(ih, (r, q)), p), Implies(x, y)),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_UFLIRA
                 ),
 
-            Example(hr="((q = (p - 3)) -> ((p < ih(r, (q + 3))) | (ih(r, p) <= p)))",
+            Example(hr="(((p - 3) = q) -> ((p < ih(r, (q + 3))) | (ih(r, p) <= p)))",
                     expr=Implies(Equals(Minus(p, Int(3)), q),
                                  Or(GT(Function(ih, (r, Plus(q, Int(3)))), p),
                                     LE(Function(ih, (r, p)), p))),
@@ -680,7 +677,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_UFLIRA
                 ),
 
-            Example(hr="(((r = ToReal((p - 3))) & (r = ToReal(q))) -> ((ih(r, p) <= p) | (p < ih(ToReal((p - 3)), (q + 3)))))",
+            Example(hr="(((ToReal((p - 3)) = r) & (ToReal(q) = r)) -> ((p < ih(ToReal((p - 3)), (q + 3))) | (ih(r, p) <= p)))",
                     expr=Implies(And(Equals(ToReal(Minus(p, Int(3))), r),
                                      Equals(ToReal(q), r)),
                                  Or(GT(Function(ih, (ToReal(Minus(p, Int(3))),
@@ -691,7 +688,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_UFLIRA
                 ),
 
-            Example(hr="(! (((r = ToReal((p - 3))) & (r = ToReal(q))) -> ((ih(r, p) <= p) | (p < ih(ToReal((p - 3)), (q + 3))))))",
+            Example(hr="(! (((ToReal((p - 3)) = r) & (ToReal(q) = r)) -> ((p < ih(ToReal((p - 3)), (q + 3))) | (ih(r, p) <= p))))",
                     expr=Not(Implies(And(Equals(ToReal(Minus(p, Int(3))), r),
                                          Equals(ToReal(q), r)),
                                      Or(GT(Function(ih, (ToReal(Minus(p, Int(3))),
@@ -712,7 +709,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                 ),
 
             # ToInt must not truncate towards zero
-            Example(hr="((r = -3/2) & (-1 = ToInt(r)))",
+            Example(hr="((r = -3/2) & (ToInt(r) = -1))",
                     expr=And(Equals(r, Real(Fraction(-3, 2))),
                              Equals(ToInt(r), Int(-1))),
                     is_valid=False,
@@ -720,7 +717,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_LIRA
                 ),
 
-            Example(hr="((0.0 < r) & (p = ToInt(r)))",
+            Example(hr="((ToInt(r) = p) & (0.0 < r))",
                     expr=And(Equals(ToInt(r), p),
                              GT(r, Real(0))),
                     is_valid=False,
@@ -730,14 +727,14 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
             #
             # STR
             #
-            Example(hr='(str1 = "mystr")',
+            Example(hr='("mystr" = str1)',
                     expr=Equals(String("mystr"), str1),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_SLIA
                 ),
 
-            Example(hr='((str1 = "mystr") & (5 < str.len(str1)))',
+            Example(hr='((5 < str.len(str1)) & ("mystr" = str1))',
                     expr=And(LT(Int(5), StrLength(str1)),
                              Equals(String("mystr"), str1)),
                     is_valid=False,
@@ -745,7 +742,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_SLIA
                 ),
 
-            Example(hr='((5 = str.len(str1)) & (str1 = str.++("my", "str")))',
+            Example(hr='((5 = str.len(str1)) & (str.++("my", "str") = str1))',
                     expr=And(Equals(Int(5), StrLength(str1)),
                              Equals(StrConcat(String("my"),String("str")), str1)),
                     is_valid=False,
@@ -761,20 +758,20 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                 ),
 
             Example(hr='str.contains("mystr", "my")',
-                    expr=StrContains(String("mystr"), String("my")),
+                    expr=StrContains(String("mystr"),String("my")),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_SLIA
                 ),
 
-            Example(hr='(2 = str.indexof("mystr", "str", 1))',
-                    expr=Equals(StrIndexOf(String("mystr"), String("str"), Int(1)), Int(2)),
+            Example(hr='(str.indexof("mystr", "str", 1) = 2)',
+                    expr=Equals(StrIndexOf(String("mystr"),String("str"),Int(1)),Int(2)),
                     is_valid=True,
                     is_sat=True,
                     logic=pysmt.logics.QF_SLIA
                 ),
 
-            Example(hr='(2 = str.indexof(str1, "str", 1))',
+            Example(hr='(str.indexof(str1, "str", 1) = 2)',
                     expr=Equals(StrIndexOf(str1,String("str"),Int(1)),Int(2)),
                     is_valid=False,
                     is_sat=True,
@@ -814,7 +811,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     is_sat=True,
                     logic=pysmt.logics.QF_SLIA),
 
-            Example(hr='(9 = str.to.int("9"))',
+            Example(hr='(str.to.int("9") = 9)',
                     expr=Equals(StrToInt(String("9")), Int(9)),
                     is_valid=True,
                     is_sat=True,
@@ -841,7 +838,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     is_sat=True,
                     logic=pysmt.logics.QF_ALIA),
 
-            Example(hr="(0 = aii[0 := 0][0])",
+            Example(hr="(aii[0 := 0][0] = 0)",
                     expr=Equals(Select(Store(aii, Int(0), Int(0)), Int(0)),
                                 Int(0)),
                     is_valid=True,
@@ -849,28 +846,28 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_ALIA
                 ),
 
-            Example(hr="((aii = Array{Int, Int}(0)[1 := 1]) & (0 = aii[1]))",
+            Example(hr="((Array{Int, Int}(0)[1 := 1] = aii) & (aii[1] = 0))",
                     expr=And(Equals(Array(INT, Int(0), {Int(1) : Int(1)}), aii), Equals(Select(aii, Int(1)), Int(0))),
                     is_valid=False,
                     is_sat=False,
                     logic=pysmt.logics.get_logic_by_name("QF_ALIA*")
                 ),
 
-            Example(hr="((aii = Array{Int, Int}(0)[1 := 3]) & (3 = aii[1]))",
+            Example(hr="((Array{Int, Int}(0)[1 := 3] = aii) & (aii[1] = 3))",
                     expr=And(Equals(Array(INT, Int(0), {Int(1) : Int(3)}), aii), Equals(Select(aii, Int(1)), Int(3))),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.get_logic_by_name("QF_ALIA*")
                 ),
 
-            Example(hr="((ari = Array{Real, Int}(10)) & (0 = ari[6/5]))",
+            Example(hr="((Array{Real, Int}(10) = ari) & (ari[6/5] = 0))",
                     expr=And(Equals(Array(REAL, Int(10)), ari), Equals(Select(ari, Real((6, 5))), Int(0))),
                     is_valid=False,
                     is_sat=False,
                     logic=pysmt.logics.get_logic_by_name("QF_AUFBVLIRA*")
                 ),
 
-            Example(hr="((ari = Array{Real, Int}(0)[1.0 := 10][2.0 := 20][3.0 := 30][4.0 := 40]) & (! ((0 = ari[0.0]) & (10 = ari[1.0]) & (20 = ari[2.0]) & (30 = ari[3.0]) & (40 = ari[4.0]))))",
+            Example(hr="((Array{Real, Int}(0)[1.0 := 10][2.0 := 20][3.0 := 30][4.0 := 40] = ari) & (! ((ari[0.0] = 0) & (ari[1.0] = 10) & (ari[2.0] = 20) & (ari[3.0] = 30) & (ari[4.0] = 40))))",
                     expr=And(Equals(Array(REAL, Int(0), {Real(1) : Int(10), Real(2) : Int(20), Real(3) : Int(30), Real(4) : Int(40)}), ari),
                              Not(And(Equals(Select(ari, Real(0)), Int(0)),
                                      Equals(Select(ari, Real(1)), Int(10)),
@@ -882,7 +879,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.get_logic_by_name("QF_AUFBVLIRA*")
                 ),
 
-            Example(hr="((ari = Array{Real, Int}(0)[1.0 := 10][2.0 := 20][3.0 := 30][4.0 := 40][5.0 := 50]) & (! ((0 = ari[0.0]) & (10 = ari[1.0]) & (20 = ari[2.0]) & (30 = ari[3.0]) & (40 = ari[4.0]) & (50 = ari[5.0]))))",
+            Example(hr="((Array{Real, Int}(0)[1.0 := 10][2.0 := 20][3.0 := 30][4.0 := 40][5.0 := 50] = ari) & (! ((ari[0.0] = 0) & (ari[1.0] = 10) & (ari[2.0] = 20) & (ari[3.0] = 30) & (ari[4.0] = 40) & (ari[5.0] = 50))))",
                     expr=And(Equals(Array(REAL, Int(0), {Real(1) : Int(10), Real(2) : Int(20), Real(3) : Int(30), Real(4) : Int(40), Real(5) : Int(50)}), ari),
                              Not(And(Equals(Select(ari, Real(0)), Int(0)),
                                      Equals(Select(ari, Real(1)), Int(10)),
@@ -895,14 +892,14 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.get_logic_by_name("QF_AUFBVLIRA*")
                 ),
 
-            Example(hr="((abb = Array{BV{8}, BV{8}}(0_8)[1_8 := 42_8]) & (42_8 = abb[1_8]))",
+            Example(hr="((Array{BV{8}, BV{8}}(0_8)[1_8 := 42_8] = abb) & (abb[1_8] = 42_8))",
                     expr=And(Equals(Array(BV8, BV(0, 8), {BV(1, 8) : BV(42, 8)}), abb), Equals(Select(abb, BV(1, 8)), BV(42, 8))),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.get_logic_by_name("QF_ABV*")
                 ),
 
-            Example(hr="((a_arb_aii = Array{Array{Real, BV{8}}, Array{Int, Int}}(Array{Int, Int}(7))) -> (7 = a_arb_aii[arb][42]))",
+            Example(hr="((a_arb_aii = Array{Array{Real, BV{8}}, Array{Int, Int}}(Array{Int, Int}(7))) -> (a_arb_aii[arb][42] = 7))",
                     expr=Implies(Equals(nested_a, Array(ArrayType(REAL, BV8),
                                                         Array(INT, Int(7)))),
                                  Equals(Select(Select(nested_a, arb), Int(42)),
@@ -935,14 +932,14 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_NRA
                 ),
 
-            Example(hr="(0.0 = (p ^ 2))",
+            Example(hr="((p ^ 2) = 0.0)",
                     expr=Equals(Pow(p, Int(2)), Real(0)),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_NIRA
                     ),
 
-            Example(hr="(0.0 = (r ^ 2.0))",
+            Example(hr="((r ^ 2.0) = 0.0)",
                     expr=Equals(Pow(r, Real(2)), Real(0)),
                     is_valid=False,
                     is_sat=True,
@@ -956,7 +953,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_NRA
                 ),
 
-            Example(hr="(25.0 = (r * 5.0 * 5.0))",
+            Example(hr="((5.0 * r * 5.0) = 25.0)",
                     expr=Equals(Times(Real(5), r, Real(5)), Real(25)),
                     is_valid=False,
                     is_sat=True,
@@ -970,14 +967,14 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_NIA
                 ),
 
-            Example(hr="(25 = (p * 5 * 5))",
+            Example(hr="((5 * p * 5) = 25)",
                     expr=Equals(Times(Int(5), p, Int(5)), Int(25)),
                     is_valid=False,
                     is_sat=True,
                     logic=pysmt.logics.QF_LIA
                 ),
 
-            Example(hr="(0 = (p * 1 * (1 - 1)))",
+            Example(hr="(((1 - 1) * p * 1) = 0)",
                     expr=Equals(Times(Minus(Int(1), Int(1)), p, Int(1)),
                                 Int(0)),
                     is_valid=True,
@@ -994,7 +991,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     logic=pysmt.logics.QF_LRA
                 ),
 
-            Example(hr="(0.0 = ((r + s + 5.0) * (r + s + 2.0)))",
+            Example(hr="(((r + 5.0 + s) * (s + 2.0 + r)) = 0.0)",
                     expr=Equals(Times(Plus(r, Real(5), s),
                                       Plus(s, Real(2), r)),
                                 Real(0)),
@@ -1002,7 +999,7 @@ def get_full_example_formulae(environment: Optional[Environment]=None) -> List[E
                     is_sat=True,
                     logic=pysmt.logics.QF_NRA),
 
-            Example(hr="(((p + q + 5) * (p - (q - 5))) = (25 + (p * p) + (p * 10) + (q * q * -1)))",
+            Example(hr="(((p + 5 + q) * (p - (q - 5))) = ((p * p) + (10 * p) + 25 + (-1 * q * q)))",
                     expr=Equals(Times(Plus(p, Int(5), q),
                                       Minus(p, Minus(q, Int(5)))),
                                 Plus(Times(p, p),

--- a/pysmt/test/smtlib/test_parser_examples.py
+++ b/pysmt/test/smtlib/test_parser_examples.py
@@ -317,7 +317,7 @@ class TestSMTParseExamples(TestCase):
             AllDifferent(a, b, c),
             # bit-vectors
             Equals(BVXor(BVXor(x, y), z), x),
-            Equals(BVConcat(BVConcat(x, y), z), BVConcat(BVConcat(z, y), x)),
+            Equals(BVConcat(x, y, z), BVConcat(z, y, x)),
         ]
 
         parser = SmtLibParser()

--- a/pysmt/test/test_bv_simplification.py
+++ b/pysmt/test/test_bv_simplification.py
@@ -61,7 +61,7 @@ class TestBvSimplification(TestCase):
     def check(self, f):
         simp_f = f.simplify()
         solver_f = self.solver_simplify(f)
-        self.assertEqual(solver_f, simp_f)
+        self.assertEqual(solver_f, simp_f, f.serialize())
 
     def all_binary(self):
         for l in self.all_bv_numbers():
@@ -279,6 +279,27 @@ class TestBvSimplification(TestCase):
         f = BVAnd(x, BVZero(32))
         self.check_equal_and_valid(f, BVZero(32))
 
+    def test_bv_and_3_const_args(self):
+        arg0 = BV("1100")
+        arg1 = BV("1111")
+        arg2 = BV("0011")
+        formula = BVAnd(arg0, arg1, arg2)
+        self.check_equal_and_valid(formula, BVZero(4))
+
+    def test_bv_and_2_const_var_args(self):
+        arg0 = BV("1100")
+        arg1 = BV("1111")
+        arg2 = Symbol("x", BVType(4))
+        formula = BVAnd(arg0, arg1, arg2)
+        self.check_equal_and_valid(formula, BVAnd(arg2, arg0))
+
+    def test_bv_and_const_var_const_args(self):
+        arg2 = BV("0110")
+        arg1 = Symbol("x", BVType(4))
+        arg0 = BV("1100")
+        formula = BVAnd(arg0, arg1, arg2)
+        self.check_equal_and_valid(formula, BVAnd(arg1, BV("0100")))
+
     def test_bv_zero_and(self):
         x = Symbol("x", BVType(32))
         f = BVAnd(BVZero(32), x)
@@ -308,6 +329,27 @@ class TestBvSimplification(TestCase):
         f = BVOr(x, BVZero(32))
         self.check_equal_and_valid(f, x)
 
+    def test_bv_or_3_args(self):
+        arg0 = BV("1100")
+        arg1 = BV("0010")
+        arg2 = BV("0001")
+        formula = BVOr(arg0, arg1, arg2)
+        self.check_equal_and_valid(formula, BV("1111"))
+
+    def test_bv_or_2_const_var_args(self):
+        arg0 = BV("1100")
+        arg1 = BV("1110")
+        arg2 = Symbol("x", BVType(4))
+        formula = BVOr(arg0, arg1, arg2)
+        self.check_equal_and_valid(formula, BVOr(arg2, BV("1110")))
+
+    def test_bv_or_const_var_const_args(self):
+        arg0 = BV("1100")
+        arg1 = Symbol("x", BVType(4))
+        arg2 = BV("0110")
+        formula = BVOr(arg0, arg1, arg2)
+        self.check_equal_and_valid(formula, BVOr(arg1, BV("1110")))
+
     def test_bv_zero_or(self):
         x = Symbol("x", BVType(32))
         f = BVOr(BVZero(32), x)
@@ -332,10 +374,61 @@ class TestBvSimplification(TestCase):
         f = BVOr(BV(0xdededede, 32), BV(0xacacacac, 32))
         self.check_equal_and_valid(f, BV(0xfefefefe, 32))
 
+    def test_bv_xor_zeros(self):
+        zeros = BV("0000")
+        formula = BVXor(zeros)
+        self.assertEqual(formula, zeros)
+
+        formula = BVXor(zeros, zeros)
+        self.check_equal_and_valid(formula, zeros)
+
+        formula = BVXor(zeros, zeros, zeros)
+        self.check_equal_and_valid(formula, zeros)
+
+    def test_bv_xor_ones(self):
+        zeros = BV("0000")
+        ones = BV("1111")
+        formula = BVXor(ones)
+        self.assertEqual(formula, ones)
+
+        formula = BVXor(ones, ones)
+        self.check_equal_and_valid(formula, zeros)
+
+        formula = BVXor(ones, ones, ones)
+        self.check_equal_and_valid(formula, ones)
+
+    def test_bv_xor_const_var_const(self):
+        arg0 = BV("1001")
+        arg1 = Symbol("x", BVType(4))
+        arg2 = BV("0011")
+        formula = BVXor(arg0, arg1, arg2)
+        self.check_equal_and_valid(formula, BVXor(arg1, BV("1010")))
+
     def test_bv_sub_zero(self):
         x = Symbol("x", BVType(32))
         f = BVSub(x, BVZero(32))
         self.check_equal_and_valid(f, x)
+
+    def test_bv_concat_3_const_args(self):
+        arg0 = BV("10")
+        arg1 = BV("01")
+        arg2 = BV("00")
+        formula = BVConcat(arg0, arg1, arg2)
+        self.check_equal_and_valid(formula, BV("100100"))
+
+    def test_bv_concat_2_const_1_var(self):
+        arg0 = BV("10")
+        arg1 = BV("01")
+        arg2 = Symbol("s", BVType(32))
+        formula = BVConcat(arg0, arg1, arg2)
+        self.check_equal_and_valid(formula, BVConcat(BV("1001"), arg2))
+
+    def test_bv_concat_const_var_const(self):
+        arg0 = BV("10")
+        arg1 = Symbol("s", BVType(32))
+        arg2 = BV("01")
+        formula = BVConcat(arg0, arg1, arg2)
+        self.check_equal_and_valid(formula, BVConcat(arg0, arg1, arg2))
 
     def test_bv_sub_eq(self):
         x, y = (Symbol(name, BVType(32)) for name in "xy")

--- a/pysmt/test/test_formula.py
+++ b/pysmt/test/test_formula.py
@@ -1064,42 +1064,49 @@ class TestFormulaManager(TestCase):
         self.assertNotEqual(x.node_id(), y.node_id())
 
     @skipIfNoSolverForLogic(QF_BV)
-    def test_left_associative_bv(self):
-        """Test that the left-associative bv operators work properly"""
+    def test_left_associative_bv_valid(self):
+        """Test that the left-associative bv operators work properly,
+           assert validity of equality between FNodes"""
         bva = self.mgr.Symbol('a', BV8)
         bvb = self.mgr.Symbol('b', BV8)
         bvc = self.mgr.BV('10101010')
-        self.assertValid(
+        eq = self.mgr.Equals(
             # passing a list of elements
             self.mgr.BVAnd([bva, bvb, bvc]),
             self.mgr.BVAnd(
                 self.mgr.BVAnd(bva, bvb),
                 bvc
-            )
-        )
-        self.assertValid(
+            ))
+        self.assertValid(eq)
+
+        eq = self.mgr.Equals(
             # passing n elements
             self.mgr.BVOr(bva, bvb, bvc),
             self.mgr.BVOr(
                 self.mgr.BVOr(bva, bvb),
                 bvc
-            )
-        )
-        self.assertValid(
+            ))
+        self.assertValid(eq)
+
+        eq = self.mgr.Equals(
             self.mgr.BVAdd(bva, bvb, bvc),
             self.mgr.BVAdd(
                 self.mgr.BVAdd(bva, bvb),
                 bvc
-            )
-        )
-        self.assertValid(
+            ))
+        self.assertValid(eq)
+
+        eq = self.mgr.Equals(
             self.mgr.BVMul(bva, bvb, bvc),
             self.mgr.BVMul(
                 self.mgr.BVMul(bva, bvb),
                 bvc
-            )
-        )
+            ))
+        self.assertValid(eq)
 
+    def test_left_associative_bv_equal(self):
+        """Test syntactic equalities between BV FNodes"""
+        bva = self.mgr.Symbol('a', BV8)
         # passing a single element
         self.assertEqual(self.mgr.BVAnd(bva), bva)
         self.assertEqual(self.mgr.BVOr(bva), bva)
@@ -1107,14 +1114,10 @@ class TestFormulaManager(TestCase):
         self.assertEqual(self.mgr.BVMul(bva), bva)
 
         # passing no elements
-        self.assertRaises(PysmtValueError,
-            lambda: self.mgr.BVAnd([]))
-        self.assertRaises(PysmtValueError,
-            lambda: self.mgr.BVOr([]))
-        self.assertRaises(PysmtValueError,
-            lambda: self.mgr.BVAdd([]))
-        self.assertRaises(PysmtValueError,
-            lambda: self.mgr.BVMul([]))
+        self.assertRaises(PysmtValueError, lambda: self.mgr.BVAnd([]))
+        self.assertRaises(PysmtValueError, lambda: self.mgr.BVOr([]))
+        self.assertRaises(PysmtValueError, lambda: self.mgr.BVAdd([]))
+        self.assertRaises(PysmtValueError, lambda: self.mgr.BVMul([]))
 
     def test_function_substitute(self):
         FunTy = FunctionType(BOOL, [INT])

--- a/pysmt/test/test_formula.py
+++ b/pysmt/test/test_formula.py
@@ -15,8 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import pysmt
-
 from pysmt.typing import BOOL, REAL, INT, FunctionType, BV8, BVType
 from pysmt.shortcuts import Symbol, is_sat, Not, Implies, GT, Plus, Int, Real
 from pysmt.shortcuts import Minus, Times, Xor, And, Or, TRUE, Iff, FALSE, Ite, Abs
@@ -24,7 +22,7 @@ from pysmt.shortcuts import Equals
 from pysmt.shortcuts import get_env
 from pysmt.environment import Environment
 from pysmt.test import TestCase, skipIfNoSolverForLogic, main
-from pysmt.logics import QF_BOOL
+from pysmt.logics import QF_BOOL, QF_BV
 from pysmt.exceptions import (UndefinedSymbolError, UnsupportedOperatorError,
                               PysmtTypeError, PysmtModeError, PysmtValueError)
 from pysmt.formula import FormulaManager
@@ -1065,12 +1063,13 @@ class TestFormulaManager(TestCase):
         self.assertEqual(x.node_id(), xx.node_id())
         self.assertNotEqual(x.node_id(), y.node_id())
 
+    @skipIfNoSolverForLogic(QF_BV)
     def test_left_associative_bv(self):
         """Test that the left-associative bv operators work properly"""
         bva = self.mgr.Symbol('a', BV8)
         bvb = self.mgr.Symbol('b', BV8)
         bvc = self.mgr.BV('10101010')
-        self.assertEqual(
+        self.assertValid(
             # passing a list of elements
             self.mgr.BVAnd([bva, bvb, bvc]),
             self.mgr.BVAnd(
@@ -1078,7 +1077,7 @@ class TestFormulaManager(TestCase):
                 bvc
             )
         )
-        self.assertEqual(
+        self.assertValid(
             # passing n elements
             self.mgr.BVOr(bva, bvb, bvc),
             self.mgr.BVOr(
@@ -1086,14 +1085,14 @@ class TestFormulaManager(TestCase):
                 bvc
             )
         )
-        self.assertEqual(
+        self.assertValid(
             self.mgr.BVAdd(bva, bvb, bvc),
             self.mgr.BVAdd(
                 self.mgr.BVAdd(bva, bvb),
                 bvc
             )
         )
-        self.assertEqual(
+        self.assertValid(
             self.mgr.BVMul(bva, bvb, bvc),
             self.mgr.BVMul(
                 self.mgr.BVMul(bva, bvb),

--- a/pysmt/test/test_printing.py
+++ b/pysmt/test/test_printing.py
@@ -34,9 +34,9 @@ class TestPrinting(TestCase):
         return formula.to_smtlib(daggify=False)
 
     def test_real(self):
-        f = Plus([ Real(1),
-                   Symbol("x", REAL),
-                   Symbol("y", REAL)])
+        f = Plus([Real(1),
+                  Symbol("x", REAL),
+                  Symbol("y", REAL)])
 
         self.assertEqual(f.to_smtlib(daggify=False), "(+ 1.0 x y)")
         self.assertEqual(f.to_smtlib(daggify=True), "(let ((.def_0 (+ 1.0 x y))) .def_0)")
@@ -46,9 +46,9 @@ class TestPrinting(TestCase):
         f = Or(And(Not(x), Iff(x, y)), Implies(x, z))
 
         self.assertEqual(f.to_smtlib(daggify=False),
-                          "(or (and (not x) (= x y)) (=> x z))")
+                         "(or (and (not x) (= x y)) (=> x z))")
         self.assertEqual(f.to_smtlib(daggify=True),
-                          "(let ((.def_0 (=> x z))) (let ((.def_1 (= x y))) (let ((.def_2 (not x))) (let ((.def_3 (and .def_2 .def_1))) (let ((.def_4 (or .def_3 .def_0))) .def_4)))))")
+                         "(let ((.def_0 (not x))) (let ((.def_1 (= x y))) (let ((.def_2 (and .def_0 .def_1))) (let ((.def_3 (=> x z))) (let ((.def_4 (or .def_2 .def_3))) .def_4)))))")
 
     def test_int(self):
         p, q = Symbol("p", INT), Symbol("q", INT)
@@ -58,7 +58,7 @@ class TestPrinting(TestCase):
         self.assertEqual(f.to_smtlib(daggify=False),
                           "(or (= (* p 5) (- p q)) (< p q) (<= 6 1))")
         self.assertEqual(f.to_smtlib(daggify=True),
-                          "(let ((.def_0 (<= 6 1))) (let ((.def_1 (< p q))) (let ((.def_2 (- p q))) (let ((.def_3 (* p 5))) (let ((.def_4 (= .def_3 .def_2))) (let ((.def_5 (or .def_4 .def_1 .def_0))) .def_5))))))")
+                          "(let ((.def_0 (* p 5))) (let ((.def_1 (- p q))) (let ((.def_2 (= .def_0 .def_1))) (let ((.def_3 (< p q))) (let ((.def_4 (<= 6 1))) (let ((.def_5 (or .def_2 .def_3 .def_4))) .def_5))))))")
 
     def test_ite(self):
         x = Symbol("x")

--- a/pysmt/test/test_simplify.py
+++ b/pysmt/test/test_simplify.py
@@ -36,7 +36,8 @@ class TestSimplify(TestCase):
     def test_simplify_qf(self):
         simp = get_env().simplifier
         for (f, _, _, logic) in get_example_formulae():
-            if logic.is_quantified(): continue
+            if logic.is_quantified():
+                continue
             sname = "z3" if not logic.theory.strings else "cvc5"
             simp.validate_simplifications = sname
             sf = f.simplify()

--- a/pysmt/test/test_sort_commutative.py
+++ b/pysmt/test/test_sort_commutative.py
@@ -1,0 +1,226 @@
+#
+# This file is part of pySMT.
+#
+#   Copyright 2014 Andrea Micheli and Marco Gario
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+from pysmt.environment import Environment
+from pysmt.formula import FormulaManager
+from pysmt.fnode import FNode
+from pysmt.typing import BOOL, REAL, INT, BVType
+from pysmt.test import TestCase
+
+
+class TestSortCommutative(TestCase):
+
+    def setUp(self) -> None:
+        self.env = Environment()
+        # enable sorting of arguments for commutative operations.
+        self.env.sort_commutative_args = True
+
+    @property
+    def mgr(self) -> FormulaManager:
+        return self.env.formula_manager
+
+    def test_setup(self):
+        self.assertTrue(self.env.sort_commutative_args)
+
+    def test_forall(self):
+        b1: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        b2: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        b3: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        forall: FNode = self.mgr.ForAll([b3, b2, b1], self.mgr.TRUE())
+        # ordered by creation time
+        self.assertEqual(forall.quantifier_vars(), (b1, b2, b3))
+
+    def test_exists(self):
+        b1: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        b2: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        b3: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        exists: FNode = self.mgr.Exists([b3, b2, b1], self.mgr.TRUE())
+        # ordered by creation time
+        self.assertEqual(exists.quantifier_vars(), (b1, b2, b3))
+
+    def test_implies(self):
+        b1: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        b2: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        # not commutative
+        for first, second in [(b1, b2), (b2, b1)]:
+            impl: FNode = self.mgr.Implies(first, second)
+            self.assertEqual(impl.args(), (first, second))
+
+    def test_iff(self):
+        b1: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        b2: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        iff: FNode = self.mgr.Iff(b2, b1)
+        # ordered by creation time
+        self.assertEqual(iff.args(), (b1, b2))
+
+    def test_plus_real(self):
+        s1: FNode = self.mgr.Real(1)
+        s2: FNode = self.mgr.new_fresh_symbol(REAL, "r%d")
+        s3: FNode = self.mgr.new_fresh_symbol(REAL, "r%d")
+        add: FNode = self.mgr.Plus(s3, s2, s1)
+        # ordered by creation time
+        self.assertEqual(add.args(), (s1, s2, s3))
+
+    def test_plus_int(self):
+        s1: FNode = self.mgr.Int(1)
+        s2: FNode = self.mgr.new_fresh_symbol(INT, "i%d")
+        s3: FNode = self.mgr.new_fresh_symbol(INT, "i%d")
+        add: FNode = self.mgr.Plus(s3, s2, s1)
+        # ordered by creation time
+        self.assertEqual(add.args(), (s1, s2, s3))
+
+    def test_minus(self):
+        arg1: FNode = self.mgr.new_fresh_symbol(REAL, "r%d")
+        arg2: FNode = self.mgr.new_fresh_symbol(REAL, "r%d")
+        # not commutative
+        for first, second in [(arg1, arg2), (arg2, arg1)]:
+            impl: FNode = self.mgr.Minus(first, second)
+            self.assertEqual(impl.args(), (first, second))
+
+    def test_times(self):
+        arg1: FNode = self.mgr.new_fresh_symbol(INT, "i%d")
+        arg2: FNode = self.mgr.new_fresh_symbol(INT, "i%d")
+        arg3: FNode = self.mgr.new_fresh_symbol(INT, "i%d")
+        times: FNode = self.mgr.Times(arg3, arg2, arg1)
+        # ordered by creation time
+        self.assertEqual(times.args(), (arg1, arg2, arg3))
+
+    def test_pow(self):
+        # create exponent first
+        arg1: FNode = self.mgr.Real(len(self.mgr.real_constants) + 0.2)
+        # use symbol as base to avoid this turning into a fract constant.
+        arg2: FNode = self.mgr.new_fresh_symbol(REAL, "r%d")
+
+        # not commutative
+        formula: FNode = self.mgr.Pow(arg2, arg1)
+        self.assertEqual(formula.args(), (arg2, arg1))
+
+    def test_div(self):
+        arg1: FNode = self.mgr.new_fresh_symbol(REAL, "r%d")
+        arg2: FNode = self.mgr.new_fresh_symbol(REAL, "r%d")
+        # not commutative
+        for first, second in [(arg1, arg2), (arg2, arg1)]:
+            formula: FNode = self.mgr.Div(first, second)
+            self.assertEqual(formula.args(), (first, second))
+
+    def test_equals(self):
+        arg1: FNode = self.mgr.new_fresh_symbol(INT, "i%d")
+        arg2: FNode = self.mgr.new_fresh_symbol(INT, "i%d")
+        formula: FNode = self.mgr.Equals(arg2, arg1)
+        # ordered by creation time
+        self.assertEqual(formula.args(), (arg1, arg2))
+
+    def test_le(self):
+        arg1: FNode = self.mgr.new_fresh_symbol(REAL, "r%d")
+        arg2: FNode = self.mgr.new_fresh_symbol(REAL, "r%d")
+        # not commutative
+        for first, second in [(arg1, arg2), (arg2, arg1)]:
+            formula: FNode = self.mgr.LE(first, second)
+            self.assertEqual(formula.args(), (first, second))
+
+    def test_lt(self):
+        arg1: FNode = self.mgr.new_fresh_symbol(REAL, "r%d")
+        arg2: FNode = self.mgr.new_fresh_symbol(REAL, "r%d")
+        # not commutative
+        for first, second in [(arg1, arg2), (arg2, arg1)]:
+            formula: FNode = self.mgr.LT(first, second)
+            self.assertEqual(formula.args(), (first, second))
+
+    def test_ite(self):
+        arg1: FNode = self.mgr.new_fresh_symbol(REAL, "r%d")
+        arg2: FNode = self.mgr.new_fresh_symbol(REAL, "r%d")
+        cond: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        # not commutative
+        for first, second in [(arg1, arg2), (arg2, arg1)]:
+            formula: FNode = self.mgr.Ite(cond, first, second)
+            self.assertEqual(formula.args(), (cond, first, second))
+
+    def test_and(self):
+        arg1: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        arg2: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        arg3: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        arg4: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        formula: FNode = self.mgr.And(arg4, arg3, arg2, arg1)
+        # ordered by creation time
+        self.assertEqual(formula.args(), (arg1, arg2, arg3, arg4))
+
+    def test_or(self):
+        arg1: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        arg2: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        arg3: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        arg4: FNode = self.mgr.new_fresh_symbol(BOOL, "b%d")
+        formula: FNode = self.mgr.Or(arg4, arg3, arg2, arg1)
+        # ordered by creation time
+        self.assertEqual(formula.args(), (arg1, arg2, arg3, arg4))
+
+    def test_bv_and(self):
+        arg1: FNode = self.mgr.new_fresh_symbol(BVType(4), "b%d")
+        arg2: FNode = self.mgr.new_fresh_symbol(BVType(4), "b%d")
+        arg3: FNode = self.mgr.new_fresh_symbol(BVType(4), "b%d")
+        arg4: FNode = self.mgr.new_fresh_symbol(BVType(4), "b%d")
+        formula: FNode = self.mgr.BVAnd(arg4, arg3, arg2, arg1)
+        # ordered by creation time
+        self.assertEqual(formula.args(), (arg1, arg2, arg3, arg4))
+
+    def test_bv_or(self):
+        arg1: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        arg2: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        arg3: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        arg4: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        formula: FNode = self.mgr.BVOr(arg4, arg3, arg2, arg1)
+        # ordered by creation time
+        self.assertEqual(formula.args(), (arg1, arg2, arg3, arg4))
+
+    def test_bv_xor(self):
+        arg1: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        arg2: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        arg3: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        arg4: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        formula: FNode = self.mgr.BVXor(arg4, arg3, arg2, arg1)
+        # ordered by creation time
+        self.assertEqual(formula.args(), (arg1, arg2, arg3, arg4))
+
+    def test_bv_add(self):
+        arg1: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        arg2: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        arg3: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        arg4: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        formula: FNode = self.mgr.BVAdd(arg4, arg3, arg2, arg1)
+        # ordered by creation time
+        self.assertEqual(formula.args(), (arg1, arg2, arg3, arg4))
+
+    def test_bv_mul(self):
+        arg1: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        arg2: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        arg3: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        arg4: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        formula: FNode = self.mgr.BVMul(arg4, arg3, arg2, arg1)
+        # ordered by creation time
+        self.assertEqual(formula.args(), (arg1, arg2, arg3, arg4))
+
+    def test_bv_concat(self):
+        arg1: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        arg2: FNode = self.mgr.new_fresh_symbol(BVType(3), "b%d")
+        # not commutative
+        for first, second in [(arg1, arg2), (arg2, arg1)]:
+            formula: FNode = self.mgr.BVConcat(first, second)
+            self.assertEqual(formula.args(), (first, second))
+
+
+if __name__ == "__main__":
+    from pysmt.test import main
+    main()

--- a/pysmt/type_checker.py
+++ b/pysmt/type_checker.py
@@ -25,9 +25,9 @@ reasoning about the type of formulae.
 from typing import Any, Iterable, List, Optional, Sequence, Set, cast
 
 import pysmt
-import pysmt.walkers as walkers
-import pysmt.operators as op
-import pysmt.typing as types
+from pysmt import walkers
+from pysmt import operators as op
+from pysmt import typing as types
 
 from pysmt.typing import PySMTType, BOOL, REAL, INT, STRING
 from pysmt.exceptions import PysmtTypeError
@@ -36,7 +36,7 @@ from pysmt.fnode import FNode
 
 class SimpleTypeChecker(walkers.DagWalker):
 
-    def __init__(self, env: Optional["pysmt.environment.Environment"]=None):
+    def __init__(self, env: Optional["pysmt.environment.Environment"] = None):
         walkers.DagWalker.__init__(self, env=env)
         # If `be_nice` is true, the `get_type` method will return None if
         # the type cannot be computed instead of than raising an exception.
@@ -58,12 +58,12 @@ class SimpleTypeChecker(walkers.DagWalker):
                                  % str(formula))
         return cast(PySMTType, res)
 
-    def walk_type_to_type(self, formula: FNode, args: List[PySMTType], type_in: PySMTType, type_out: PySMTType) -> Optional[PySMTType]:
+    def walk_type_to_type(self, formula: FNode, args: List[PySMTType],
+                          type_in: PySMTType, type_out: PySMTType) -> Optional[PySMTType]:
         assert formula is not None
-        for x in args:
-            if x is None or x != type_in:
-                return None
-        return type_out
+        if all(curr_t is not None and type_in == curr_t for curr_t in args):
+            return type_out
+        return None
 
     @walkers.handles(op.AND, op.OR, op.NOT, op.IMPLIES, op.IFF)
     def walk_bool_to_bool(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
@@ -104,10 +104,10 @@ class SimpleTypeChecker(walkers.DagWalker):
         #pylint: disable=unused-argument
         # We check that all children are BV and the same size
         target_bv_type = self.env.type_manager.BVType(formula.bv_width())
-        for a in args:
-            if not a == target_bv_type:
-                return None
-        return target_bv_type
+
+        if all(target_bv_type == curr_t for curr_t in args):
+            return target_bv_type
+        return None
 
     @walkers.handles(op.STR_CONCAT, op.STR_REPLACE)
     def walk_str_to_str(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
@@ -140,10 +140,10 @@ class SimpleTypeChecker(walkers.DagWalker):
     def walk_bv_to_bool(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
         #pylint: disable=unused-argument
         width = cast(types._BVType, args[0]).width
-        for a in args[1:]:
-            if (not a.is_bv_type()) or width != cast(types._BVType, a).width:
-                return None
-        return BOOL
+        if all(curr_t.is_bv_type() and width == curr_t.width
+               for curr_t in args[1:]):
+            return BOOL
+        return None
 
     def walk_bv_tonatural(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
         #pylint: disable=unused-argument
@@ -156,12 +156,12 @@ class SimpleTypeChecker(walkers.DagWalker):
         # The type-checker only verifies that they are indeed
         # correct.
         try:
-            l_width = cast(types._BVType, args[0]).width
-            r_width = cast(types._BVType, args[1]).width
+            expected_width = sum(cast(types._BVType, curr_t).width
+                                 for curr_t in args)
             target_width = formula.bv_width()
         except AttributeError:
             return None
-        if not l_width + r_width == target_width:
+        if expected_width != target_width:
             return None
         return self.env.type_manager.BVType(target_width)
 
@@ -219,8 +219,9 @@ class SimpleTypeChecker(walkers.DagWalker):
 
     def walk_ite(self, formula: FNode, args: List[PySMTType], **kwargs) -> Any:
         assert formula is not None
-        if None in args: return None
-        if (args[0] == BOOL and args[1]==args[2]):
+        if None in args:
+            return None
+        if (args[0] == BOOL and args[1] == args[2]):
             return args[1]
         return None
 
@@ -282,11 +283,9 @@ class SimpleTypeChecker(walkers.DagWalker):
         if len(args) != len(cast(types._FunctionType, tp).param_types):
             return None
 
-        for (arg, p_type) in zip(args, cast(types._FunctionType, tp).param_types):
-            if arg != p_type:
-                return None
-
-        return cast(types._FunctionType, tp).return_type
+        if all(arg == p_type for arg, p_type in zip(args, tp.param_types)):
+            return cast(types._FunctionType, tp).return_type
+        return None
 
     def walk_str_charat(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
         assert formula is not None
@@ -312,31 +311,36 @@ class SimpleTypeChecker(walkers.DagWalker):
 
     def walk_array_select(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
         assert formula is not None
-        if None in args: return None
-        if (args[0].is_array_type() and cast(types._ArrayType, args[0]).index_type==args[1]):
+        if None in args:
+            return None
+        if (args[0].is_array_type()
+              and cast(types._ArrayType, args[0]).index_type == args[1]):
             return cast(types._ArrayType, args[0]).elem_type
         return None
 
     def walk_array_store(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
         assert formula is not None
-        if None in args: return None
-        if (args[0].is_array_type() and cast(types._ArrayType, args[0]).index_type==args[1] and
-            cast(types._ArrayType, args[0]).elem_type==args[2]):
+        if None in args:
+            return None
+        if (args[0].is_array_type()
+              and cast(types._ArrayType, args[0]).index_type == args[1]
+              and cast(types._ArrayType, args[0]).elem_type == args[2]):
             return args[0]
         return None
 
     def walk_array_value(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
         assert formula is not None
-        if None in args: return None
+        if None in args:
+            return None
 
         default_type = args[0]
         idx_type = formula.array_value_index_type()
-        for i, c in enumerate(args[1:]):
-            if i % 2 == 0 and c != idx_type:
-                return None # Wrong index type
-            elif i % 2 == 1 and c != default_type:
-                return None
-        return self.env.type_manager.ArrayType(idx_type, default_type)
+
+        if all(c == (idx_type if i % 2 == 0 else default_type)
+               for i, c in enumerate(args[1:])):
+            return self.env.type_manager.ArrayType(idx_type, default_type)
+
+        return None
 
     def walk_pow(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
         if args[0] != args[1]:

--- a/pysmt/type_checker.py
+++ b/pysmt/type_checker.py
@@ -140,7 +140,7 @@ class SimpleTypeChecker(walkers.DagWalker):
     def walk_bv_to_bool(self, formula: FNode, args: List[PySMTType], **kwargs) -> Optional[PySMTType]:
         #pylint: disable=unused-argument
         width = cast(types._BVType, args[0]).width
-        if all(curr_t.is_bv_type() and width == curr_t.width
+        if all(curr_t.is_bv_type() and width == cast(types._BVType, curr_t).width
                for curr_t in args[1:]):
             return BOOL
         return None
@@ -283,7 +283,7 @@ class SimpleTypeChecker(walkers.DagWalker):
         if len(args) != len(cast(types._FunctionType, tp).param_types):
             return None
 
-        if all(arg == p_type for arg, p_type in zip(args, tp.param_types)):
+        if all(arg == p_type for arg, p_type in zip(args, cast(types._FunctionType, tp).param_types)):
             return cast(types._FunctionType, tp).return_type
         return None
 

--- a/pysmt/walkers/dag.py
+++ b/pysmt/walkers/dag.py
@@ -38,7 +38,8 @@ class DagWalker(Walker):
     be used in memoization. See substituter for an example.
     """
 
-    def __init__(self, env: Optional["pysmt.environment.Environment"]=None, invalidate_memoization: bool=False):
+    def __init__(self, env: Optional["pysmt.environment.Environment"] = None,
+                 invalidate_memoization: bool = False):
         """The flag ``invalidate_memoization`` can be used to clear the cache
         after the walk has been completed: the cache is one-time use.
         """
@@ -46,7 +47,8 @@ class DagWalker(Walker):
 
         self.memoization: Dict[FNode, Any] = {}
         self.invalidate_memoization = invalidate_memoization
-        self.stack: List[Tuple[bool, Union[FNode, Any]]] = [] # TODO consider to create a generic type variable instead of Any
+        # TODO consider to create a generic type variable instead of Any
+        self.stack: List[Tuple[bool, Union[FNode, Any]]] = []
 
     def _get_children(self, formula: FNode) -> Any:
         return formula.args()
@@ -54,7 +56,7 @@ class DagWalker(Walker):
     def _push_with_children_to_stack(self, formula: FNode, **kwargs):
         """Add children to the stack."""
         self.stack.append((True, formula))
-        for s in self._get_children(formula):
+        for s in reversed(self._get_children(formula)):
             # Add only if not memoized already
             key = self._get_key(s, **kwargs)
             if key not in self.memoization:
@@ -73,7 +75,7 @@ class DagWalker(Walker):
             except KeyError:
                 f = self.walk_error
 
-            args = [self.memoization[self._get_key(s, **kwargs)] \
+            args = [self.memoization[self._get_key(s, **kwargs)]
                     for s in self._get_children(formula)]
             self.memoization[key] = f(formula, args=args, **kwargs)
         else:

--- a/pysmt/walkers/generic.py
+++ b/pysmt/walkers/generic.py
@@ -29,12 +29,14 @@ else:
 import pysmt.operators as op
 import pysmt.exceptions
 
+
 # NodeType to Function Name
 def nt_to_fun(o: int) -> str:
     """Returns the name of the walk function for the given nodetype."""
     return "walk_%s" % op.op_to_str(o).lower()
 
-class handles(object):
+
+class handles:
     """Decorator for walker functions.
 
     Use it by specifying the nodetypes that need to be handled by the
@@ -61,6 +63,7 @@ class handles(object):
         setattr(func, "nodetypes", nodetypes)
         return func
 
+
 class MetaNodeTypeHandler(type):
     """Metaclass used to intepret the nodehandler decorator. """
     def __new__(cls: Type["MetaNodeTypeHandler"], name: str, bases: Any, dct: Dict[str, Any]) -> Any:
@@ -71,13 +74,13 @@ class MetaNodeTypeHandler(type):
         return obj
 
 
-class Walker(object, metaclass=MetaNodeTypeHandler):
+class Walker(metaclass=MetaNodeTypeHandler):
     """Base Abstract Walker class.
 
     Do not subclass directly, use DagWalker or TreeWalker, instead.
     """
 
-    def __init__(self, env: Optional["pysmt.environment.Environment"]=None):
+    def __init__(self, env: Optional["pysmt.environment.Environment"] = None):
         if env is None:
             import pysmt.environment
             env = pysmt.environment.get_env()
@@ -127,11 +130,10 @@ class Walker(object, metaclass=MetaNodeTypeHandler):
         if node_type in self.env.dwf:
             dwf = self.env.dwf[node_type]
             walker_class = type(self)
-            if type(self) in dwf:
+            if walker_class in dwf:
                 self.functions[node_type] = partial(dwf[walker_class], self)
                 return self.functions[node_type](formula, **kwargs)
 
-        node_type = formula.node_type()
         raise pysmt.exceptions.UnsupportedOperatorError(node_type=node_type,
                                                         expression=formula)
 

--- a/pysmt/walkers/identitydag.py
+++ b/pysmt/walkers/identitydag.py
@@ -22,6 +22,7 @@ from pysmt.walkers.dag import DagWalker
 from pysmt.fnode import FNode
 from typing import Any, List, Optional, Union, cast
 
+
 class IdentityDagWalker(DagWalker):
     """This class traverses a formula and rebuilds it recursively
     identically.
@@ -31,7 +32,8 @@ class IdentityDagWalker(DagWalker):
 
     """
 
-    def __init__(self, env: Optional["pysmt.environment.Environment"]=None, invalidate_memoization: bool=False):
+    def __init__(self, env: Optional["pysmt.environment.Environment"] = None,
+                 invalidate_memoization: bool = False):
         DagWalker.__init__(self,
                            env=env,
                            invalidate_memoization=invalidate_memoization)
@@ -121,7 +123,7 @@ class IdentityDagWalker(DagWalker):
         return self.mgr.BV(cast(int, formula.constant_value()), formula.bv_width())
 
     def walk_bv_and(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
-        return self.mgr.BVAnd(args[0], args[1])
+        return self.mgr.BVAnd(args)
 
     def walk_bv_not(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
         return self.mgr.BVNot(args[0])
@@ -130,19 +132,19 @@ class IdentityDagWalker(DagWalker):
         return self.mgr.BVNeg(args[0])
 
     def walk_bv_or(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
-        return self.mgr.BVOr(args[0], args[1])
+        return self.mgr.BVOr(args)
 
     def walk_bv_xor(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
         return self.mgr.BVXor(args[0], args[1])
 
     def walk_bv_add(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
-        return self.mgr.BVAdd(args[0], args[1])
+        return self.mgr.BVAdd(args)
 
     def walk_bv_sub(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
         return self.mgr.BVSub(args[0], args[1])
 
     def walk_bv_mul(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
-        return self.mgr.BVMul(args[0], args[1])
+        return self.mgr.BVMul(args)
 
     def walk_bv_udiv(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
         return self.mgr.BVUDiv(args[0], args[1])
@@ -174,7 +176,7 @@ class IdentityDagWalker(DagWalker):
         return self.mgr.BVZExt(args[0], formula.bv_extend_step())
 
     def walk_bv_concat(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
-        return self.mgr.BVConcat(args[0], args[1])
+        return self.mgr.BVConcat(args)
 
     def walk_bv_lshl(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
         return self.mgr.BVLShl(args[0], args[1])

--- a/pysmt/walkers/identitydag.py
+++ b/pysmt/walkers/identitydag.py
@@ -135,7 +135,7 @@ class IdentityDagWalker(DagWalker):
         return self.mgr.BVOr(args)
 
     def walk_bv_xor(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
-        return self.mgr.BVXor(args[0], args[1])
+        return self.mgr.BVXor(args)
 
     def walk_bv_add(self, formula: FNode, args: List[FNode], **kwargs) -> FNode:
         return self.mgr.BVAdd(args)

--- a/pysmt/walkers/tree.py
+++ b/pysmt/walkers/tree.py
@@ -21,6 +21,7 @@ import pysmt
 from pysmt.walkers.generic import Walker
 from pysmt.fnode import FNode
 
+
 class TreeWalker(Walker):
     """TreeWalker treats the formula as a Tree and does not perform memoization.
 
@@ -36,11 +37,10 @@ class TreeWalker(Walker):
 
     """
 
-    def __init__(self, env: Optional["pysmt.environment.Environment"]=None):
+    def __init__(self, env: Optional["pysmt.environment.Environment"] = None):
         Walker.__init__(self, env)
-        return
 
-    def walk(self, formula: FNode, threshold: Optional[int]=None):
+    def walk(self, formula: FNode, threshold: Optional[int] = None):
         """Generic walk method, will apply the function defined by the map
         self.functions.
 
@@ -76,7 +76,6 @@ class TreeWalker(Walker):
                         stack.append(iterator)
             except StopIteration:
                 stack.pop()
-        return
 
     def walk_threshold(self, formula):
         raise NotImplementedError


### PR DESCRIPTION
* sort arguments of commutative operations based on FNode id in FormulaManager.
* update walks in solvers: btor, cvc5, cvc4, mathsat, yices, z3.
* remove unused imports
* fix formatting

Supersedes [#730](https://github.com/pysmt/pysmt/pull/730).