### PR TITLE
Test cvc5 on macOS in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,8 @@ jobs:
             pysmt_solver: z3
           - os: macos-latest
             pysmt_solver: yices
+          - os: macos-latest
+            pysmt_solver: cvc5
           - os: windows-latest
             pysmt_solver: none
           - os: windows-latest


### PR DESCRIPTION
cvc5 is installed from PyPI and upstream ships `macosx_11_0_arm64` wheels, so it should work on the `macos-latest` runners. This adds the corresponding entry to the `run-tests-master` matrix to find out.