### PR TITLE
Support constant arrays in CVC4 and test them on CVC4/CVC5

### DIFF
--- a/pysmt/solvers/cvcfour.py
+++ b/pysmt/solvers/cvcfour.py
@@ -25,7 +25,7 @@ except ImportError:
     raise SolverAPINotFound
 
 import pysmt.typing as types
-from pysmt.logics import PYSMT_LOGICS, ARRAYS_CONST_LOGICS
+from pysmt.logics import PYSMT_LOGICS
 
 from pysmt.solvers.solver import Solver, Converter, SolverOptions
 from pysmt.exceptions import (SolverReturnedUnknownResultError,
@@ -77,7 +77,6 @@ class CVC4Options(SolverOptions):
 class CVC4Solver(SmtLibBasicSolver):
 
     LOGICS = PYSMT_LOGICS -\
-             ARRAYS_CONST_LOGICS -\
              set(l for l in PYSMT_LOGICS if not l.theory.linear)
 
     OptionsClass = CVC4Options
@@ -92,6 +91,9 @@ class CVC4Solver(SmtLibBasicSolver):
         self.cvc4 = None
         self.declarations = None
         self.logic_name = str(logic)
+        if self.logic_name.endswith("*"):
+            # Const-array extension (pySMT-internal suffix)
+            self.logic_name = self.logic_name[:-1]
         if "t" in self.logic_name:
             # Custom Type extension
             self.logic_name = self.logic_name.replace("t","")
@@ -247,17 +249,33 @@ class CVC4Converter(Converter, DagWalker):
                 v = expr.getConstString()
                 res = self.mgr.String(v.toString())
             elif expr.getType().isArray():
-                const_ = expr.getConstArrayStoreAll()
-                array_type = self._cvc4_type_to_type(const_.getType())
-                base_value = self.back(const_.getExpr())
-                res = self.mgr.Array(array_type.index_type,
-                                     base_value)
+                res = self._back_array(expr)
             else:
                 raise PysmtTypeError("Unsupported constant type:",
                                      expr.getType().toString())
         else:
             raise PysmtTypeError("Unsupported expression:", expr.toString())
 
+        return res
+
+    def _back_array(self, expr):
+        """Converts a CVC4 array value into a pySMT Array.
+
+        CVC4 represents an array value as a (possibly empty) sequence of
+        STOREs on top of a STORE_ALL node, which holds the default value.
+        """
+        assert expr.getType().isArray(), "Expecting a CVC4 array"
+        stores = []
+        while expr.getNumChildren() == 3:
+            # STORE(array, index, value)
+            array, index, value = expr.getChildren()
+            stores.append((self.back(index), self.back(value)))
+            expr = array
+        const_ = expr.getConstArrayStoreAll()
+        array_type = self._cvc4_type_to_type(const_.getType())
+        res = self.mgr.Array(array_type.index_type, self.back(const_.getExpr()))
+        for index, value in reversed(stores):
+            res = self.mgr.Store(res, index, value)
         return res
 
     @catch_conversion_error
@@ -333,6 +351,15 @@ class CVC4Converter(Converter, DagWalker):
 
     def walk_array_select(self, formula, args, **kwargs):
         return self.mkExpr(CVC4.SELECT, args[0], args[1])
+
+    def walk_array_value(self, formula, args, **kwargs):
+        arr_type = self.env.stc.get_type(formula)
+        rval = self.mkConst(CVC4.ArrayStoreAll(self._type_to_cvc4(arr_type),
+                                               args[0]))
+        # The remaining args are (index, value) pairs
+        for i in range(1, len(args), 2):
+            rval = self.mkExpr(CVC4.STORE, rval, args[i], args[i+1])
+        return rval
 
     def walk_minus(self, formula, args, **kwargs):
         return self.mkExpr(CVC4.MINUS, args[0], args[1])

--- a/pysmt/test/test_array.py
+++ b/pysmt/test/test_array.py
@@ -18,12 +18,15 @@
 
 from pysmt.test import TestCase, main
 from pysmt.test import skipIfNoSolverForLogic, skipIfSolverNotAvailable
-from pysmt.logics import QF_AUFLIA, QF_AUFBV
+from pysmt.logics import QF_AUFLIA, QF_AUFBV, get_logic_by_name
 from pysmt.typing import ARRAY_INT_INT, ArrayType, INT, REAL, BV8, BOOL
-from pysmt.shortcuts import (Solver,
+from pysmt.shortcuts import (Solver, get_env, simplify,
                              Symbol, Not, Equals, Int, BV, Real, FreshSymbol,
                              Select, Store, Array, TRUE)
 from pysmt.exceptions import ConvertExpressionError, PysmtTypeError, PysmtValueError
+
+
+QF_ALIA_CONST = get_logic_by_name("QF_ALIA*")
 
 
 class TestArray(TestCase):
@@ -91,6 +94,22 @@ class TestArray(TestCase):
     def test_btor_support_bool_as_array_elements(self):
         formula = Equals(Array(BV8, TRUE()), FreshSymbol(ArrayType(BV8, BOOL)))
         self.assertSat(formula, logic=QF_AUFBV, solver_name="btor")
+
+    @skipIfNoSolverForLogic(QF_ALIA_CONST)
+    def test_const_array_model(self):
+        """Constant arrays round-trip through every solver supporting them."""
+        a = Symbol("a", ARRAY_INT_INT)
+        value = Store(Store(Array(INT, Int(0)), Int(1), Int(5)), Int(2), Int(7))
+        formula = Equals(a, value)
+        for name in get_env().factory.all_solvers(logic=QF_ALIA_CONST):
+            with Solver(name=name, logic=QF_ALIA_CONST) as s:
+                s.add_assertion(formula)
+                self.assertTrue(s.solve(), name)
+                model = s.get_value(a)
+                for idx, expected in [(Int(1), Int(5)), (Int(2), Int(7)),
+                                      (Int(42), Int(0))]:
+                    self.assertEqual(simplify(Select(model, idx)), expected,
+                                     (name, model))
 
     def test_complex_types(self):
         with self.assertRaises(PysmtTypeError):

--- a/pysmt/test/test_solving.py
+++ b/pysmt/test/test_solving.py
@@ -209,10 +209,25 @@ class TestBasic(TestCase):
     @skipIfSolverNotAvailable("cvc5")
     def test_examples_cvc(self):
         for (f, validity, satisfiability, logic) in get_example_formulae():
-            if logic.theory.arrays_const: continue
             try:
                 v = is_valid(f, solver_name='cvc5', logic=logic)
                 s = is_sat(f, solver_name='cvc5', logic=logic)
+                self.assertEqual(validity, v, f)
+                self.assertEqual(satisfiability, s, f)
+            except SolverReturnedUnknownResultError:
+                # CVC does not handle quantifiers in a complete way
+                self.assertFalse(logic.quantifier_free)
+            except NoSolverAvailableError:
+                # Logic is not supported by CVC
+                pass
+
+    @skipIfSolverNotAvailable("cvc4")
+    def test_examples_cvc4(self):
+        for (f, validity, satisfiability, logic) in get_example_formulae():
+            if not logic.theory.linear: continue
+            try:
+                v = is_valid(f, solver_name='cvc4', logic=logic)
+                s = is_sat(f, solver_name='cvc4', logic=logic)
                 self.assertEqual(validity, v, f)
                 self.assertEqual(satisfiability, s, f)
             except SolverReturnedUnknownResultError:


### PR DESCRIPTION
Revives #546, which added `ARRAY_VALUE` support to CVC4 but was never merged.

### CVC4

The fix still applies verbatim on master: `cvcfour.py` still subtracts
`ARRAYS_CONST_LOGICS` from its `LOGICS` and has no `walk_array_value`.

- `walk_array_value` builds a `STORE_ALL` node for the default value and a chain
  of `STORE`s for the point overrides.
- The logic exclusion is dropped.
- `back()` is generalised: a CVC4 array model is a (possibly empty) sequence of
  `STORE`s on top of a `STORE_ALL`, not just a bare `STORE_ALL`.
- The pySMT-internal `*` suffix of the const-array logic names is stripped
  before reaching `setLogic`.

### CVC5

The conversion side is already in place (`walk_array_value` + `isConstArray` /
`STORE` handling in `back()`), so nothing to port there. What was still missing
is the test part of #546: `test_examples_cvc` skipped every `arrays_const`
logic. That skip is now removed.

### Tests

- `test_examples_cvc` no longer skips const-array logics.
- New `test_examples_cvc4`, mirroring the CVC5 one.
- New `test_const_array_model` in `test_array.py`: asserts a constant array with
  point overrides, then checks the model reads back correctly. It runs for every
  installed solver supporting `QF_ALIA*`, so it covers the back-conversion of
  CVC4, CVC5 and MathSAT/OptiMathSAT at once.

### Verification

Ran locally against CVC4 1.7-prerelease (built from the pySMT installer), CVC5,
OptiMathSAT and Boolector. Full suite passes; the only failures are two
pre-existing `test_omt_lib_solver.py` optimsat failures that also fail on a
clean `master`.

All example formulae in const-array logics now pass on CVC4, including
`QF_AUFBVLIRA*` (arrays indexed by arrays), which CVC5 still excludes.