### PR TITLE
Upgrade repycudd to master (fixes build with SWIG 4)

### DIFF
--- a/pysmt/cmd/install.py
+++ b/pysmt/cmd/install.py
@@ -42,7 +42,7 @@ INSTALLERS = [
     Installer(PicoSATInstaller, "965",
               {"pypicosat_minor_version" : "1708010052"}),
     Installer(CuddInstaller,    "2.0.3",
-              {"git_version" : "ecb03d6d231273343178f566cc4d7258dcce52b4"}),
+              {"git_version" : "0dabef26859b15710fd92e68e4eb6cf922a09de9"}),
     Installer(OptiMSatInstaller, "1.7.5", {})
 ]
 

--- a/pysmt/cmd/installers/bdd.py
+++ b/pysmt/cmd/installers/bdd.py
@@ -39,16 +39,10 @@ class CuddInstaller(SolverInstaller):
         if self.architecture == "x86_64":
             makefile = "Makefile_64bit"
 
-        swig = "swig"
-        swig_version = SolverInstaller.run("swig -version", get_output=True)
-        if '4.0.1' in swig_version or '4.0.0' in swig_version:
-            print("WARNING: the BDD solver does not work with Swig4 < 4.0.2. Fallback to Swig3")
-            swig = "swig3.0" # This is the Ubuntu naming of the executable
-
         import sysconfig
         PYTHON_INCLUDE_DIR = sysconfig.get_path("include")
-        SolverInstaller.run("make -C %s -f %s PYTHON_INCL=-I%s SWIG=%s" %
-                            (self.extract_path, makefile, PYTHON_INCLUDE_DIR, swig))
+        SolverInstaller.run("make -C %s -f %s PYTHON_INCL=-I%s" %
+                            (self.extract_path, makefile, PYTHON_INCLUDE_DIR))
 
 
     def move(self):


### PR DESCRIPTION
Bumps the pinned `repycudd` revision to the current master head of https://github.com/pysmt/repycudd (`0dabef2`).

The previously pinned revision used the `$function` special variable in its `%exception` blocks. SWIG 4 no longer expands it, so building the CUDD bindings failed on recent swig releases (the installer worked around this by falling back to `swig3.0` on 4.0.0/4.0.1). Upstream now uses `$action`, which works across SWIG 1.3-4.x, so the fallback is dropped.

Thanks to @roboogle for the upstream fix!