### PR TITLE
Support empty symbol names in all solvers

### DIFF
--- a/pysmt/exceptions.py
+++ b/pysmt/exceptions.py
@@ -131,6 +131,16 @@ class PysmtImportError(PysmtException, ImportError):
 class PysmtValueError(PysmtException, ValueError):
     pass
 
+class PysmtEmptySymbolNameError(PysmtValueError):
+    """A symbol with the empty name was built, but they are not enabled."""
+
+    def __init__(self):
+        PysmtValueError.__init__(
+            self,
+            "The empty string is not a valid symbol name. SMT-LIB allows it "
+            "(as `||`), but not every solver does, so pySMT requires it to be "
+            "enabled explicitly by setting `env.allow_empty_var_names = True`.")
+
 class PysmtTypeError(PysmtException, TypeError):
     pass
 

--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -45,7 +45,8 @@ import pysmt.operators as op
 from pysmt.fnode import FNode
 from pysmt.typing import PySMTType
 from pysmt.fnode import FNode, FNodeContent
-from pysmt.exceptions import UndefinedSymbolError, PysmtValueError,PysmtTypeError
+from pysmt.exceptions import (UndefinedSymbolError, PysmtValueError,
+                             PysmtTypeError, PysmtEmptySymbolNameError)
 from pysmt.walkers.identitydag import IdentityDagWalker
 from pysmt.constants import Fraction, Numeral
 from pysmt.constants import (is_pysmt_fraction,
@@ -107,7 +108,7 @@ class FormulaManager(object):
 
     def _create_symbol(self, name: str, typename: PySMTType=types.BOOL) -> FNode:
         if len(name) == 0 and not self.env.allow_empty_var_names:
-            raise PysmtValueError("Empty string is not a valid name")
+            raise PysmtEmptySymbolNameError()
         if not isinstance(typename, types.PySMTType):
             raise PysmtValueError("typename must be a PySMTType.")
         n = self.create_node(node_type=op.SYMBOL,

--- a/pysmt/parsing.py
+++ b/pysmt/parsing.py
@@ -22,7 +22,8 @@ from typing import List, Optional
 import pysmt
 import pysmt.typing as types
 from pysmt.environment import get_env
-from pysmt.exceptions import PysmtSyntaxError, UndefinedSymbolError
+from pysmt.exceptions import (PysmtSyntaxError, UndefinedSymbolError,
+                             PysmtEmptySymbolNameError)
 from pysmt.constants import Fraction
 
 
@@ -332,6 +333,9 @@ class Constant(GrammarSymbol):
 class Identifier(GrammarSymbol):
     def __init__(self, name, env):
         GrammarSymbol.__init__(self)
+        if name == "" and not env.allow_empty_var_names:
+            # Otherwise this would be reported as an undefined symbol
+            raise PysmtEmptySymbolNameError()
         self.value = env.formula_manager.get_symbol(name)
         if self.value is None:
             raise UndefinedSymbolError(name)

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -730,7 +730,7 @@ class MSatConverter(Converter, DagWalker):
                 val, width = map(int, str(term).split("_"))
                 res = self.mgr.BV(val, width)
         elif self._msat_lib.msat_term_is_constant(self.msat_env(), term):
-            rep = self._msat_lib.msat_term_repr(term)
+            rep = self._restore_empty(self._msat_lib.msat_term_repr(term))
             ty = self._msat_lib.msat_term_get_type(term)
             if self._msat_lib.msat_term_is_boolean_constant(self.msat_env(), term):
                 res = self.mgr.Symbol(rep, types.BOOL)
@@ -1141,10 +1141,10 @@ class MSatConverter(Converter, DagWalker):
         if not var.is_symbol():
             raise PysmtTypeError("Trying to declare as a variable something "
                                  "that is not a symbol: %s" % var)
-        if var.symbol_name() not in self.symbol_to_decl:
+        if var not in self.symbol_to_decl:
             tp = self._type_to_msat(var.symbol_type())
             decl = self._msat_lib.msat_declare_function(self.msat_env(),
-                                                 var.symbol_name(),
+                                                 self._rename_empty(var.symbol_name()),
                                                  tp)
             if self._msat_lib.MSAT_ERROR_DECL(decl):
                 msat_msg = self._msat_lib.msat_last_error_message(self.msat_env())

--- a/pysmt/solvers/solver.py
+++ b/pysmt/solvers/solver.py
@@ -16,6 +16,7 @@
 #   limitations under the License.
 #
 from fractions import Fraction
+import pysmt.formula
 from pysmt.typing import BOOL
 from pysmt.solvers.options import SolverOptions
 from pysmt.decorators import clear_pending_pop
@@ -566,3 +567,25 @@ class Converter(object):
     def back(self, expr: Any, *args: Any, **kwargs: Any) -> FNode:
         """Convert an expression of the Solver into a PySMT term."""
         raise NotImplementedError
+
+    # SMT-LIB allows a symbol with the empty name (`||`), but some
+    # solvers refuse to declare it (MathSAT) or cannot print it back
+    # (Z3). Those converters rename it to a fresh, unused name on the
+    # way in and undo the renaming on the way out.
+    _empty_name_subst: Optional[str] = None
+    mgr: 'pysmt.formula.FormulaManager'
+
+    def _rename_empty(self, name: str) -> str:
+        """Map a pySMT symbol name to the name used by the solver."""
+        if name != "":
+            return name
+        if self._empty_name_subst is None:
+            i = 0
+            while ("__pysmt_empty_name_%d" % i) in self.mgr.symbols:
+                i += 1
+            self._empty_name_subst = "__pysmt_empty_name_%d" % i
+        return self._empty_name_subst
+
+    def _restore_empty(self, name: str) -> str:
+        """Inverse of _rename_empty()."""
+        return "" if name == self._empty_name_subst else name

--- a/pysmt/solvers/z3.py
+++ b/pysmt/solvers/z3.py
@@ -573,7 +573,7 @@ class Z3Converter(Converter, DagWalker):
             else:
                 # it must be a symbol
                 try:
-                    return self.mgr.get_symbol(str(expr))
+                    return self.mgr.get_symbol(self._restore_empty(str(expr)))
                 except UndefinedSymbolError:
                     import warnings
                     symb_type = self._z3_to_type(expr.sort())
@@ -582,7 +582,7 @@ class Z3Converter(Converter, DagWalker):
                                                 template="__z3_%d")
         elif z3.is_function(expr):
             # This needs to be after we try to convert regular Symbols
-            fsymbol = self.mgr.get_symbol(expr.decl().name())
+            fsymbol = self.mgr.get_symbol(self._restore_empty(expr.decl().name()))
             return self.mgr.Function(fsymbol, args)
 
         # If we reach this point, we did not manage to translate the expression
@@ -622,6 +622,11 @@ class Z3Converter(Converter, DagWalker):
                                              expr.ast)
         stream_in = StringIO(s)
         r = parser.get_script(stream_in).get_last_formula(self.mgr)
