### PR TITLE
Remove instance-based walkers in favor of class-based dispatch

### DIFF
--- a/pysmt/environment.py
+++ b/pysmt/environment.py
@@ -87,9 +87,9 @@ class Environment(object):
         # (e.g. substitution and simplification).
         self.allow_empty_var_names = False
 
-        # Dynamic Walker Configuration Map
+        # Dynamic Walker Configuration(s)
         # See: add_dynamic_walker_function
-        self.dwf = {}
+        self._dwf: set = set()
 
     @property
     def formula_manager(self) -> pysmt.formula.FormulaManager:
@@ -157,12 +157,13 @@ class Environment(object):
         See :py:meth:`pysmt.walkers.generic.Walker.walk_error` for
         more information.
         """
-        # self.dwf is a map of maps: {nodetype, {walker: function}}
-        if nodetype not in self.dwf:
-            self.dwf[nodetype] = {}
-
-        assert walker not in self.dwf[nodetype], "Redefinition"
-        self.dwf[nodetype][walker] = function
+        # self._dwf is a set of (nodetype, walker) pairs, used only to
+        # detect redefinitions (which are otherwise hard to debug). The
+        # function is registered directly as a walk_* handler on the
+        # walker class.
+        assert (nodetype, walker) not in self._dwf, "Dynamic Walker Redefinition!"
+        self._dwf.add((nodetype, walker))
+        walker.set_handler(function, nodetype)
 
     @property
     def factory(self) -> "pysmt.factory.Factory":

--- a/pysmt/environment.py
+++ b/pysmt/environment.py
@@ -21,7 +21,7 @@ singleton objects that are used throughout the system, such as the
 FormulaManager, Simplifier, HRSerializer, SimpleTypeChecker.
 """
 
-from typing import List, Optional
+from typing import Callable, Dict, List, Optional, Tuple, Type
 
 import pysmt.simplifier
 import pysmt.printers
@@ -87,9 +87,11 @@ class Environment(object):
         # (e.g. substitution and simplification).
         self.allow_empty_var_names = False
 
-        # Dynamic Walker Configuration(s)
+        # Dynamic Walker Functions: handlers for custom node types,
+        # keyed by (nodetype, walker_class). Kept local to this
+        # environment so registrations never leak across environments.
         # See: add_dynamic_walker_function
-        self._dwf: set = set()
+        self.dwf: Dict[Tuple[int, Type], Callable] = {}
 
     @property
     def formula_manager(self) -> pysmt.formula.FormulaManager:
@@ -154,16 +156,20 @@ class Environment(object):
         function to a given walker, so that the walker will be able to
         handle the new nodetype.
 
-        See :py:meth:`pysmt.walkers.generic.Walker.walk_error` for
-        more information.
+        See :py:meth:`pysmt.walkers.generic.Walker.super` for more
+        information on how the handler is dispatched.
         """
-        # self._dwf is a set of (nodetype, walker) pairs, used only to
-        # detect redefinitions (which are otherwise hard to debug). The
-        # function is registered directly as a walk_* handler on the
-        # walker class.
-        assert (nodetype, walker) not in self._dwf, "Dynamic Walker Redefinition!"
-        self._dwf.add((nodetype, walker))
-        walker.set_handler(function, nodetype)
+        key = (nodetype, walker)
+        assert key not in self.dwf, "Dynamic Walker Redefinition!"
+        self.dwf[key] = function
+
+    def get_dynamic_walker_function(self, nodetype, walker_class):
+        """Return the handler registered for (nodetype, walker_class), or None.
+
+        Used by :py:meth:`pysmt.walkers.generic.Walker.super` to
+        dispatch custom node types without mutating the walker class.
+        """
+        return self.dwf.get((nodetype, walker_class))
 
     @property
     def factory(self) -> "pysmt.factory.Factory":

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -68,12 +68,16 @@ class SizeOracle(walkers.DagWalker):
                          SizeOracle.MEASURE_SYMBOLS: self.walk_count_symbols,
                          SizeOracle.MEASURE_BOOL_DAG: self.walk_count_bool_dag,
                         }
+        self._walking_fun = None
 
+    @walkers.handles(*op.ALL_TYPES)
+    def walk_measure(self, formula, args, **kwargs):
+        return self._walking_fun(formula, args, **kwargs)
 
     def set_walking_measure(self, measure: int):
         if measure not in self.measure_to_fun:
             raise NotImplementedError
-        self.set_function(self.measure_to_fun[measure], *op.ALL_TYPES)
+        self._walking_fun = self.measure_to_fun[measure]
 
     def _get_key(self, formula, measure, **kwargs):
         """Memoize using a tuple (measure, formula)."""

--- a/pysmt/oracles.py
+++ b/pysmt/oracles.py
@@ -27,7 +27,7 @@ properties of formulae.
 """
 
 from itertools import chain
-from typing import FrozenSet, Iterable, List, Any, Optional, Union, cast
+from typing import FrozenSet, Iterable, List, Any, Optional, Union, cast, Callable, Dict
 
 import pysmt
 import pysmt.walkers as walkers
@@ -60,7 +60,7 @@ class SizeOracle(walkers.DagWalker):
     def __init__(self, env: Optional["pysmt.environment.Environment"]=None):
         walkers.DagWalker.__init__(self, env=env)
 
-        self.measure_to_fun = \
+        self.measure_to_fun: Dict[int, Callable] = \
                         {SizeOracle.MEASURE_TREE_NODES: self.walk_count_tree,
                          SizeOracle.MEASURE_DAG_NODES: self.walk_count_dag,
                          SizeOracle.MEASURE_LEAVES: self.walk_count_leaves,
@@ -68,11 +68,11 @@ class SizeOracle(walkers.DagWalker):
                          SizeOracle.MEASURE_SYMBOLS: self.walk_count_symbols,
                          SizeOracle.MEASURE_BOOL_DAG: self.walk_count_bool_dag,
                         }
-        self._walking_fun = None
+        self._walking_fun: Optional[Callable] = None
 
     @walkers.handles(*op.ALL_TYPES)
     def walk_measure(self, formula, args, **kwargs):
-        return self._walking_fun(formula, args, **kwargs)
+        return assert_not_none(self._walking_fun)(formula, args, **kwargs)
 
     def set_walking_measure(self, measure: int):
         if measure not in self.measure_to_fun:

--- a/pysmt/rewritings.py
+++ b/pysmt/rewritings.py
@@ -268,15 +268,12 @@ class PolarityCNFizer(CNFizer):
     def _compute_node_result(self, formula, pol=None, **kwargs):
         key = self._get_key(formula, pol, **kwargs)
         if key not in self.memoization:
-            try:
-                f = self.functions[formula.node_type()]
-            except KeyError:
-                f = self.walk_error
-
             args = [self.memoization[self._get_key(s, p, **kwargs)] \
                     for s, p in self._get_children(formula, pol)]
 
-            self.memoization[key] = f(formula, args=args, pol=pol, **kwargs)
+            self.memoization[key] = self.__class__.super(self, formula,
+                                                         args=args, pol=pol,
+                                                         **kwargs)
         else:
             pass
 

--- a/pysmt/simplifier.py
+++ b/pysmt/simplifier.py
@@ -74,8 +74,7 @@ class Simplifier(pysmt.walkers.DagWalker):
 
         args = [self.walk(s, **kwargs) for s in formula.args()]
 
-        f = self.functions[formula.node_type()]
-        res = f(formula, args=args, **kwargs)
+        res = self.__class__.super(self, formula, args=args, **kwargs)
         ltype = get_type(formula)
         rtype = get_type(res)
         test = Equals(formula, res) if ltype != BOOL else Iff(formula, res)

--- a/pysmt/smtlib/printers.py
+++ b/pysmt/smtlib/printers.py
@@ -346,8 +346,7 @@ class SmtDagPrinter(DagWalker):
         if formula.is_quantifier():
             # 1. We invoke the relevant function (walk_exists or
             #    walk_forall) to print the formula
-            fun = self.functions[formula.node_type()]
-            res = fun(formula, args=None, **kwargs)
+            res = self.__class__.super(self, formula, args=None, **kwargs)
 
             # 2. We memoize the result
             key = self._get_key(formula, **kwargs)

--- a/pysmt/solvers/msat.py
+++ b/pysmt/solvers/msat.py
@@ -41,6 +41,7 @@ from pysmt.decorators import clear_pending_pop, catch_conversion_error
 from pysmt.solvers.qelim import QuantifierEliminator
 from pysmt.solvers.interpolation import Interpolator
 from pysmt.walkers.identitydag import IdentityDagWalker
+from pysmt.walkers.generic import handles
 from pysmt.environment import Environment
 from pysmt.fnode import FNode
 from pysmt.formula import FormulaManager