+        if self._empty_name_subst is not None:
+            # Undo the renaming of the empty symbol name (see Converter)
+            src = self.mgr.get_symbol(self._empty_name_subst)
+            r = self.env.substituter.substitute(
+                r, {src: self.mgr.Symbol("", src.symbol_type())})
         key = (askey(expr), None)
         self._back_memoization[key] = r
         return r
@@ -642,7 +647,7 @@ class Z3Converter(Converter, DagWalker):
 
     def walk_symbol(self, formula: FNode, **kwargs) -> z3.Ast:
         symbol_type = formula.symbol_type()
-        sname = formula.symbol_name()
+        sname = self._rename_empty(formula.symbol_name())
         z3_sname = z3.Z3_mk_string_symbol(self.ctx.ref(), sname)
         if symbol_type.is_bool_type():
             sort_ast = self.z3BoolSort.ast
@@ -756,7 +761,7 @@ class Z3Converter(Converter, DagWalker):
                 z3dom[i] = self._type_to_z3(t).ast
             z3ret = self._type_to_z3(tp.return_type).ast
             z3name = z3.Z3_mk_string_symbol(self.ctx.ref(),
-                                            func_name.symbol_name())
+                                            self._rename_empty(func_name.symbol_name()))
             z3func = z3.Z3_mk_func_decl(self.ctx.ref(), z3name,
                                         arity, z3dom, z3ret)
             self._z3_func_decl_cache[func_name] = z3func

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -270,6 +270,43 @@ class TestRegressions(TestCase):
     def test_empty_string_symbol(self):
         with self.assertRaises(PysmtValueError):
             Symbol("")