@@ -1183,8 +1184,6 @@ class MSatQuantifierEliminator(QuantifierEliminator, IdentityDagWalker):
         self.msat_env = MSATCreateEnv(self.__class__.__lib_name__, self.msat_config)
         self._msat_lib.msat_destroy_config(self.msat_config)
 
-        self.set_function(self.walk_identity, op.SYMBOL, op.REAL_CONSTANT,
-                          op.BOOL_CONSTANT, op.INT_CONSTANT)
         self.logic = logic
 
         self.algorithm = algorithm
@@ -1242,6 +1241,11 @@ class MSatQuantifierEliminator(QuantifierEliminator, IdentityDagWalker):
         variables = formula.quantifier_vars()
         subf = args[0]
         return self.exist_elim(variables, subf)
+
+    @handles(op.SYMBOL, op.REAL_CONSTANT, op.BOOL_CONSTANT, op.INT_CONSTANT)
+    def walk_identity(self, formula, args, **kwargs):
+        # Leaves are unchanged by quantifier elimination.
+        return formula
 
     def _exit(self):
         del self.msat_env

--- a/pysmt/substituter.py
+++ b/pysmt/substituter.py
@@ -157,8 +157,7 @@ class Substituter(pysmt.walkers.IdentityDagWalker):
 
             # 3. We invoke the relevant function (walk_exists or
             #    walk_forall) to compute the substitution
-            fun = self.functions[formula.node_type()]
-            res = fun(formula, args=[res_formula], **kwargs)
+            res = self.__class__.super(self, formula, args=[res_formula], **kwargs)
 
             # 4. We memoize the result
             key = self._get_key(formula, **kwargs)

--- a/pysmt/test/test_dwf.py
+++ b/pysmt/test/test_dwf.py
@@ -73,3 +73,50 @@ class TestDwf(TestCase):
         new_t = new_node_type()
         new_types_set = set(all_types())
         self.assertEqual(new_types_set - old_types_set, set([new_t]))
+
+    def test_03_dwf_is_environment_local(self):
+        # A DWF registered in one environment must not leak into another.
+        # Handlers are dispatched via Walker.super through the walker's
+        # own env, not by mutating the (process-global) walker class.
+        from pysmt.environment import Environment
+        from pysmt.printers import HRPrinter
+
+        def make_printer(sep):
+            def hrprinter_walk_XOR(self, formula):
+                self.stream.write("(")
+                yield formula.arg(0)
+                self.stream.write(sep)
+                yield formula.arg(1)
+                self.stream.write(")")
+            return hrprinter_walk_XOR
+
+        XOR = new_node_type()
+        env1 = Environment()
+        env2 = Environment()
+
+        # Both envs must be able to build the node, so both get a
+        # type-checker handler. Only env1 gets a printer handler.
+        for env in (env1, env2):
+            env.add_dynamic_walker_function(
+                XOR, SimpleTypeChecker, SimpleTypeChecker.walk_bool_to_bool)
+        env1.add_dynamic_walker_function(XOR, HRPrinter, make_printer(" *+* "))
+
+        x1 = env1.formula_manager.Symbol("x")
+        f1 = env1.formula_manager.create_node(node_type=XOR, args=(x1, x1))
+        self.assertEqual(env1.serializer.serialize(f1), "(x *+* x)")
+
+        # The handler registered on env1 must NOT leak into env2.
+        x2 = env2.formula_manager.Symbol("x")
+        f2 = env2.formula_manager.create_node(node_type=XOR, args=(x2, x2))
+        with self.assertRaises(UnsupportedOperatorError):
+            env2.serializer.serialize(f2)
+
+        # env2 can register its own, independent handler for the same
+        # (nodetype, walker) pair, and env1 stays unaffected.
+        env2.add_dynamic_walker_function(XOR, HRPrinter, make_printer(" XOR "))
+        self.assertEqual(env2.serializer.serialize(f2), "(x XOR x)")
+        self.assertEqual(env1.serializer.serialize(f1), "(x *+* x)")
+
+        # Redefining the same (nodetype, walker) within one env is caught.
+        with self.assertRaises(AssertionError):
+            env1.add_dynamic_walker_function(XOR, HRPrinter, make_printer("!"))

--- a/pysmt/test/test_walkers.py
+++ b/pysmt/test/test_walkers.py
@@ -21,7 +21,8 @@ from pysmt.shortcuts import And, Or, Iff, Not, Function, Real
 from pysmt.shortcuts import LT, GT, Plus, Minus, Equals
 from pysmt.shortcuts import get_env, substitute, TRUE
 from pysmt.typing import INT, BOOL, REAL, FunctionType
-from pysmt.walkers import TreeWalker, DagWalker, IdentityDagWalker
+from pysmt.walkers import TreeWalker, DagWalker, IdentityDagWalker, handles
+from pysmt.walkers.generic import nt_to_fun
 from pysmt.test import TestCase, main
 from pysmt.formula import FormulaManager
 from pysmt.test.examples import get_example_formulae
@@ -105,36 +106,36 @@ class TestWalkers(TestCase):
             tree_walker.walk(varA)
 
     def test_walker_new_operators_complete(self):
-        walkerA = IdentityDagWalker(env=self.env)
         idx = op.new_node_type(node_str="fancy_new_node")
-        walkerB = IdentityDagWalker(env=self.env)
-        with self.assertRaises(KeyError):
-            walkerA.functions[idx]
-        self.assertEqual(walkerB.functions[idx], walkerB.walk_error)
+        fun_name = nt_to_fun(idx)
 
-        # Use a mixin to handle the node type
+        # A node type introduced after the class was defined has no
+        # dedicated walk_* method: dispatch falls back to walk_error.
+        self.assertFalse(hasattr(IdentityDagWalker, fun_name))
+
+        # Use a mixin to handle the node type (the method name matches
+        # nt_to_fun, so it is picked up by class-based dispatch).
         class FancyNewNodeWalkerMixin(object):
-            def walk_fancy_new_node(self, args, **kwargs):
+            def walk_fancy_new_node(self, formula, args, **kwargs):
                 raise UnsupportedOperatorError
 
         class IdentityDagWalker2(IdentityDagWalker, FancyNewNodeWalkerMixin):
             pass
-        walkerC = IdentityDagWalker2(env=self.env)
-        self.assertEqual(walkerC.functions[idx],
-                         walkerC.walk_fancy_new_node)
+        self.assertEqual(getattr(IdentityDagWalker2, fun_name),
+                         FancyNewNodeWalkerMixin.walk_fancy_new_node)
 
     def test_identity_walker_simple(self):
 
-        def walk_and_to_or(formula, args, **kwargs):
-            return Or(args)
+        class MyWalker(IdentityDagWalker):
+            @handles(op.AND)
+            def walk_and_to_or(self, formula, args, **kwargs):
+                return Or(args)
 
-        def walk_or_to_and(formula, args, **kwargs):
-            return And(args)
+            @handles(op.OR)
+            def walk_or_to_and(self, formula, args, **kwargs):
+                return And(args)
 
-        walker = IdentityDagWalker(env=get_env())
-
-        walker.set_function(walk_and_to_or, op.AND)
-        walker.set_function(walk_or_to_and, op.OR)
+        walker = MyWalker(env=get_env())
 
         x, y, z = Symbol('x'), Symbol('y'), Symbol('z')
 
@@ -240,8 +241,9 @@ class TestWalkers(TestCase):
         x = Symbol("x")
         w = DagWalker()
         for o in op.ALL_TYPES:
+            f = getattr(w, nt_to_fun(o))
             with self.assertRaises(UnsupportedOperatorError):
-                w.functions[o](x)
+                f(x)
 
     def test_walker_super(self):
         from pysmt.walkers import DagWalker