+        # SMT-LIB allows `||` as a symbol name (see #587), but pySMT
+        # requires the user to opt-in explicitly.
+        self.env.allow_empty_var_names = True
+        self.assertNotEqual(Symbol(""), Symbol(" "))
+
+    def test_empty_string_symbol_in_solvers(self):
+        self.env.allow_empty_var_names = True
+        empty = Symbol("", BVType(8))
+        other = Symbol("other", BVType(8))
+        f = Not(Equals(empty, other))
+        for sname in self.env.factory.all_solvers(logic=logics.QF_BV):
+            with Solver(name=sname, logic=logics.QF_BV) as s:
+                s.add_assertion(f)
+                self.assertTrue(s.solve(), sname)
+                self.assertTrue(s.get_value(empty).is_bv_constant(), sname)
+                # Round-trip, but only for converters that can back-convert
+                # a regular symbol in the first place.
+                try:
+                    can_back = s.converter.back(s.converter.convert(other)) == other
+                except Exception:
+                    can_back = False
+                if can_back:
+                    self.assertEqual(s.converter.back(s.converter.convert(empty)),
+                                     empty, sname)
+
+    def test_empty_string_symbol_smtlib(self):
+        # The benchmark reported in #587 declares `||` and `| |`.
+        self.env.allow_empty_var_names = True
+        txt = """(set-logic QF_BV)
+        (declare-fun || () (_ BitVec 4))
+        (declare-fun | | () (_ BitVec 4))
+        (assert (not (= || | |)))
+        (check-sat)"""
+        script = SmtLibParser().get_script(StringIO(txt))
+        self.assertEqual({s.symbol_name() for s in script.get_declared_symbols()},
+                         {"", " "})
+        self.assertSat(script.get_last_formula())
 
     def test_smtlib_info_quoting(self):
         cmd = SmtLibCommand(smtcmd.SET_INFO, [":source", "This\nis\nmultiline!"])

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -296,6 +296,7 @@ class TestRegressions(TestCase):
         Symbol("")
         self.assertEqual(hr_parse("''"), Symbol(""))
 
+    @skipIfNoSolverForLogic(logics.QF_BV)
     def test_empty_string_symbol_in_solvers(self):
         self.env.allow_empty_var_names = True
         empty = Symbol("", BVType(8))
@@ -316,6 +317,7 @@ class TestRegressions(TestCase):
                     self.assertEqual(s.converter.back(s.converter.convert(empty)),
                                      empty, sname)
 
+    @skipIfNoSolverForLogic(logics.QF_BV)
     def test_empty_string_symbol_smtlib(self):
         # The benchmark reported in #587 declares `||` and `| |`.
         self.env.allow_empty_var_names = True

--- a/pysmt/test/test_regressions.py
+++ b/pysmt/test/test_regressions.py
@@ -29,11 +29,13 @@ from pysmt.test import (TestCase, skipIfSolverNotAvailable, skipIfNoSolverForLog
                         skipIfNoQEForLogic)
 from pysmt.test import main
 from pysmt.exceptions import (ConvertExpressionError, PysmtValueError,
-                              PysmtTypeError, InternalSolverError)
+                              PysmtTypeError, InternalSolverError,
+                              PysmtEmptySymbolNameError, UndefinedSymbolError)
 from pysmt.test.examples import get_example_formulae
 from pysmt.environment import Environment
 from pysmt.rewritings import cnf_as_set
 from pysmt.smtlib.parser import SmtLibParser