--- a/pysmt/walkers/dag.py
+++ b/pysmt/walkers/dag.py
@@ -68,14 +68,10 @@ class DagWalker(Walker):
         """
         key = self._get_key(formula, **kwargs)
         if key not in self.memoization:
-            try:
-                f = self.functions[formula.node_type()]
-            except KeyError:
-                f = self.walk_error
-
             args = [self.memoization[self._get_key(s, **kwargs)] \
                     for s in self._get_children(formula)]
-            self.memoization[key] = f(formula, args=args, **kwargs)
+            self.memoization[key] = self.__class__.super(self, formula,
+                                                         args=args, **kwargs)
         else:
             pass
 

--- a/pysmt/walkers/generic.py
+++ b/pysmt/walkers/generic.py
@@ -98,8 +98,13 @@ class Walker(object, metaclass=MetaNodeTypeHandler):
             setattr(cls, nt_to_fun(nt), function)
 
     @classmethod
-    def super(cls, self, formula: FNode, *args, **kwargs) -> FNode:
-        """Call the correct walk_* function of cls for the given formula."""
+    def super(cls, self, formula: FNode, *args, **kwargs) -> Any:
+        """Call the correct walk_* function of cls for the given formula.
+
+        The return type depends on the walker: an FNode for rewriting
+        walkers, but a generator (TreeWalker), a set or an int (oracles),
+        etc. for others; hence Any.
+        """
         nt = formula.node_type()
         try:
             f = getattr(cls, nt_to_fun(nt))

--- a/pysmt/walkers/generic.py
+++ b/pysmt/walkers/generic.py
@@ -15,8 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from functools import partial
-
 import sys
 from pysmt.fnode import FNode
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast, Iterable
@@ -83,24 +81,15 @@ class Walker(object, metaclass=MetaNodeTypeHandler):
             env = pysmt.environment.get_env()
         self.env: "pysmt.environment.Environment" = env
 
-        self.functions = {}
-        for o in op.all_types():
-            try:
-                # getattr will raise an AttributeError exception if a
-                # method does not exist
-                self.functions[o] = getattr(self, nt_to_fun(o))
-            except AttributeError:
-                self.functions[o] = self.walk_error
-
     def set_function(self, function, *node_types):
-        """Overrides the default walking function for each of the specified
-        node_types with the given function
+        """Instance-based walkers (<=0.6.0) are no longer supported.
+
+        Use class-based walkers instead: define walk_* methods (or use
+        the ``@handles`` decorator) on a subclass.
         """
-        from warnings import warn
-        warn("Instance-based walkers (<=0.6.0) walkers are deprecated. "
-             "You should use new-style/class based walkers", stacklevel=2)
-        for nt in node_types:
-            self.functions[nt] = function
+        raise NotImplementedError(
+            "Instance-based walkers (<=0.6.0) are deprecated. "
+            "You should use new-style/class based walkers.")
 
     @classmethod
     def set_handler(cls, function: Callable, *node_types):
@@ -111,26 +100,19 @@ class Walker(object, metaclass=MetaNodeTypeHandler):
     @classmethod
     def super(cls, self, formula: FNode, *args, **kwargs) -> FNode:
         """Call the correct walk_* function of cls for the given formula."""
-        f = getattr(cls, nt_to_fun(formula.node_type()))
+        nt = formula.node_type()
+        try:
+            f = getattr(cls, nt_to_fun(nt))
+        except AttributeError as ex:
+            # Custom node types (see new_node_type) have no walk_* method
+            # unless one is registered via add_dynamic_walker_function.
+            raise pysmt.exceptions.UnsupportedOperatorError(
+                node_type=nt, expression=formula) from ex
         return f(self, formula, *args, **kwargs)
 
     @handles(op.ALL_TYPES)
     def walk_error(self, formula, **kwargs):
-        """Default function for a node that is not handled by the Walker.
-
-        This tries to handle the node using the Dynamic Walker
-        Function information from the environment. If this fails, then
-        an UnsupportedOperatorError exception is given.
-
-        """
-        node_type = formula.node_type()
-        if node_type in self.env.dwf:
-            dwf = self.env.dwf[node_type]
-            walker_class = type(self)
-            if type(self) in dwf:
-                self.functions[node_type] = partial(dwf[walker_class], self)
-                return self.functions[node_type](formula, **kwargs)
-
+        """Default function for a node that is not handled by the Walker."""
         node_type = formula.node_type()
         raise pysmt.exceptions.UnsupportedOperatorError(node_type=node_type,
                                                         expression=formula)

--- a/pysmt/walkers/generic.py
+++ b/pysmt/walkers/generic.py
@@ -108,11 +108,17 @@ class Walker(object, metaclass=MetaNodeTypeHandler):
         nt = formula.node_type()
         try:
             f = getattr(cls, nt_to_fun(nt))
-        except AttributeError as ex:
+        except AttributeError:
             # Custom node types (see new_node_type) have no walk_* method
-            # unless one is registered via add_dynamic_walker_function.
-            raise pysmt.exceptions.UnsupportedOperatorError(
-                node_type=nt, expression=formula) from ex
+            # on the class. Look for a handler registered on this walker's
+            # environment via add_dynamic_walker_function; keeping the
+            # lookup env-local is what stops registrations from leaking
+            # across environments.
+            fun = self.env.get_dynamic_walker_function(nt, cls)
+            if fun is None:
+                raise pysmt.exceptions.UnsupportedOperatorError(
+                    node_type=nt, expression=formula)
+            return fun(self, formula, *args, **kwargs)
         return f(self, formula, *args, **kwargs)
 
     @handles(op.ALL_TYPES)

--- a/pysmt/walkers/tree.py
+++ b/pysmt/walkers/tree.py
@@ -41,19 +41,14 @@ class TreeWalker(Walker):
         return
 
     def walk(self, formula: FNode, threshold: Optional[int]=None):
-        """Generic walk method, will apply the function defined by the map
-        self.functions.
+        """Generic walk method, will apply the function associated with
+        the node.
 
         If threshold parameter is specified, the walk_threshold
         function will be called for all nodes with depth >= threshold.
         """
 
-        try:
-            f = self.functions[formula.node_type()]
-        except KeyError:
-            f = self.walk_error
-
-        iterator = f(formula)
+        iterator = self.__class__.super(self, formula)
         if iterator is None:
             return
 
@@ -67,11 +62,7 @@ class TreeWalker(Walker):
                     if iterator is not None:
                         stack.append(iterator)
                 else:
-                    try:
-                        cf = self.functions[child.node_type()]
-                    except KeyError:
-                        cf = self.walk_error
-                    iterator = cf(child)
+                    iterator = self.__class__.super(self, child)
                     if iterator is not None:
                         stack.append(iterator)
             except StopIteration:


### PR DESCRIPTION
Supersedes #728 (and closes #410).

#728 removed the last uses of the instance-based `functions` dictionary but was opened in 2022 and no longer merges: master has since added type annotations to the walker files. This PR reapplies that design on top of current master, and additionally fixes a walker the original PR missed.

## Rationale

`Walker` used to build a per-instance `functions` dictionary mapping each node type to its walk method. These were the "instance-based walkers": in principle each instance could bind different functions (via `set_function`). We moved away from this in 0.6 in favor of "class-based walkers", where the walk method is found by name from the node type (`walk_add` handles `add`). The two mechanisms have coexisted since; this removes the instance-based one.

Concretely:

- **Dispatch** goes through `Walker.super`, which resolves `walk_*` on the class with `getattr` and raises `UnsupportedOperatorError` when there is no handler (i.e. custom node types registered via `new_node_type` without a walker). `DagWalker`, `TreeWalker`, `Simplifier.walk_debug`, the SMT-LIB printer and substituter quantifier handling now call `self.__class__.super(...)` instead of indexing `self.functions`.
- **`self.functions` and `set_function` are removed.** `set_function` now raises `NotImplementedError` pointing callers at class-based walkers (define `walk_*` methods, or use `@handles`).
- **Dynamic Walker Functions** (`add_dynamic_walker_function`) stay local to the environment. The environment keeps `dwf`, a map from `(nodetype, walker_class)` to the handler. `Walker.super`, when a custom node type has no `walk_*` method on the class, looks the handler up on the walker instance's own environment (`self.env.get_dynamic_walker_function`) before raising. Registration no longer mutates the walker class, so a handler registered in one environment does not leak into any other.

## Beyond #728

- **`CNFizer` (`pysmt/rewritings.py`)** has its own polarity-threading `_compute_node_result` that still used `self.functions`. It was not touched by #728; fixed here the same way.
- I surveyed the other `DagWalker` subclasses (`NNFizer`, `PrenexNormalizer`, `AIGer`, `TimesDistributor`, `Ackermannizer`): none override dispatch, so the central `dag.py` change covers them.
- The `add_dynamic_walker_function` redefinition guard in #728 asserted `(nodetype, walker) not in self._dwf` but never populated the set, so the check was dead. The per-environment `dwf` map here makes the guard live again: redefining the same `(nodetype, walker_class)` within one environment trips the assertion.

## Environment locality of Dynamic Walker Functions

The first TODO from #728 (multiple environments in the DWF implementation) is addressed here rather than deferred. An earlier revision of this PR registered handlers on the walker class via `Walker.set_handler`, which is process-global: a registration in one environment leaked into every other environment sharing the walker class. Keeping the handlers in the per-environment `dwf` map and dispatching through `self.env` in `Walker.super` preserves the isolation the old `env.dwf`/`walk_error` lookup had, without reintroducing the instance-based `functions` dictionary.