+from pysmt.parsing import parse as hr_parse
 from pysmt.smtlib.commands import DECLARE_FUN
 from pysmt.smtlib.script import SmtLibCommand
 from pysmt.logics import get_closer_smtlib_logic
@@ -274,6 +276,25 @@ class TestRegressions(TestCase):
         # requires the user to opt-in explicitly.
         self.env.allow_empty_var_names = True
         self.assertNotEqual(Symbol(""), Symbol(" "))
+
+    def test_empty_string_symbol_error_message(self):
+        # Parsing a symbol with the empty name must point at the option
+        # to enable, not fail with an unrelated message.
+        smtlib = """(set-logic QF_BV)
+        (declare-fun || () (_ BitVec 4))
+        (assert (= || || ))
+        (check-sat)"""
+        with self.assertRaises(PysmtEmptySymbolNameError) as ctx:
+            SmtLibParser().get_script(StringIO(smtlib))
+        self.assertIn("allow_empty_var_names", str(ctx.exception))
+        with self.assertRaises(PysmtEmptySymbolNameError):
+            hr_parse("'' & x")
+        # Once enabled, the empty name is just an undeclared symbol
+        self.env.allow_empty_var_names = True
+        with self.assertRaises(UndefinedSymbolError):
+            hr_parse("'' & x")
+        Symbol("")
+        self.assertEqual(hr_parse("''"), Symbol(""))
 
     def test_empty_string_symbol_in_solvers(self):
         self.env.allow_empty_var_names = True


### PR DESCRIPTION
Supersedes #588, closes the solver-support half of #587.

## Background

SMT-LIB allows a symbol whose name is the empty string, written `||`. #588 (2019) proposed removing pySMT's restriction outright; the discussion stalled on the concern that not every solver could handle it. What eventually landed instead, in 1bdcd34, was the `env.allow_empty_var_names` opt-in flag: pySMT can now *build* `Symbol("")`, but nothing was done on the solver side, so enabling the flag still broke as soon as a solver was involved.

Measured on master with the flag on:

| solver | solve + `get_value` | `back()` |
| --- | --- | --- |
| MathSAT / OptiMathSAT | `InternalSolverError: Empty name for symbol` | fails |
| Z3 | works | **wrong**: `Z3_get_symbol_string` returns `<null>`, so back-conversion silently produced a fresh `__z3_0` symbol |
| Boolector, CVC4, CVC5, Yices | works | not implemented for symbols in general, unrelated to this issue |

## Changes

**Solver support.** `Converter` gains `_rename_empty()` / `_restore_empty()`: the empty name is mapped onto a fresh, unused name on the way into the solver and the renaming is undone on the way out. MathSAT and Z3 use it (in `declare_variable` / `_back_tag_unknown`, and in `walk_symbol` / `_z3_func_decl` / `_back_single_term` / `back_via_smtlib` respectively). The other solvers accept the empty name as is and are untouched.

This differs from #588, which hardcoded the placeholder `___PYSMT_EMPTY_STRING___` and duplicated the helper in each solver module. A fixed placeholder collides with a user symbol of that name; picking a name that is provably unused in the current `FormulaManager` does not, and putting the helper on `Converter` means the next solver that needs it gets it for free.

**Error messages.** Parsing `||` from SMT-LIB used to fail with "Empty string is not a valid name", and `''` from the human-readable syntax with "'' is not defined!". The second one is actively misleading: it blames a missing declaration when the name simply cannot be built. Both now raise `PysmtEmptySymbolNameError`, which names the option to set. It subclasses `PysmtValueError`, so existing handlers keep working. With the flag on, the HR parser goes back to reporting a genuinely undeclared `''` as `UndefinedSymbolError`.

**Drive-by.** `MSatConverter.declare_variable` looked up `var.symbol_name()` in `symbol_to_decl`, a dict keyed by `FNode`, so the guard never fired and every symbol was re-declared. Harmless (MathSAT is idempotent here) but wrong.
